### PR TITLE
clang compatibility fixes

### DIFF
--- a/src/gadgetlib1/protoboard.tcc
+++ b/src/gadgetlib1/protoboard.tcc
@@ -40,7 +40,7 @@ var_index_t protoboard<FieldT>::allocate_var_index(const std::string &annotation
     assert(annotation != "");
     constraint_system.variable_annotations[next_free_var] = annotation;
 #else
-    UNUSED(annotation);
+    libff::UNUSED(annotation);
 #endif
     ++constraint_system.auxiliary_input_size;
     values.emplace_back(FieldT::zero());
@@ -103,7 +103,7 @@ void protoboard<FieldT>::add_r1cs_constraint(const r1cs_constraint<FieldT> &cons
     assert(annotation != "");
     constraint_system.constraint_annotations[constraint_system.constraints.size()] = annotation;
 #else
-    UNUSED(annotation);
+    libff::UNUSED(annotation);
 #endif
     constraint_system.constraints.emplace_back(constr);
 }

--- a/src/knowledge_commitment/knowledge_commitment.hpp
+++ b/src/knowledge_commitment/knowledge_commitment.hpp
@@ -60,8 +60,8 @@ struct knowledge_commitment {
 template<typename T1, typename T2, mp_size_t m>
 knowledge_commitment<T1,T2> operator*(const libff::bigint<m> &lhs, const knowledge_commitment<T1,T2> &rhs);
 
-template<typename T1, typename T2, mp_size_t m, const libff::bigint<m> &modulus_p>
-knowledge_commitment<T1,T2> operator*(const libff::Fp_model<m, modulus_p> &lhs, const knowledge_commitment<T1,T2> &rhs);
+template<typename T1, typename T2, typename T>
+knowledge_commitment<T1,T2> operator*(const T &lhs, const knowledge_commitment<T1,T2> &rhs);
 
 template<typename T1,typename T2>
 std::ostream& operator<<(std::ostream& out, const knowledge_commitment<T1,T2> &kc);

--- a/src/knowledge_commitment/knowledge_commitment.tcc
+++ b/src/knowledge_commitment/knowledge_commitment.tcc
@@ -69,8 +69,8 @@ knowledge_commitment<T1,T2> operator*(const libff::bigint<m> &lhs, const knowled
                                        lhs * rhs.h);
 }
 
-template<typename T1, typename T2, mp_size_t m, const libff::bigint<m> &modulus_p>
-knowledge_commitment<T1,T2> operator*(const libff::Fp_model<m, modulus_p> &lhs, const knowledge_commitment<T1,T2> &rhs)
+template<typename T1, typename T2, typename T>
+knowledge_commitment<T1,T2> operator*(const T &lhs, const knowledge_commitment<T1,T2> &rhs)
 {
     return (lhs.as_bigint()) * rhs;
 }


### PR DESCRIPTION
This PR together with the one in libff has some solution for clang compatibility.

Specifically, it handles issues mentioned in #54 and #67, about the following:
1. non-type template parameter deduction - by using a higher abstraction of the template parameter.
2. UNUSED macro in libff.