### PR TITLE
Add missing comma in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DEPSRC = depsrc
 DEPINST = depinst
 
 CXXFLAGS += -I$(DEPINST)/include -Isrc
-LDFLAGS += -L$(DEPINST)/lib -Wl,-rpath $(DEPINST)/lib
+LDFLAGS += -L$(DEPINST)/lib -Wl,-rpath,$(DEPINST)/lib
 LDLIBS += -lgmpxx -lgmp -lboost_program_options
 # OpenSSL and its dependencies (needed explicitly for static builds):
 LDLIBS += -lcrypto -ldl -lz


### PR DESCRIPTION
We've been applying this patch to make the Zcash build work, although I can't recall the specifics of why it was needed, or why the upstream build works with it but ours didn't.