### PR TITLE
Fixed link error on build

### DIFF
--- a/src/gadgetlib2/variable.cpp
+++ b/src/gadgetlib2/variable.cpp
@@ -310,6 +310,8 @@ VariableArray::VariableArray(const size_t size, const ::std::string& name) : Var
 }
 
 VariableArray::VariableArray(const string& name) : VariableArrayContents() { UNUSED(name); }
+VariableArray::VariableArray(const size_t size, const ::std::string& name)
+    : VariableArrayContents(size) { UNUSED(name); }
 VariableArray::VariableArray(const int size, const ::std::string& name)
     : VariableArrayContents(size) { UNUSED(name); }
 #endif


### PR DESCRIPTION
On some systems you will have a link error during build because one of the constructor wasn't implemented.