### PR TITLE
gadgetlib1: add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ EXECUTABLES = \
 
 
 EXECUTABLES_WITH_GTEST = \
+	src/gadgetlib1/tests/gadgetlib1_test \
 	src/gadgetlib2/examples/tutorial \
 	src/gadgetlib2/tests/gadgetlib2_test
 

--- a/src/gadgetlib1/examples/simple_example.hpp
+++ b/src/gadgetlib1/examples/simple_example.hpp
@@ -8,7 +8,7 @@
 #ifndef SIMPLE_EXAMPLE_HPP_
 #define SIMPLE_EXAMPLE_HPP_
 
-#include "examples/r1cs_examples.hpp"
+#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/examples/simple_example.tcc
+++ b/src/gadgetlib1/examples/simple_example.tcc
@@ -8,7 +8,6 @@
 #ifndef SIMPLE_EXAMPLE_TCC_
 #define SIMPLE_EXAMPLE_TCC_
 
-#include <cassert>
 #include "gadgetlib1/gadgets/basic_gadgets.hpp"
 
 namespace libsnark {
@@ -16,8 +15,7 @@ namespace libsnark {
 /* NOTE: all examples here actually generate one constraint less to account for soundness constraint in QAP */
 
 template<typename FieldT>
-r1cs_example<FieldT> gen_r1cs_example_from_protoboard(const size_t num_constraints,
-                                                      const size_t num_inputs)
+r1cs_example<FieldT> gen_r1cs_example_from_protoboard(const size_t num_constraints)
 {
     const size_t new_num_constraints = num_constraints - 1;
 
@@ -43,11 +41,7 @@ r1cs_example<FieldT> gen_r1cs_example_from_protoboard(const size_t num_constrain
     }
 
     compute_inner_product.generate_r1cs_witness();
-
-    pb.constraint_system.num_inputs = num_inputs;
-    const r1cs_variable_assignment<FieldT> va = pb.values;
-    const r1cs_variable_assignment<FieldT> input(va.begin(), va.begin() + num_inputs);
-    return r1cs_example<FieldT>(pb.constraint_system, input, va, num_inputs);
+    return r1cs_example<FieldT>(pb.get_constraint_system(), pb.primary_input(), pb.auxiliary_input());
 }
 
 } // libsnark

--- a/src/gadgetlib1/tests/gadgetlib1_test.cpp
+++ b/src/gadgetlib1/tests/gadgetlib1_test.cpp
@@ -1,0 +1,32 @@
+/** @file
+ *****************************************************************************
+ Unit tests for gadgetlib1 - main() for running all tests
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include "gadgetlib1/examples/simple_example.hpp"
+#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
+
+namespace {
+
+TEST(gadgetLib1,Integration) {
+    typedef libsnark::Fr<libsnark::default_ec_pp> FieldT;
+    // Create an example constraint system and translate to libsnark format
+    libsnark::default_ec_pp::init_public_params();
+    const auto example = libsnark::gen_r1cs_example_from_protoboard<FieldT>(100);
+    const bool test_serialization = false;
+    // Run ppzksnark. Jump into function for breakdown
+    const bool bit = libsnark::run_r1cs_ppzksnark<libsnark::default_ec_pp>(example, test_serialization);
+    EXPECT_TRUE(bit);
+};
+
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp
@@ -13,6 +13,7 @@
 #ifndef RUN_R1CS_PPZKSNARK_HPP_
 #define RUN_R1CS_PPZKSNARK_HPP_
 
+#include "common/default_types/ec_pp.hpp"
 #include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {


### PR DESCRIPTION
The gadgetlib1 simple example was out of date / broken.
This patch fixes it and adds a test, very similar to gadgetlib2.
