### PR TITLE
Make the discussion of system sources of randomness clearer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ Known issues include the following:
   and memory usage. These form timing and cache-contention side channels,
   which may be an issue in some applications.
 
-* Randomness is retrieved from /dev/urandom, but this should be changed to
-  an external, high-quality randomness source when creating long-term
-  proving/verification keys.
+* Randomness is retrieved from /dev/urandom, but this should be
+  changed to a carefully considered (depending on system and threat
+  model) external, high-quality randomness source when creating
+  long-term proving/verification keys.
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
On most modern linux systems, there's essentially no security
difference between /dev/random and /dev/urandom, meaning that the
blocking property of /dev/random is actually harmful in many
cases. This advice is not necessarily true if you care about
e.g. embedded systems where you're going to generate crypto keys
immediately after boot (or, in some cases, even a long time after
boot).

In general, the best advice is to use external high-quality randomness
for keys (or to use urandom on a system where you believe it has been
keyed appropriately). See
http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/
for a careful explanation. Also know that there's a lot of active work
to improve the behavior and cluefulness of both /dev/random and
/dev/urandom. I don't know enough about the state of that to summarize
it, though.
