### PR TITLE
Include header required for std::iota.

### DIFF
--- a/src/common/data_structures/integer_permutation.cpp
+++ b/src/common/data_structures/integer_permutation.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <numeric>
 #include <unordered_set>
 
 namespace libsnark {

--- a/src/common/data_structures/sparse_vector.tcc
+++ b/src/common/data_structures/sparse_vector.tcc
@@ -16,6 +16,8 @@
 
 #include "algebra/scalar_multiplication/multiexp.hpp"
 
+#include <numeric>
+
 namespace libsnark {
 
 template<typename T>


### PR DESCRIPTION
This fixes the error...

```
...
g++ -o src/algebra/curves/mnt/mnt6/mnt6_init.o   src/algebra/curves/mnt/mnt6/mnt6_init.cpp -c -MMD -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-comment -Wfatal-errors -O2 -march=native -mtune=native -DUSE_ASM -DMONTGOMERY_OUTPUT -DCURVE_BN128 -Idepinst/include -Isrc -DBN_SUPPORT_SNARK -fPIC
g++ -o src/algebra/curves/mnt/mnt6/mnt6_pairing.o   src/algebra/curves/mnt/mnt6/mnt6_pairing.cpp -c -MMD -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-comment -Wfatal-errors -O2 -march=native -mtune=native -DUSE_ASM -DMONTGOMERY_OUTPUT -DCURVE_BN128 -Idepinst/include -Isrc -DBN_SUPPORT_SNARK -fPIC
g++ -o src/algebra/curves/mnt/mnt6/mnt6_pp.o   src/algebra/curves/mnt/mnt6/mnt6_pp.cpp -c -MMD -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-comment -Wfatal-errors -O2 -march=native -mtune=native -DUSE_ASM -DMONTGOMERY_OUTPUT -DCURVE_BN128 -Idepinst/include -Isrc -DBN_SUPPORT_SNARK -fPIC
g++ -o src/common/data_structures/integer_permutation.o   src/common/data_structures/integer_permutation.cpp -c -MMD -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wno-comment -Wfatal-errors -O2 -march=native -mtune=native -DUSE_ASM -DMONTGOMERY_OUTPUT -DCURVE_BN128 -Idepinst/include -Isrc -DBN_SUPPORT_SNARK -fPIC
src/common/data_structures/integer_permutation.cpp: In constructor ‘libsnark::integer_permutation::integer_permutation(size_t)’:
src/common/data_structures/integer_permutation.cpp:26:5: error: ‘iota’ is not a member of ‘std’
     std::iota(contents.begin(), contents.end(), 0);
     ^~~
compilation terminated due to -Wfatal-errors.
Makefile:226: recipe for target 'src/common/data_structures/integer_permutation.o' failed
make: *** [src/common/data_structures/integer_permutation.o] Error 1
```

...encountered on...

```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/6.1.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc-multilib/src/gcc/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-shared --enable-threads=posix --enable-libmpx --with-system-zlib --with-isl --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --disable-libstdcxx-pch --disable-libssp --enable-gnu-unique-object --enable-linker-build-id --enable-lto --enable-plugin --enable-install-libiberty --with-linker-hash-style=gnu --enable-gnu-indirect-function --enable-multilib --disable-werror --enable-checking=release
Thread model: posix
gcc version 6.1.1 20160501 (GCC)
```