### PR TITLE
Change some includes to allow dependent programs to build out of place.

### DIFF
--- a/prepare-depends.sh
+++ b/prepare-depends.sh
@@ -12,7 +12,7 @@ mkdir -p $DEPSRC
 
 cd $DEPSRC
 [ ! -d xbyak ] && git clone git://github.com/herumi/xbyak.git
-[ ! -d ate-pairing ] && git clone git://github.com/herumi/ate-pairing.git
+[ ! -d ate-pairing ] && git clone git://github.com/gstew5/ate-pairing.git
 cd ate-pairing
 make -j SUPPORT_SNARK=1
 cd ..

--- a/src/algebra/scalar_multiplication/wnaf.hpp
+++ b/src/algebra/scalar_multiplication/wnaf.hpp
@@ -12,6 +12,8 @@
 #ifndef WNAF_HPP_
 #define WNAF_HPP_
 
+#include <algebra/fields/bigint.hpp>
+
 namespace libsnark {
 
 /**

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
@@ -48,11 +48,11 @@
 
 #include <memory>
 
-#include "algebra/curves/public_params.hpp"
-#include "common/data_structures/accumulation_vector.hpp"
-#include "algebra/knowledge_commitment/knowledge_commitment.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark_params.hpp"
+#include <algebra/curves/public_params.hpp>
+#include <common/data_structures/accumulation_vector.hpp>
+#include <algebra/knowledge_commitment/knowledge_commitment.hpp>
+#include <relations/constraint_satisfaction_problems/r1cs/r1cs.hpp>
+#include <zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark_params.hpp>
 
 namespace libsnark {
 


### PR DESCRIPTION
When building a program that depends on libsnark in a directory outside libsnark's source tree, the include paths don't quite work out, requiring the program that depends on libsnark to #include a
bunch of irrelevant files. This change closes over much of that, leading to a cleaner use of the library's API.

This may not be the best way to solve the issue, but these changes do allow me to build a tool that acts as a generator/prover/verifier. I'm open to negotiation as to exactly what to change, but I do want to be able to use the library without having unused #includes in my client program.