### PR TITLE
Add 'libssl-dev' and 'libboost-all-dev' to Ubuntu package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ let us know!) See also the notes on [portability](#portability) below.
 
 For example, on a fresh install of Ubuntu 14.04, install the following packages:
 
-    $ sudo apt-get install build-essential git libgmp3-dev libprocps3-dev libgtest-dev python-markdown
+    $ sudo apt-get install build-essential git libgmp3-dev libprocps3-dev libgtest-dev python-markdown libboost-all-dev libssl-dev
 
 Or, on Fedora 20:
 


### PR DESCRIPTION
When building `libsnark` on a fresh installation of Ubuntu (15.04, not 14.04), I had to install 'libssl-dev' and 'libboost-all-dev' in addition to the other Ubuntu packages listed in README.md. I don't know the corresponding Fedora packages.