### PR TITLE
add a space to maintain compatibility with older compilers

### DIFF
--- a/src/gadgetlib2/constraint.hpp
+++ b/src/gadgetlib2/constraint.hpp
@@ -154,7 +154,7 @@ public:
     ::std::string annotation() const;
     Variable::set getUsedVariables() const;
 
-    typedef ::std::set<::std::unique_ptr<Polynomial> > PolyPtrSet;
+    typedef ::std::set< ::std::unique_ptr<Polynomial> > PolyPtrSet;
     /// Required for interfacing with BREX. Should be optimized in the future
     PolyPtrSet getConstraintPolynomials() const {
         PolyPtrSet retset;


### PR DESCRIPTION
 <::SomeNamespace> doesn't compile in older versions of g++ (<4.8).

Specifically, with g++ 4.7.3, I see
`In file included from src/gadgetlib2/adapters.hpp:18:0,
                 from src/gadgetlib2/adapters.cpp:10:
src/gadgetlib2/constraint.hpp:157:23: error: ‘<::’ cannot begin a template-argument list [-fpermissive]
compilation terminated due to -Wfatal-errors.`
Adding a space fixes the problem.