### PR TITLE
Fix usage of FMT macro from libff

### DIFF
--- a/src/gadgetlib1/gadgets/basic_gadgets.hpp
+++ b/src/gadgetlib1/gadgets/basic_gadgets.hpp
@@ -121,12 +121,12 @@ public:
                          const std::string &annotation_prefix="") :
         gadget<FieldT>(pb, annotation_prefix)
     {
-        packed.allocate(pb, libff::FMT(this->annotation_prefix, " packed"));
-        bits.allocate(pb, width, libff::FMT(this->annotation_prefix, " bits"));
+        packed.allocate(pb, FMT(this->annotation_prefix, " packed"));
+        bits.allocate(pb, width, FMT(this->annotation_prefix, " bits"));
         consistency_check.reset(new packing_gadget<FieldT>(pb,
                                                            bits,
                                                            packed,
-                                                           libff::FMT(this->annotation_prefix, " consistency_check")));
+                                                           FMT(this->annotation_prefix, " consistency_check")));
     }
 
     dual_variable_gadget(protoboard<FieldT> &pb,
@@ -134,11 +134,11 @@ public:
                          const std::string &annotation_prefix="") :
         gadget<FieldT>(pb, annotation_prefix), bits(bits)
     {
-        packed.allocate(pb, libff::FMT(this->annotation_prefix, " packed"));
+        packed.allocate(pb, FMT(this->annotation_prefix, " packed"));
         consistency_check.reset(new packing_gadget<FieldT>(pb,
                                                            bits,
                                                            packed,
-                                                           libff::FMT(this->annotation_prefix, " consistency_check")));
+                                                           FMT(this->annotation_prefix, " consistency_check")));
     }
 
     dual_variable_gadget(protoboard<FieldT> &pb,
@@ -147,11 +147,11 @@ public:
                          const std::string &annotation_prefix="") :
         gadget<FieldT>(pb, annotation_prefix), packed(packed)
     {
-        bits.allocate(pb, width, libff::FMT(this->annotation_prefix, " bits"));
+        bits.allocate(pb, width, FMT(this->annotation_prefix, " bits"));
         consistency_check.reset(new packing_gadget<FieldT>(pb,
                                                            bits,
                                                            packed,
-                                                           libff::FMT(this->annotation_prefix, " consistency_check")));
+                                                           FMT(this->annotation_prefix, " consistency_check")));
     }
 
     void generate_r1cs_constraints(const bool enforce_bitness);
@@ -183,7 +183,7 @@ public:
         gadget<FieldT>(pb, annotation_prefix), inputs(inputs), output(output)
     {
         assert(inputs.size() >= 1);
-        inv.allocate(pb, libff::FMT(this->annotation_prefix, " inv"));
+        inv.allocate(pb, FMT(this->annotation_prefix, " inv"));
     }
 
     void generate_r1cs_constraints();
@@ -208,7 +208,7 @@ public:
         gadget<FieldT>(pb, annotation_prefix), inputs(inputs), output(output)
     {
         assert(inputs.size() >= 1);
-        inv.allocate(pb, libff::FMT(this->annotation_prefix, " inv"));
+        inv.allocate(pb, FMT(this->annotation_prefix, " inv"));
     }
 
     void generate_r1cs_constraints();
@@ -243,19 +243,19 @@ public:
                       const std::string &annotation_prefix="") :
         gadget<FieldT>(pb, annotation_prefix), n(n), A(A), B(B), less(less), less_or_eq(less_or_eq)
     {
-        alpha.allocate(pb, n, libff::FMT(this->annotation_prefix, " alpha"));
+        alpha.allocate(pb, n, FMT(this->annotation_prefix, " alpha"));
         alpha.emplace_back(less_or_eq); // alpha[n] is less_or_eq
 
-        alpha_packed.allocate(pb, libff::FMT(this->annotation_prefix, " alpha_packed"));
-        not_all_zeros.allocate(pb, libff::FMT(this->annotation_prefix, " not_all_zeros"));
+        alpha_packed.allocate(pb, FMT(this->annotation_prefix, " alpha_packed"));
+        not_all_zeros.allocate(pb, FMT(this->annotation_prefix, " not_all_zeros"));
 
         pack_alpha.reset(new packing_gadget<FieldT>(pb, alpha, alpha_packed,
-                                                    libff::FMT(this->annotation_prefix, " pack_alpha")));
+                                                    FMT(this->annotation_prefix, " pack_alpha")));
 
         all_zeros_test.reset(new disjunction_gadget<FieldT>(pb,
                                                             pb_variable_array<FieldT>(alpha.begin(), alpha.begin() + n),
                                                             not_all_zeros,
-                                                            libff::FMT(this->annotation_prefix, " all_zeros_test")));
+                                                            FMT(this->annotation_prefix, " all_zeros_test")));
     };
 
     void generate_r1cs_constraints();
@@ -285,7 +285,7 @@ public:
         assert(A.size() >= 1);
         assert(A.size() == B.size());
 
-        S.allocate(pb, A.size()-1, libff::FMT(this->annotation_prefix, " S"));
+        S.allocate(pb, A.size()-1, FMT(this->annotation_prefix, " S"));
     }
 
     void generate_r1cs_constraints();
@@ -321,8 +321,8 @@ public:
                               const std::string &annotation_prefix="") :
         gadget<FieldT>(pb, annotation_prefix), arr(arr), index(index), result(result), success_flag(success_flag)
     {
-        alpha.allocate(pb, arr.size(), libff::FMT(this->annotation_prefix, " alpha"));
-        compute_result.reset(new inner_product_gadget<FieldT>(pb, alpha, arr, result, libff::FMT(this->annotation_prefix, " compute_result")));
+        alpha.allocate(pb, arr.size(), FMT(this->annotation_prefix, " alpha"));
+        compute_result.reset(new inner_product_gadget<FieldT>(pb, alpha, arr, result, FMT(this->annotation_prefix, " compute_result")));
     };
 
     void generate_r1cs_constraints();

--- a/src/gadgetlib1/gadgets/basic_gadgets.tcc
+++ b/src/gadgetlib1/gadgets/basic_gadgets.tcc
@@ -18,27 +18,27 @@ void generate_boolean_r1cs_constraint(protoboard<FieldT> &pb, const pb_linear_co
 /* forces lc to take value 0 or 1 by adding constraint lc * (1-lc) = 0 */
 {
     pb.add_r1cs_constraint(r1cs_constraint<FieldT>(lc, 1-lc, 0),
-                           libff::FMT(annotation_prefix, " boolean_r1cs_constraint"));
+                           FMT(annotation_prefix, " boolean_r1cs_constraint"));
 }
 
 template<typename FieldT>
 void generate_r1cs_equals_const_constraint(protoboard<FieldT> &pb, const pb_linear_combination<FieldT> &lc, const FieldT& c, const std::string &annotation_prefix)
 {
     pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, lc, c),
-                           libff::FMT(annotation_prefix, " constness_constraint"));
+                           FMT(annotation_prefix, " constness_constraint"));
 }
 
 template<typename FieldT>
 void packing_gadget<FieldT>::generate_r1cs_constraints(const bool enforce_bitness)
 /* adds constraint result = \sum  bits[i] * 2^i */
 {
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, pb_packing_sum<FieldT>(bits), packed), libff::FMT(this->annotation_prefix, " packing_constraint"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, pb_packing_sum<FieldT>(bits), packed), FMT(this->annotation_prefix, " packing_constraint"));
 
     if (enforce_bitness)
     {
         for (size_t i = 0; i < bits.size(); ++i)
         {
-            generate_boolean_r1cs_constraint<FieldT>(this->pb, bits[i], libff::FMT(this->annotation_prefix, " bitness_%zu", i));
+            generate_boolean_r1cs_constraint<FieldT>(this->pb, bits[i], FMT(this->annotation_prefix, " bitness_%zu", i));
         }
     }
 }
@@ -74,7 +74,7 @@ multipacking_gadget<FieldT>::multipacking_gadget(protoboard<FieldT> &pb,
     {
         packers.emplace_back(packing_gadget<FieldT>(this->pb, pb_linear_combination_array<FieldT>(bits.begin() + i * chunk_size,
                                                                                                   bits.begin() + std::min((i+1) * chunk_size, bits.size())),
-                                                    packed_vars[i], libff::FMT(this->annotation_prefix, " packers_%zu", i)));
+                                                    packed_vars[i], FMT(this->annotation_prefix, " packers_%zu", i)));
     }
 }
 
@@ -128,7 +128,7 @@ void field_vector_copy_gadget<FieldT>::generate_r1cs_constraints()
     for (size_t i = 0; i < source.size(); ++i)
     {
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(do_copy, source[i] - target[i], 0),
-                                     libff::FMT(this->annotation_prefix, " copying_check_%zu", i));
+                                     FMT(this->annotation_prefix, " copying_check_%zu", i));
     }
 }
 
@@ -158,13 +158,13 @@ bit_vector_copy_gadget<FieldT>::bit_vector_copy_gadget(protoboard<FieldT> &pb,
 {
     assert(source_bits.size() == target_bits.size());
 
-    packed_source.allocate(pb, num_chunks, libff::FMT(annotation_prefix, " packed_source"));
-    pack_source.reset(new multipacking_gadget<FieldT>(pb, source_bits, packed_source, chunk_size, libff::FMT(annotation_prefix, " pack_source")));
+    packed_source.allocate(pb, num_chunks, FMT(annotation_prefix, " packed_source"));
+    pack_source.reset(new multipacking_gadget<FieldT>(pb, source_bits, packed_source, chunk_size, FMT(annotation_prefix, " pack_source")));
 
-    packed_target.allocate(pb, num_chunks, libff::FMT(annotation_prefix, " packed_target"));
-    pack_target.reset(new multipacking_gadget<FieldT>(pb, target_bits, packed_target, chunk_size, libff::FMT(annotation_prefix, " pack_target")));
+    packed_target.allocate(pb, num_chunks, FMT(annotation_prefix, " packed_target"));
+    pack_target.reset(new multipacking_gadget<FieldT>(pb, target_bits, packed_target, chunk_size, FMT(annotation_prefix, " pack_target")));
 
-    copier.reset(new field_vector_copy_gadget<FieldT>(pb, packed_source, packed_target, do_copy, libff::FMT(annotation_prefix, " copier")));
+    copier.reset(new field_vector_copy_gadget<FieldT>(pb, packed_source, packed_target, do_copy, FMT(annotation_prefix, " copier")));
 }
 
 template<typename FieldT>
@@ -223,7 +223,7 @@ void disjunction_gadget<FieldT>::generate_r1cs_constraints()
     }
     c1.add_term(output);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a1, b1, c1), libff::FMT(this->annotation_prefix, " inv*sum=output"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a1, b1, c1), FMT(this->annotation_prefix, " inv*sum=output"));
 
     /* (1-output) * sum = 0 */
     linear_combination<FieldT> a2, b2, c2;
@@ -235,7 +235,7 @@ void disjunction_gadget<FieldT>::generate_r1cs_constraints()
     }
     c2.add_term(ONE, 0);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a2, b2, c2), libff::FMT(this->annotation_prefix, " (1-output)*sum=0"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a2, b2, c2), FMT(this->annotation_prefix, " (1-output)*sum=0"));
 }
 
 template<typename FieldT>
@@ -314,7 +314,7 @@ void conjunction_gadget<FieldT>::generate_r1cs_constraints()
     c1.add_term(ONE);
     c1.add_term(output, -1);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a1, b1, c1), libff::FMT(this->annotation_prefix, " inv*(n-sum)=(1-output)"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a1, b1, c1), FMT(this->annotation_prefix, " inv*(n-sum)=(1-output)"));
 
     /* output * (n-sum) = 0 */
     linear_combination<FieldT> a2, b2, c2;
@@ -326,7 +326,7 @@ void conjunction_gadget<FieldT>::generate_r1cs_constraints()
     }
     c2.add_term(ONE, 0);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a2, b2, c2), libff::FMT(this->annotation_prefix, " output*(n-sum)=0"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a2, b2, c2), FMT(this->annotation_prefix, " output*(n-sum)=0"));
 }
 
 template<typename FieldT>
@@ -411,16 +411,16 @@ void comparison_gadget<FieldT>::generate_r1cs_constraints()
 
     /* not_all_zeros to be Boolean, alpha_i are Boolean by packing gadget */
     generate_boolean_r1cs_constraint<FieldT>(this->pb, not_all_zeros,
-                                     libff::FMT(this->annotation_prefix, " not_all_zeros"));
+                                     FMT(this->annotation_prefix, " not_all_zeros"));
 
     /* constraints for packed(alpha) = 2^n + B - A */
     pack_alpha->generate_r1cs_constraints(true);
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, (FieldT(2)^n) + B - A, alpha_packed), libff::FMT(this->annotation_prefix, " main_constraint"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, (FieldT(2)^n) + B - A, alpha_packed), FMT(this->annotation_prefix, " main_constraint"));
 
     /* compute result */
     all_zeros_test->generate_r1cs_constraints();
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(less_or_eq, not_all_zeros, less),
-                                 libff::FMT(this->annotation_prefix, " less"));
+                                 FMT(this->annotation_prefix, " less"));
 }
 
 template<typename FieldT>
@@ -488,7 +488,7 @@ void inner_product_gadget<FieldT>::generate_r1cs_constraints()
         this->pb.add_r1cs_constraint(
             r1cs_constraint<FieldT>(A[i], B[i],
                                     (i == A.size()-1 ? result : S[i]) + (i == 0 ? 0 * ONE : -S[i-1])),
-            libff::FMT(this->annotation_prefix, " S_%zu", i));
+            FMT(this->annotation_prefix, " S_%zu", i));
     }
 }
 
@@ -561,7 +561,7 @@ void loose_multiplexing_gadget<FieldT>::generate_r1cs_constraints()
     {
         this->pb.add_r1cs_constraint(
             r1cs_constraint<FieldT>(alpha[i], index - i, 0),
-            libff::FMT(this->annotation_prefix, " alpha_%zu", i));
+            FMT(this->annotation_prefix, " alpha_%zu", i));
     }
 
     /* 1 * (\sum \alpha_i) = success_flag */
@@ -572,11 +572,11 @@ void loose_multiplexing_gadget<FieldT>::generate_r1cs_constraints()
         b.add_term(alpha[i]);
     }
     c.add_term(success_flag);
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), libff::FMT(this->annotation_prefix, " main_constraint"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), FMT(this->annotation_prefix, " main_constraint"));
 
     /* now success_flag is constrained to either 0 (if index is out of
        range) or \alpha_i. constrain it and \alpha_i to zero */
-    generate_boolean_r1cs_constraint<FieldT>(this->pb, success_flag, libff::FMT(this->annotation_prefix, " success_flag"));
+    generate_boolean_r1cs_constraint<FieldT>(this->pb, success_flag, FMT(this->annotation_prefix, " success_flag"));
 
     /* compute result */
     compute_result->generate_r1cs_constraints();
@@ -680,7 +680,7 @@ void create_linear_combination_constraints(protoboard<FieldT> &pb,
 
         c.add_term(target.all_vars[i]);
 
-        pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), libff::FMT(annotation_prefix, " linear_combination_%zu", i));
+        pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), FMT(annotation_prefix, " linear_combination_%zu", i));
     }
 }
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/components/bar_gadget.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/components/bar_gadget.tcc
@@ -34,15 +34,15 @@ bar_gadget<FieldT>::bar_gadget(protoboard<FieldT> &pb,
     assert(X.size() == Y.size());
     width = X.size();
 
-    result.allocate(pb, libff::FMT(annotation_prefix, " result"));
-    Z_bits.allocate(pb, width, libff::FMT(annotation_prefix, " Z_bits"));
-    overflow.allocate(pb, 2*width, libff::FMT(annotation_prefix, " overflow"));
+    result.allocate(pb, FMT(annotation_prefix, " result"));
+    Z_bits.allocate(pb, width, FMT(annotation_prefix, " Z_bits"));
+    overflow.allocate(pb, 2*width, FMT(annotation_prefix, " overflow"));
 
     unpacked_result.insert(unpacked_result.end(), Z_bits.begin(), Z_bits.end());
     unpacked_result.insert(unpacked_result.end(), overflow.begin(), overflow.end());
 
-    unpack_result.reset(new packing_gadget<FieldT>(pb, unpacked_result, result, libff::FMT(annotation_prefix, " unpack_result")));
-    pack_Z.reset(new packing_gadget<FieldT>(pb, Z_bits, Z_packed, libff::FMT(annotation_prefix, " pack_Z")));
+    unpack_result.reset(new packing_gadget<FieldT>(pb, unpacked_result, result, FMT(annotation_prefix, " unpack_result")));
+    pack_Z.reset(new packing_gadget<FieldT>(pb, Z_bits, Z_packed, FMT(annotation_prefix, " pack_Z")));
 }
 
 template<typename FieldT>
@@ -51,7 +51,7 @@ void bar_gadget<FieldT>::generate_r1cs_constraints()
     unpack_result->generate_r1cs_constraints(true);
     pack_Z->generate_r1cs_constraints(false);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, a * pb_packing_sum<FieldT>(X) + b * pb_packing_sum<FieldT>(Y), result), libff::FMT(this->annotation_prefix, " compute_result"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, a * pb_packing_sum<FieldT>(X) + b * pb_packing_sum<FieldT>(Y), result), FMT(this->annotation_prefix, " compute_result"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.tcc
@@ -40,8 +40,8 @@ fooram_cpu_checker<FieldT>::fooram_cpu_checker(fooram_protoboard<FieldT> &pb,
     next_has_accepted(next_has_accepted)
 {
     /* increment PC */
-    packed_next_pc_addr.allocate(pb, libff::FMT(annotation_prefix, " packed_next_pc_addr"));
-    pack_next_pc_addr.reset(new packing_gadget<FieldT>(pb, next_pc_addr, packed_next_pc_addr, libff::FMT(annotation_prefix, " pack_next_pc_addr")));
+    packed_next_pc_addr.allocate(pb, FMT(annotation_prefix, " packed_next_pc_addr"));
+    pack_next_pc_addr.reset(new packing_gadget<FieldT>(pb, next_pc_addr, packed_next_pc_addr, FMT(annotation_prefix, " pack_next_pc_addr")));
 
     one_as_addr.resize(next_pc_addr.size());
     one_as_addr[0].assign(this->pb, 1);
@@ -51,45 +51,45 @@ fooram_cpu_checker<FieldT>::fooram_cpu_checker(fooram_protoboard<FieldT> &pb,
     }
 
     /* packed_next_pc_addr = prev_pc_addr + one_as_addr */
-    increment_pc.reset(new bar_gadget<FieldT>(pb, prev_pc_addr, FieldT::one(), one_as_addr, FieldT::one(), packed_next_pc_addr, libff::FMT(annotation_prefix, " increment_pc")));
+    increment_pc.reset(new bar_gadget<FieldT>(pb, prev_pc_addr, FieldT::one(), one_as_addr, FieldT::one(), packed_next_pc_addr, FMT(annotation_prefix, " increment_pc")));
 
     /* packed_store_addr = prev_pc_addr + prev_pc_val */
-    packed_store_addr.allocate(pb, libff::FMT(annotation_prefix, " packed_store_addr"));
-    compute_packed_store_addr.reset(new bar_gadget<FieldT>(pb, prev_pc_addr, FieldT::one(), prev_pc_val, FieldT::one(), packed_store_addr, libff::FMT(annotation_prefix, " compute_packed_store_addr")));
+    packed_store_addr.allocate(pb, FMT(annotation_prefix, " packed_store_addr"));
+    compute_packed_store_addr.reset(new bar_gadget<FieldT>(pb, prev_pc_addr, FieldT::one(), prev_pc_val, FieldT::one(), packed_store_addr, FMT(annotation_prefix, " compute_packed_store_addr")));
 
     /* packed_load_addr = 2 * x + next_pc_addr */
-    packed_load_addr.allocate(pb, libff::FMT(annotation_prefix, " packed_load_addr"));
-    compute_packed_load_addr.reset(new bar_gadget<FieldT>(pb, prev_pc_val, FieldT(2), next_pc_addr, FieldT::one(), packed_load_addr, libff::FMT(annotation_prefix, " compute_packed_load_addr")));
+    packed_load_addr.allocate(pb, FMT(annotation_prefix, " packed_load_addr"));
+    compute_packed_load_addr.reset(new bar_gadget<FieldT>(pb, prev_pc_val, FieldT(2), next_pc_addr, FieldT::one(), packed_load_addr, FMT(annotation_prefix, " compute_packed_load_addr")));
 
     /*
       packed_ls_addr = x0 * packed_load_addr + (1-x0) * packed_store_addr
       packed_ls_addr ~ ls_addr
     */
-    packed_ls_addr.allocate(pb, libff::FMT(annotation_prefix, " packed_ls_addr"));
+    packed_ls_addr.allocate(pb, FMT(annotation_prefix, " packed_ls_addr"));
     pack_ls_addr.reset(new packing_gadget<FieldT>(pb, ls_addr, packed_ls_addr, " pack_ls_addr"));
 
     /* packed_store_val = prev_state_bits + prev_pc_addr */
-    packed_store_val.allocate(pb, libff::FMT(annotation_prefix, " packed_store_val"));
-    compute_packed_store_val.reset(new bar_gadget<FieldT>(pb, prev_state, FieldT::one(), prev_pc_addr, FieldT::one(), packed_store_val, libff::FMT(annotation_prefix, " compute_packed_store_val")));
+    packed_store_val.allocate(pb, FMT(annotation_prefix, " packed_store_val"));
+    compute_packed_store_val.reset(new bar_gadget<FieldT>(pb, prev_state, FieldT::one(), prev_pc_addr, FieldT::one(), packed_store_val, FMT(annotation_prefix, " compute_packed_store_val")));
 
     /*
       packed_ls_next_val = x0 * packed_ls_prev_val + (1-x0) * packed_store_val
       packed_ls_next_val ~ ls_next_val
     */
-    packed_ls_prev_val.allocate(pb, libff::FMT(annotation_prefix, " packed_ls_prev_val"));
-    pack_ls_prev_val.reset(new packing_gadget<FieldT>(this->pb, ls_prev_val, packed_ls_prev_val, libff::FMT(annotation_prefix, " pack_ls_prev_val")));
-    packed_ls_next_val.allocate(pb, libff::FMT(annotation_prefix, " packed_ls_next_val"));
-    pack_ls_next_val.reset(new packing_gadget<FieldT>(this->pb, ls_next_val, packed_ls_next_val, libff::FMT(annotation_prefix, " pack_ls_next_val")));
+    packed_ls_prev_val.allocate(pb, FMT(annotation_prefix, " packed_ls_prev_val"));
+    pack_ls_prev_val.reset(new packing_gadget<FieldT>(this->pb, ls_prev_val, packed_ls_prev_val, FMT(annotation_prefix, " pack_ls_prev_val")));
+    packed_ls_next_val.allocate(pb, FMT(annotation_prefix, " packed_ls_next_val"));
+    pack_ls_next_val.reset(new packing_gadget<FieldT>(this->pb, ls_next_val, packed_ls_next_val, FMT(annotation_prefix, " pack_ls_next_val")));
 
     /*
       packed_next_state = x0 * packed_ls_prev_val + (1-x0) * packed_prev_state
       packed_next_state ~ next_state
       packed_prev_state ~ prev_state
     */
-    packed_prev_state.allocate(pb, libff::FMT(annotation_prefix, " packed_prev_state"));
+    packed_prev_state.allocate(pb, FMT(annotation_prefix, " packed_prev_state"));
     pack_prev_state.reset(new packing_gadget<FieldT>(pb, prev_state, packed_prev_state, " pack_prev_state"));
 
-    packed_next_state.allocate(pb, libff::FMT(annotation_prefix, " packed_next_state"));
+    packed_next_state.allocate(pb, FMT(annotation_prefix, " packed_next_state"));
     pack_next_state.reset(new packing_gadget<FieldT>(pb, next_state, packed_next_state, " pack_next_state"));
 
     /* next_has_accepted = 1 */
@@ -117,7 +117,7 @@ void fooram_cpu_checker<FieldT>::generate_r1cs_constraints()
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(prev_pc_val[0],
                                                          packed_load_addr - packed_store_addr,
                                                          packed_ls_addr - packed_store_addr),
-                                 libff::FMT(this->annotation_prefix, " compute_ls_addr_packed"));
+                                 FMT(this->annotation_prefix, " compute_ls_addr_packed"));
 
     /* packed_store_val = prev_state_bits + prev_pc_addr */
     compute_packed_store_val->generate_r1cs_constraints();
@@ -132,7 +132,7 @@ void fooram_cpu_checker<FieldT>::generate_r1cs_constraints()
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(prev_pc_val[0],
                                                          packed_ls_prev_val - packed_store_val,
                                                          packed_ls_next_val - packed_store_val),
-                                 libff::FMT(this->annotation_prefix, " compute_packed_ls_next_val"));
+                                 FMT(this->annotation_prefix, " compute_packed_ls_next_val"));
 
     /*
       packed_next_state = x0 * packed_ls_prev_val + (1-x0) * packed_prev_state
@@ -145,10 +145,10 @@ void fooram_cpu_checker<FieldT>::generate_r1cs_constraints()
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(prev_pc_val[0],
                                                          packed_ls_prev_val - packed_prev_state,
                                                          packed_next_state - packed_prev_state),
-                                 libff::FMT(this->annotation_prefix, " compute_packed_next_state"));
+                                 FMT(this->annotation_prefix, " compute_packed_next_state"));
 
     /* next_has_accepted = 1 */
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, next_has_accepted, 1), libff::FMT(this->annotation_prefix, " always_accepted"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, next_has_accepted, 1), FMT(this->annotation_prefix, " always_accepted"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.hpp
@@ -70,15 +70,15 @@ public:
                    const std::string &annotation_prefix="") :
         ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, result, result_flag, annotation_prefix)
     {
-        res_word.allocate(pb, pb.ap.w, libff::FMT(this->annotation_prefix, " res_bit"));
-        not_all_zeros_result.allocate(pb, libff::FMT(this->annotation_prefix, " not_all_zeros_result"));
+        res_word.allocate(pb, pb.ap.w, FMT(this->annotation_prefix, " res_bit"));
+        not_all_zeros_result.allocate(pb, FMT(this->annotation_prefix, " not_all_zeros_result"));
 
         pack_result.reset(
             new packing_gadget<FieldT>(pb, res_word, result,
-                                       libff::FMT(this->annotation_prefix, " pack_result")));
+                                       FMT(this->annotation_prefix, " pack_result")));
         not_all_zeros.reset(
             new disjunction_gadget<FieldT>(pb, res_word, not_all_zeros_result,
-                                           libff::FMT(this->annotation_prefix, "not_all_zeros")));
+                                           FMT(this->annotation_prefix, "not_all_zeros")));
     }
 
     void generate_r1cs_constraints();
@@ -107,15 +107,15 @@ public:
                   const std::string &annotation_prefix="") :
         ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, result, result_flag, annotation_prefix)
     {
-        res_word.allocate(pb, pb.ap.w, libff::FMT(this->annotation_prefix, " res_bit"));
-        not_all_zeros_result.allocate(pb, libff::FMT(this->annotation_prefix, " not_all_zeros_result"));
+        res_word.allocate(pb, pb.ap.w, FMT(this->annotation_prefix, " res_bit"));
+        not_all_zeros_result.allocate(pb, FMT(this->annotation_prefix, " not_all_zeros_result"));
 
         pack_result.reset(
             new packing_gadget<FieldT>(pb, res_word, result,
-                                       libff::FMT(this->annotation_prefix, " pack_result")));
+                                       FMT(this->annotation_prefix, " pack_result")));
         not_all_zeros.reset(
             new disjunction_gadget<FieldT>(pb, res_word, not_all_zeros_result,
-                                           libff::FMT(this->annotation_prefix, "not_all_zeros")));
+                                           FMT(this->annotation_prefix, "not_all_zeros")));
     }
 
     void generate_r1cs_constraints();
@@ -144,15 +144,15 @@ public:
                    const std::string &annotation_prefix="") :
         ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, result, result_flag, annotation_prefix)
     {
-        res_word.allocate(pb, pb.ap.w, libff::FMT(this->annotation_prefix, " res_bit"));
-        not_all_zeros_result.allocate(pb, libff::FMT(this->annotation_prefix, " not_all_zeros_result"));
+        res_word.allocate(pb, pb.ap.w, FMT(this->annotation_prefix, " res_bit"));
+        not_all_zeros_result.allocate(pb, FMT(this->annotation_prefix, " not_all_zeros_result"));
 
         pack_result.reset(
             new packing_gadget<FieldT>(pb, res_word, result,
-                                       libff::FMT(this->annotation_prefix, " pack_result")));
+                                       FMT(this->annotation_prefix, " pack_result")));
         not_all_zeros.reset(
             new disjunction_gadget<FieldT>(pb, res_word, not_all_zeros_result,
-                                           libff::FMT(this->annotation_prefix, "not_all_zeros")));
+                                           FMT(this->annotation_prefix, "not_all_zeros")));
     }
 
     void generate_r1cs_constraints();
@@ -182,15 +182,15 @@ public:
                    const std::string &annotation_prefix="") :
         ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, result, result_flag, annotation_prefix)
     {
-        res_word.allocate(pb, pb.ap.w, libff::FMT(this->annotation_prefix, " res_bit"));
-        not_all_zeros_result.allocate(pb, libff::FMT(this->annotation_prefix, " not_all_zeros_result"));
+        res_word.allocate(pb, pb.ap.w, FMT(this->annotation_prefix, " res_bit"));
+        not_all_zeros_result.allocate(pb, FMT(this->annotation_prefix, " not_all_zeros_result"));
 
         pack_result.reset(
             new packing_gadget<FieldT>(pb, res_word, result,
-                                       libff::FMT(this->annotation_prefix, " pack_result")));
+                                       FMT(this->annotation_prefix, " pack_result")));
         not_all_zeros.reset(
             new disjunction_gadget<FieldT>(pb, res_word, not_all_zeros_result,
-                                           libff::FMT(this->annotation_prefix, "not_all_zeros")));
+                                           FMT(this->annotation_prefix, "not_all_zeros")));
     }
 
     void generate_r1cs_constraints();
@@ -219,18 +219,18 @@ public:
                    const std::string &annotation_prefix="") :
         ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, result, result_flag, annotation_prefix)
     {
-        addition_result.allocate(pb, libff::FMT(this->annotation_prefix, " addition_result"));
-        res_word.allocate(pb, pb.ap.w, libff::FMT(this->annotation_prefix, " res_word"));
+        addition_result.allocate(pb, FMT(this->annotation_prefix, " addition_result"));
+        res_word.allocate(pb, pb.ap.w, FMT(this->annotation_prefix, " res_word"));
 
         res_word_and_flag = res_word;
         res_word_and_flag.emplace_back(result_flag);
 
         unpack_addition.reset(
             new packing_gadget<FieldT>(pb, res_word_and_flag, addition_result,
-                                       libff::FMT(this->annotation_prefix, " unpack_addition")));
+                                       FMT(this->annotation_prefix, " unpack_addition")));
         pack_result.reset(
             new packing_gadget<FieldT>(pb, res_word, result,
-                                       libff::FMT(this->annotation_prefix, " pack_result")));
+                                       FMT(this->annotation_prefix, " pack_result")));
     }
 
     void generate_r1cs_constraints();
@@ -260,19 +260,19 @@ public:
                    const std::string &annotation_prefix="") :
         ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, result, result_flag, annotation_prefix)
     {
-        intermediate_result.allocate(pb, libff::FMT(this->annotation_prefix, " intermediate_result"));
-        negated_flag.allocate(pb, libff::FMT(this->annotation_prefix, " negated_flag"));
-        res_word.allocate(pb, pb.ap.w, libff::FMT(this->annotation_prefix, " res_word"));
+        intermediate_result.allocate(pb, FMT(this->annotation_prefix, " intermediate_result"));
+        negated_flag.allocate(pb, FMT(this->annotation_prefix, " negated_flag"));
+        res_word.allocate(pb, pb.ap.w, FMT(this->annotation_prefix, " res_word"));
 
         res_word_and_negated_flag = res_word;
         res_word_and_negated_flag.emplace_back(negated_flag);
 
         unpack_intermediate.reset(
             new packing_gadget<FieldT>(pb, res_word_and_negated_flag, intermediate_result,
-                                       libff::FMT(this->annotation_prefix, " unpack_intermediate")));
+                                       FMT(this->annotation_prefix, " unpack_intermediate")));
         pack_result.reset(
             new packing_gadget<FieldT>(pb, res_word, result,
-                                       libff::FMT(this->annotation_prefix, " pack_result")));
+                                       FMT(this->annotation_prefix, " pack_result")));
     }
 
     void generate_r1cs_constraints();
@@ -352,7 +352,7 @@ public:
                    const std::string &annotation_prefix="") :
     ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, cmpa_result, cmpa_result_flag, annotation_prefix),
         comparator(pb, pb.ap.w, arg2val.packed, arg1val.packed, cmpa_result_flag, cmpae_result_flag,
-                   libff::FMT(this->annotation_prefix, " comparator")),
+                   FMT(this->annotation_prefix, " comparator")),
         cmpe_result(cmpe_result), cmpe_result_flag(cmpe_result_flag),
         cmpa_result(cmpa_result), cmpa_result_flag(cmpa_result_flag),
         cmpae_result(cmpae_result), cmpae_result_flag(cmpae_result_flag) {}
@@ -403,8 +403,8 @@ public:
         cmpg_result(cmpg_result), cmpg_result_flag(cmpg_result_flag),
         cmpge_result(cmpge_result), cmpge_result_flag(cmpge_result_flag)
     {
-        negated_arg1val_sign.allocate(pb, libff::FMT(this->annotation_prefix, " negated_arg1val_sign"));
-        negated_arg2val_sign.allocate(pb, libff::FMT(this->annotation_prefix, " negated_arg2val_sign"));
+        negated_arg1val_sign.allocate(pb, FMT(this->annotation_prefix, " negated_arg1val_sign"));
+        negated_arg2val_sign.allocate(pb, FMT(this->annotation_prefix, " negated_arg2val_sign"));
 
         modified_arg1 = pb_variable_array<FieldT>(arg1val.bits.begin(), --arg1val.bits.end());
         modified_arg1.emplace_back(negated_arg1val_sign);
@@ -412,18 +412,18 @@ public:
         modified_arg2 = pb_variable_array<FieldT>(arg2val.bits.begin(), --arg2val.bits.end());
         modified_arg2.emplace_back(negated_arg2val_sign);
 
-        packed_modified_arg1.allocate(pb, libff::FMT(this->annotation_prefix, " packed_modified_arg1"));
-        packed_modified_arg2.allocate(pb, libff::FMT(this->annotation_prefix, " packed_modified_arg2"));
+        packed_modified_arg1.allocate(pb, FMT(this->annotation_prefix, " packed_modified_arg1"));
+        packed_modified_arg2.allocate(pb, FMT(this->annotation_prefix, " packed_modified_arg2"));
 
         pack_modified_arg1.reset(new packing_gadget<FieldT>(pb, modified_arg1, packed_modified_arg1,
-                                                            libff::FMT(this->annotation_prefix, " pack_modified_arg1")));
+                                                            FMT(this->annotation_prefix, " pack_modified_arg1")));
         pack_modified_arg2.reset(new packing_gadget<FieldT>(pb, modified_arg2, packed_modified_arg2,
-                                                            libff::FMT(this->annotation_prefix, " pack_modified_arg2")));
+                                                            FMT(this->annotation_prefix, " pack_modified_arg2")));
 
         comparator.reset(new comparison_gadget<FieldT>(pb, pb.ap.w,
                                                        packed_modified_arg2, packed_modified_arg1,
                                                        cmpg_result_flag, cmpge_result_flag,
-                                                       libff::FMT(this->annotation_prefix, " comparator")));
+                                                       FMT(this->annotation_prefix, " comparator")));
     }
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
@@ -463,17 +463,17 @@ public:
                     const pb_variable<FieldT> &umulh_flag,
                     const std::string &annotation_prefix="") :
     ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, mull_result, mull_flag, annotation_prefix),
-        mul_result(pb, 2*pb.ap.w, libff::FMT(this->annotation_prefix, " mul_result")),
+        mul_result(pb, 2*pb.ap.w, FMT(this->annotation_prefix, " mul_result")),
         mull_result(mull_result), mull_flag(mull_flag), umulh_result(umulh_result), umulh_flag(umulh_flag)
     {
         mull_bits.insert(mull_bits.end(), mul_result.bits.begin(), mul_result.bits.begin()+pb.ap.w);
         umulh_bits.insert(umulh_bits.end(), mul_result.bits.begin()+pb.ap.w, mul_result.bits.begin()+2*pb.ap.w);
 
-        pack_mull_result.reset(new packing_gadget<FieldT>(pb, mull_bits, mull_result, libff::FMT(this->annotation_prefix, " pack_mull_result")));
-        pack_umulh_result.reset(new packing_gadget<FieldT>(pb, umulh_bits, umulh_result, libff::FMT(this->annotation_prefix, " pack_umulh_result")));
+        pack_mull_result.reset(new packing_gadget<FieldT>(pb, mull_bits, mull_result, FMT(this->annotation_prefix, " pack_mull_result")));
+        pack_umulh_result.reset(new packing_gadget<FieldT>(pb, umulh_bits, umulh_result, FMT(this->annotation_prefix, " pack_umulh_result")));
 
-        result_flag.allocate(pb, libff::FMT(this->annotation_prefix, " result_flag"));
-        compute_flag.reset(new disjunction_gadget<FieldT>(pb, umulh_bits, result_flag, libff::FMT(this->annotation_prefix, " compute_flag")));
+        result_flag.allocate(pb, FMT(this->annotation_prefix, " result_flag"));
+        compute_flag.reset(new disjunction_gadget<FieldT>(pb, umulh_bits, result_flag, FMT(this->annotation_prefix, " compute_flag")));
     }
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
@@ -513,24 +513,24 @@ public:
                     const pb_variable<FieldT> &smulh_flag,
                     const std::string &annotation_prefix="") :
     ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, smulh_result, smulh_flag, annotation_prefix),
-        mul_result(pb, 2*pb.ap.w+1, libff::FMT(this->annotation_prefix, " mul_result")), /* see witness map for explanation for 2w+1 */
+        mul_result(pb, 2*pb.ap.w+1, FMT(this->annotation_prefix, " mul_result")), /* see witness map for explanation for 2w+1 */
         smulh_result(smulh_result), smulh_flag(smulh_flag)
     {
         smulh_bits.insert(smulh_bits.end(), mul_result.bits.begin()+pb.ap.w, mul_result.bits.begin()+2*pb.ap.w);
 
-        pack_smulh_result.reset(new packing_gadget<FieldT>(pb, smulh_bits, smulh_result, libff::FMT(this->annotation_prefix, " pack_smulh_result")));
+        pack_smulh_result.reset(new packing_gadget<FieldT>(pb, smulh_bits, smulh_result, FMT(this->annotation_prefix, " pack_smulh_result")));
 
-        top.allocate(pb, libff::FMT(this->annotation_prefix, " top"));
+        top.allocate(pb, FMT(this->annotation_prefix, " top"));
         pack_top.reset(new packing_gadget<FieldT>(pb, pb_variable_array<FieldT>(mul_result.bits.begin() + pb.ap.w-1, mul_result.bits.begin() + 2*pb.ap.w), top,
-                                                  libff::FMT(this->annotation_prefix, " pack_top")));
+                                                  FMT(this->annotation_prefix, " pack_top")));
 
-        is_top_empty.allocate(pb, libff::FMT(this->annotation_prefix, " is_top_empty"));
-        is_top_empty_aux.allocate(pb, libff::FMT(this->annotation_prefix, " is_top_empty_aux"));
+        is_top_empty.allocate(pb, FMT(this->annotation_prefix, " is_top_empty"));
+        is_top_empty_aux.allocate(pb, FMT(this->annotation_prefix, " is_top_empty_aux"));
 
-        is_top_full.allocate(pb, libff::FMT(this->annotation_prefix, " is_top_full"));
-        is_top_full_aux.allocate(pb, libff::FMT(this->annotation_prefix, " is_top_full_aux"));
+        is_top_full.allocate(pb, FMT(this->annotation_prefix, " is_top_full"));
+        is_top_full_aux.allocate(pb, FMT(this->annotation_prefix, " is_top_full_aux"));
 
-        result_flag.allocate(pb, libff::FMT(this->annotation_prefix, " result_flag"));
+        result_flag.allocate(pb, FMT(this->annotation_prefix, " result_flag"));
     }
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
@@ -577,11 +577,11 @@ public:
     ALU_arithmetic_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag, udiv_result, udiv_flag, annotation_prefix),
         udiv_result(udiv_result), udiv_flag(udiv_flag), umod_result(umod_result), umod_flag(umod_flag)
     {
-        B_inv.allocate(pb, libff::FMT(this->annotation_prefix, " B_inv"));
-        B_nonzero.allocate(pb, libff::FMT(this->annotation_prefix, " B_nonzer"));
-        A_aux.allocate(pb, libff::FMT(this->annotation_prefix, " A_aux"));
+        B_inv.allocate(pb, FMT(this->annotation_prefix, " B_inv"));
+        B_nonzero.allocate(pb, FMT(this->annotation_prefix, " B_nonzer"));
+        A_aux.allocate(pb, FMT(this->annotation_prefix, " A_aux"));
         r_less_B.reset(new comparison_gadget<FieldT>(pb, pb.ap.w, umod_result, arg2val.packed,
-                                                     B_nonzero, ONE, libff::FMT(this->annotation_prefix, " r_less_B")));
+                                                     B_nonzero, ONE, FMT(this->annotation_prefix, " r_less_B")));
     }
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
@@ -634,38 +634,38 @@ public:
     {
         logw = libff::log2(pb.ap.w);
 
-        reversed_input.allocate(pb, libff::FMT(this->annotation_prefix, " reversed_input"));
+        reversed_input.allocate(pb, FMT(this->annotation_prefix, " reversed_input"));
         pack_reversed_input.reset(
             new packing_gadget<FieldT>(pb, pb_variable_array<FieldT>(arg1val.bits.rbegin(), arg1val.bits.rend()),
                                        reversed_input,
-                                       libff::FMT(this->annotation_prefix, " pack_reversed_input")));
+                                       FMT(this->annotation_prefix, " pack_reversed_input")));
 
-        barrel_right_internal.allocate(pb, logw+1, libff::FMT(this->annotation_prefix, " barrel_right_internal"));
+        barrel_right_internal.allocate(pb, logw+1, FMT(this->annotation_prefix, " barrel_right_internal"));
 
         shifted_out_bits.resize(logw);
         for (size_t i = 0; i < logw; ++i)
         {
-            shifted_out_bits[i].allocate(pb, 1ul<<i, libff::FMT(this->annotation_prefix, " shifted_out_bits_%zu", i));
+            shifted_out_bits[i].allocate(pb, 1ul<<i, FMT(this->annotation_prefix, " shifted_out_bits_%zu", i));
         }
 
-        is_oversize_shift.allocate(pb, libff::FMT(this->annotation_prefix, " is_oversize_shift"));
+        is_oversize_shift.allocate(pb, FMT(this->annotation_prefix, " is_oversize_shift"));
         check_oversize_shift.reset(
             new disjunction_gadget<FieldT>(pb,
                                            pb_variable_array<FieldT>(arg2val.bits.begin()+logw, arg2val.bits.end()),
                                            is_oversize_shift,
-                                           libff::FMT(this->annotation_prefix, " check_oversize_shift")));
-        result.allocate(pb, libff::FMT(this->annotation_prefix, " result"));
+                                           FMT(this->annotation_prefix, " check_oversize_shift")));
+        result.allocate(pb, FMT(this->annotation_prefix, " result"));
 
-        result_bits.allocate(pb, pb.ap.w, libff::FMT(this->annotation_prefix, " result_bits"));
+        result_bits.allocate(pb, pb.ap.w, FMT(this->annotation_prefix, " result_bits"));
         unpack_result.reset(
             new packing_gadget<FieldT>(pb, result_bits, result, //barrel_right_internal[logw],
-                                       libff::FMT(this->annotation_prefix, " unpack_result")));
+                                       FMT(this->annotation_prefix, " unpack_result")));
 
-        reversed_result.allocate(pb, libff::FMT(this->annotation_prefix, " reversed_result"));
+        reversed_result.allocate(pb, FMT(this->annotation_prefix, " reversed_result"));
         pack_reversed_result.reset(
             new packing_gadget<FieldT>(pb, pb_variable_array<FieldT>(result_bits.rbegin(), result_bits.rend()),
                                        reversed_result,
-                                       libff::FMT(this->annotation_prefix, " pack_reversed_result")));
+                                       FMT(this->annotation_prefix, " pack_reversed_result")));
     }
     void generate_r1cs_constraints();
     void generate_r1cs_witness();

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
@@ -132,7 +132,7 @@ void ALU_and_gadget<FieldT>::generate_r1cs_constraints()
                 { this->arg1val.bits[i] },
                 { this->arg2val.bits[i] },
                 { this->res_word[i] }),
-            libff::FMT(this->annotation_prefix, " res_word_%zu", i));
+            FMT(this->annotation_prefix, " res_word_%zu", i));
     }
 
     /* generate result */
@@ -145,7 +145,7 @@ void ALU_and_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { ONE, this->not_all_zeros_result * (-1) },
             { this->result_flag }),
-        libff::FMT(this->annotation_prefix, " result_flag"));
+        FMT(this->annotation_prefix, " result_flag"));
 }
 
 template<typename FieldT>
@@ -197,7 +197,7 @@ void ALU_or_gadget<FieldT>::generate_r1cs_constraints()
                 { ONE, this->arg1val.bits[i] * (-1) },
                 { ONE, this->arg2val.bits[i] * (-1) },
                 { ONE, this->res_word[i] * (-1) }),
-            libff::FMT(this->annotation_prefix, " res_word_%zu", i));
+            FMT(this->annotation_prefix, " res_word_%zu", i));
     }
 
     /* generate result */
@@ -210,7 +210,7 @@ void ALU_or_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { ONE, this->not_all_zeros_result * (-1) },
             { this->result_flag }),
-        libff::FMT(this->annotation_prefix, " result_flag"));
+        FMT(this->annotation_prefix, " result_flag"));
 }
 
 template<typename FieldT>
@@ -263,7 +263,7 @@ void ALU_xor_gadget<FieldT>::generate_r1cs_constraints()
                 { this->arg1val.bits[i] * 2},
                 { this->arg2val.bits[i] },
                 { this->arg1val.bits[i], this->arg2val.bits[i], this->res_word[i] * (-1) }),
-            libff::FMT(this->annotation_prefix, " res_word_%zu", i));
+            FMT(this->annotation_prefix, " res_word_%zu", i));
     }
 
     /* generate result */
@@ -276,7 +276,7 @@ void ALU_xor_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { ONE, this->not_all_zeros_result * (-1) },
             { this->result_flag }),
-        libff::FMT(this->annotation_prefix, " result_flag"));
+        FMT(this->annotation_prefix, " result_flag"));
 }
 
 template<typename FieldT>
@@ -328,7 +328,7 @@ void ALU_not_gadget<FieldT>::generate_r1cs_constraints()
                 { ONE },
                 { ONE, this->arg2val.bits[i] * (-1) },
                 { this->res_word[i] }),
-            libff::FMT(this->annotation_prefix, " res_word_%zu", i));
+            FMT(this->annotation_prefix, " res_word_%zu", i));
     }
 
     /* generate result */
@@ -341,7 +341,7 @@ void ALU_not_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { ONE, this->not_all_zeros_result * (-1) },
             { this->result_flag }),
-        libff::FMT(this->annotation_prefix, " result_flag"));
+        FMT(this->annotation_prefix, " result_flag"));
 }
 
 template<typename FieldT>
@@ -391,7 +391,7 @@ void ALU_add_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { this->arg1val.packed, this->arg2val.packed },
             { this->addition_result }),
-        libff::FMT(this->annotation_prefix, " addition_result"));
+        FMT(this->annotation_prefix, " addition_result"));
 
     /* unpack into bits */
     unpack_addition->generate_r1cs_constraints(true);
@@ -449,7 +449,7 @@ void ALU_sub_gadget<FieldT>::generate_r1cs_constraints()
     b.add_term(this->arg2val.packed, -1);
     c.add_term(intermediate_result, 1);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), libff::FMT(this->annotation_prefix, " main_constraint"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), FMT(this->annotation_prefix, " main_constraint"));
 
     /* unpack into bits */
     unpack_intermediate->generate_r1cs_constraints(true);
@@ -461,7 +461,7 @@ void ALU_sub_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { ONE, this->negated_flag * (-1) },
             { this->result_flag }),
-        libff::FMT(this->annotation_prefix, " result_flag"));
+        FMT(this->annotation_prefix, " result_flag"));
 }
 
 template<typename FieldT>
@@ -516,14 +516,14 @@ void ALU_mov_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { this->arg2val.packed },
             { this->result }),
-        libff::FMT(this->annotation_prefix, " mov_result"));
+        FMT(this->annotation_prefix, " mov_result"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->flag },
             { this->result_flag }),
-        libff::FMT(this->annotation_prefix, " mov_result_flag"));
+        FMT(this->annotation_prefix, " mov_result_flag"));
 }
 
 template<typename FieldT>
@@ -568,14 +568,14 @@ void ALU_cmov_gadget<FieldT>::generate_r1cs_constraints()
             { this->flag },
             { this->arg2val.packed, this->desval.packed * (-1) },
             { this->result, this->desval.packed * (-1) }),
-        libff::FMT(this->annotation_prefix, " cmov_result"));
+        FMT(this->annotation_prefix, " cmov_result"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->flag },
             { this->result_flag }),
-        libff::FMT(this->annotation_prefix, " cmov_result_flag"));
+        FMT(this->annotation_prefix, " cmov_result_flag"));
 }
 
 template<typename FieldT>
@@ -622,7 +622,7 @@ void ALU_cmp_gadget<FieldT>::generate_r1cs_constraints()
             { cmpae_result_flag },
             { ONE, cmpa_result_flag * (-1) },
             { cmpe_result_flag }),
-        libff::FMT(this->annotation_prefix, " cmpa_result_flag"));
+        FMT(this->annotation_prefix, " cmpa_result_flag"));
 
     /* copy over results */
     this->pb.add_r1cs_constraint(
@@ -630,21 +630,21 @@ void ALU_cmp_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { this->desval.packed },
             { cmpe_result }),
-        libff::FMT(this->annotation_prefix, " cmpe_result"));
+        FMT(this->annotation_prefix, " cmpe_result"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->desval.packed },
             { cmpa_result }),
-        libff::FMT(this->annotation_prefix, " cmpa_result"));
+        FMT(this->annotation_prefix, " cmpa_result"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->desval.packed },
             { cmpae_result }),
-        libff::FMT(this->annotation_prefix, " cmpae_result"));
+        FMT(this->annotation_prefix, " cmpae_result"));
 }
 
 template<typename FieldT>
@@ -759,13 +759,13 @@ void ALU_cmps_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { ONE, this->arg1val.bits[this->pb.ap.w-1] * (-1) },
             { negated_arg1val_sign }),
-        libff::FMT(this->annotation_prefix, " negated_arg1val_sign"));
+        FMT(this->annotation_prefix, " negated_arg1val_sign"));
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { ONE, this->arg2val.bits[this->pb.ap.w-1] * (-1) },
             { negated_arg2val_sign }),
-        libff::FMT(this->annotation_prefix, " negated_arg2val_sign"));
+        FMT(this->annotation_prefix, " negated_arg2val_sign"));
 
     /* pack */
     pack_modified_arg1->generate_r1cs_constraints(false);
@@ -780,14 +780,14 @@ void ALU_cmps_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { this->desval.packed },
             { cmpg_result }),
-        libff::FMT(this->annotation_prefix, " cmpg_result"));
+        FMT(this->annotation_prefix, " cmpg_result"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->desval.packed },
             { cmpge_result }),
-        libff::FMT(this->annotation_prefix, " cmpge_result"));
+        FMT(this->annotation_prefix, " cmpge_result"));
 }
 
 template<typename FieldT>
@@ -875,7 +875,7 @@ void ALU_umul_gadget<FieldT>::generate_r1cs_constraints()
             { this->arg1val.packed },
             { this->arg2val.packed },
             { mul_result.packed }),
-        libff::FMT(this->annotation_prefix, " main_constraint"));
+        FMT(this->annotation_prefix, " main_constraint"));
     mul_result.generate_r1cs_constraints(true);
 
     /* pack result */
@@ -890,14 +890,14 @@ void ALU_umul_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { this->result_flag },
             { mull_flag }),
-        libff::FMT(this->annotation_prefix, " mull_flag"));
+        FMT(this->annotation_prefix, " mull_flag"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->result_flag },
             { umulh_flag }),
-        libff::FMT(this->annotation_prefix, " umulh_flag"));
+        FMT(this->annotation_prefix, " umulh_flag"));
 }
 
 template<typename FieldT>
@@ -992,7 +992,7 @@ void ALU_smul_gadget<FieldT>::generate_r1cs_constraints()
     b.add_term(this->arg2val.bits[this->pb.ap.w-1], -(FieldT(2)^this->pb.ap.w));
     c.add_term(mul_result.packed, 1);
     c.add_term(ONE, -(FieldT(2)^(2*this->pb.ap.w)));
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), libff::FMT(this->annotation_prefix, " main_constraint"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), FMT(this->annotation_prefix, " main_constraint"));
 
     mul_result.generate_r1cs_constraints(true);
 
@@ -1015,26 +1015,26 @@ void ALU_smul_gadget<FieldT>::generate_r1cs_constraints()
             { is_top_empty_aux },
             { top },
             { ONE, is_top_empty * (-1) }),
-        libff::FMT(this->annotation_prefix, " I*X=1-R (is_top_empty)"));
+        FMT(this->annotation_prefix, " I*X=1-R (is_top_empty)"));
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { is_top_empty },
             { top },
             { ONE * 0 }),
-        libff::FMT(this->annotation_prefix, " R*X=0 (is_top_full)"));
+        FMT(this->annotation_prefix, " R*X=0 (is_top_full)"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { is_top_full_aux },
             { top, ONE * (1l-(1ul<<(this->pb.ap.w+1))) },
             { ONE, is_top_full * (-1) }),
-        libff::FMT(this->annotation_prefix, " I*X=1-R (is_top_full)"));
+        FMT(this->annotation_prefix, " I*X=1-R (is_top_full)"));
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { is_top_full },
             { top, ONE * (1l-(1ul<<(this->pb.ap.w+1))) },
             { ONE * 0 }),
-        libff::FMT(this->annotation_prefix, " R*X=0 (is_top_full)"));
+        FMT(this->annotation_prefix, " R*X=0 (is_top_full)"));
 
     /* smulh_flag = 1 - (is_top_full + is_top_empty) */
     this->pb.add_r1cs_constraint(
@@ -1042,7 +1042,7 @@ void ALU_smul_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { ONE, is_top_full * (-1), is_top_empty * (-1) },
             { smulh_flag }),
-        libff::FMT(this->annotation_prefix, " smulh_flag"));
+        FMT(this->annotation_prefix, " smulh_flag"));
 }
 
 template<typename FieldT>
@@ -1133,7 +1133,7 @@ void ALU_divmod_gadget<FieldT>::generate_r1cs_constraints()
     b1.add_term(this->arg2val.packed, 1);
     c1.add_term(B_nonzero, 1);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a1, b1, c1), libff::FMT(this->annotation_prefix, " B_inv*B=B_nonzero"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a1, b1, c1), FMT(this->annotation_prefix, " B_inv*B=B_nonzero"));
 
     /* (1-B_nonzero) * B = 0 */
     linear_combination<FieldT> a2, b2, c2;
@@ -1142,7 +1142,7 @@ void ALU_divmod_gadget<FieldT>::generate_r1cs_constraints()
     b2.add_term(this->arg2val.packed, 1);
     c2.add_term(ONE, 0);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a2, b2, c2), libff::FMT(this->annotation_prefix, " (1-B_nonzero)*B=0"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a2, b2, c2), FMT(this->annotation_prefix, " (1-B_nonzero)*B=0"));
 
     /* B * q + r = A_aux = A * B_nonzero */
     linear_combination<FieldT> a3, b3, c3;
@@ -1151,14 +1151,14 @@ void ALU_divmod_gadget<FieldT>::generate_r1cs_constraints()
     c3.add_term(A_aux, 1);
     c3.add_term(umod_result, -1);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a3, b3, c3), libff::FMT(this->annotation_prefix, " B*q+r=A_aux"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a3, b3, c3), FMT(this->annotation_prefix, " B*q+r=A_aux"));
 
     linear_combination<FieldT> a4, b4, c4;
     a4.add_term(this->arg1val.packed, 1);
     b4.add_term(B_nonzero, 1);
     c4.add_term(A_aux, 1);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a4, b4, c4), libff::FMT(this->annotation_prefix, " A_aux=A*B_nonzero"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a4, b4, c4), FMT(this->annotation_prefix, " A_aux=A*B_nonzero"));
 
     /* q * (1-B_nonzero) = 0 */
     linear_combination<FieldT> a5, b5, c5;
@@ -1167,7 +1167,7 @@ void ALU_divmod_gadget<FieldT>::generate_r1cs_constraints()
     b5.add_term(B_nonzero, -1);
     c5.add_term(ONE, 0);
 
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a5, b5, c5), libff::FMT(this->annotation_prefix, " q*B_nonzero=0"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a5, b5, c5), FMT(this->annotation_prefix, " q*B_nonzero=0"));
 
     /* A<B_gadget<FieldT>(B, r, less=B_nonzero, leq=ONE) */
     r_less_B->generate_r1cs_constraints();
@@ -1287,7 +1287,7 @@ void ALU_shr_shl_gadget<FieldT>::generate_r1cs_constraints()
             { this->arg1val.packed, reversed_input * (-1) },
             { this->opcode_indicators[tinyram_opcode_SHR] },
             { barrel_right_internal[0], reversed_input * (-1) }),
-        libff::FMT(this->annotation_prefix, " select_arg1val_or_reversed"));
+        FMT(this->annotation_prefix, " select_arg1val_or_reversed"));
 
     /*
       do logw iterations of barrel shifts
@@ -1297,7 +1297,7 @@ void ALU_shr_shl_gadget<FieldT>::generate_r1cs_constraints()
         /* assert that shifted out part is bits */
         for (size_t j = 0; j < 1ul<<i; ++j)
         {
-            generate_boolean_r1cs_constraint<FieldT>(this->pb, shifted_out_bits[i][j], libff::FMT(this->annotation_prefix, " shifted_out_bits_%zu_%zu", i, j));
+            generate_boolean_r1cs_constraint<FieldT>(this->pb, shifted_out_bits[i][j], FMT(this->annotation_prefix, " shifted_out_bits_%zu_%zu", i, j));
         }
 
         /*
@@ -1323,7 +1323,7 @@ void ALU_shr_shl_gadget<FieldT>::generate_r1cs_constraints()
         c.add_term(barrel_right_internal[i], 1);
         c.add_term(barrel_right_internal[i+1], -1);
 
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), libff::FMT(this->annotation_prefix, " barrel_shift_%zu", i));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(a, b, c), FMT(this->annotation_prefix, " barrel_shift_%zu", i));
     }
 
     /*
@@ -1337,7 +1337,7 @@ void ALU_shr_shl_gadget<FieldT>::generate_r1cs_constraints()
             { ONE, is_oversize_shift * (-1) },
             { barrel_right_internal[logw] },
             { this->result }),
-        libff::FMT(this->annotation_prefix, " result"));
+        FMT(this->annotation_prefix, " result"));
 
     /*
       get reversed result for SHL
@@ -1355,28 +1355,28 @@ void ALU_shr_shl_gadget<FieldT>::generate_r1cs_constraints()
             { this->result, reversed_result * (-1) },
             { this->opcode_indicators[tinyram_opcode_SHR] },
             { shr_result, reversed_result * (-1) }),
-        libff::FMT(this->annotation_prefix, " shr_result"));
+        FMT(this->annotation_prefix, " shr_result"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { this->result, reversed_result * (-1) },
             { this->opcode_indicators[tinyram_opcode_SHR] },
             { shr_result, reversed_result * (-1) }),
-        libff::FMT(this->annotation_prefix, " shl_result"));
+        FMT(this->annotation_prefix, " shl_result"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->arg1val.bits[0] },
             { shr_flag }),
-        libff::FMT(this->annotation_prefix, " shr_flag"));
+        FMT(this->annotation_prefix, " shr_flag"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             { ONE },
             { this->arg1val.bits[this->pb.ap.w-1] },
             { shl_flag }),
-        libff::FMT(this->annotation_prefix, " shl_flag"));
+        FMT(this->annotation_prefix, " shl_flag"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.tcc
@@ -27,7 +27,7 @@ void ALU_jmp_gadget<FieldT>::generate_r1cs_constraints()
             { ONE },
             { this->argval2.packed },
             { this->result }),
-        libff::FMT(this->annotation_prefix, " jmp_result"));
+        FMT(this->annotation_prefix, " jmp_result"));
 }
 
 template<typename FieldT>
@@ -89,7 +89,7 @@ void ALU_cjmp_gadget<FieldT>::generate_r1cs_constraints()
             this->flag,
             pb_packing_sum<FieldT>(pb_variable_array<FieldT>(this->argval2.bits.begin() + this->pb.ap.subaddr_len(), this->argval2.bits.end())) - this->pc.packed - 1,
             this->result - this->pc.packed - 1),
-        libff::FMT(this->annotation_prefix, " cjmp_result"));
+        FMT(this->annotation_prefix, " cjmp_result"));
 }
 
 template<typename FieldT>
@@ -168,7 +168,7 @@ void ALU_cnjmp_gadget<FieldT>::generate_r1cs_constraints()
             this->flag,
             this->pc.packed + 1 - pb_packing_sum<FieldT>(pb_variable_array<FieldT>(this->argval2.bits.begin() + this->pb.ap.subaddr_len(), this->argval2.bits.end())),
             this->result - pb_packing_sum<FieldT>(pb_variable_array<FieldT>(this->argval2.bits.begin() + this->pb.ap.subaddr_len(), this->argval2.bits.end()))),
-        libff::FMT(this->annotation_prefix, " cnjmp_result"));
+        FMT(this->annotation_prefix, " cnjmp_result"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_gadget.hpp
@@ -60,49 +60,49 @@ public:
             new ALU_and_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                        instruction_results[tinyram_opcode_AND],
                                        instruction_flags[tinyram_opcode_AND],
-                                       libff::FMT(this->annotation_prefix, " AND")));
+                                       FMT(this->annotation_prefix, " AND")));
 
         components[tinyram_opcode_OR].reset(
             new ALU_or_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                       instruction_results[tinyram_opcode_OR],
                                       instruction_flags[tinyram_opcode_OR],
-                                      libff::FMT(this->annotation_prefix, " OR")));
+                                      FMT(this->annotation_prefix, " OR")));
 
         components[tinyram_opcode_XOR].reset(
             new ALU_xor_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                        instruction_results[tinyram_opcode_XOR],
                                        instruction_flags[tinyram_opcode_XOR],
-                                       libff::FMT(this->annotation_prefix, " XOR")));
+                                       FMT(this->annotation_prefix, " XOR")));
 
         components[tinyram_opcode_NOT].reset(
             new ALU_not_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                        instruction_results[tinyram_opcode_NOT],
                                        instruction_flags[tinyram_opcode_NOT],
-                                       libff::FMT(this->annotation_prefix, " NOT")));
+                                       FMT(this->annotation_prefix, " NOT")));
 
         components[tinyram_opcode_ADD].reset(
             new ALU_add_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                        instruction_results[tinyram_opcode_ADD],
                                        instruction_flags[tinyram_opcode_ADD],
-                                       libff::FMT(this->annotation_prefix, " ADD")));
+                                       FMT(this->annotation_prefix, " ADD")));
 
         components[tinyram_opcode_SUB].reset(
             new ALU_sub_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                        instruction_results[tinyram_opcode_SUB],
                                        instruction_flags[tinyram_opcode_SUB],
-                                       libff::FMT(this->annotation_prefix, " SUB")));
+                                       FMT(this->annotation_prefix, " SUB")));
 
         components[tinyram_opcode_MOV].reset(
             new ALU_mov_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                        instruction_results[tinyram_opcode_MOV],
                                        instruction_flags[tinyram_opcode_MOV],
-                                       libff::FMT(this->annotation_prefix, " MOV")));
+                                       FMT(this->annotation_prefix, " MOV")));
 
         components[tinyram_opcode_CMOV].reset(
             new ALU_cmov_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                         instruction_results[tinyram_opcode_CMOV],
                                         instruction_flags[tinyram_opcode_CMOV],
-                                        libff::FMT(this->annotation_prefix, " CMOV")));
+                                        FMT(this->annotation_prefix, " CMOV")));
 
         components[tinyram_opcode_CMPA].reset(
             new ALU_cmp_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
@@ -112,7 +112,7 @@ public:
                                        instruction_flags[tinyram_opcode_CMPA],
                                        instruction_results[tinyram_opcode_CMPAE],
                                        instruction_flags[tinyram_opcode_CMPAE],
-                                       libff::FMT(this->annotation_prefix, " CMP_unsigned")));
+                                       FMT(this->annotation_prefix, " CMP_unsigned")));
 
         components[tinyram_opcode_CMPG].reset(
             new ALU_cmps_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
@@ -120,7 +120,7 @@ public:
                                         instruction_flags[tinyram_opcode_CMPG],
                                         instruction_results[tinyram_opcode_CMPGE],
                                         instruction_flags[tinyram_opcode_CMPGE],
-                                        libff::FMT(this->annotation_prefix, " CMP_signed")));
+                                        FMT(this->annotation_prefix, " CMP_signed")));
 
         components[tinyram_opcode_UMULH].reset(
             new ALU_umul_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
@@ -128,13 +128,13 @@ public:
                                         instruction_flags[tinyram_opcode_MULL],
                                         instruction_results[tinyram_opcode_UMULH],
                                         instruction_flags[tinyram_opcode_UMULH],
-                                        libff::FMT(this->annotation_prefix, " MUL_unsigned")));
+                                        FMT(this->annotation_prefix, " MUL_unsigned")));
 
         components[tinyram_opcode_SMULH].reset(
             new ALU_smul_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
                                         instruction_results[tinyram_opcode_SMULH],
                                         instruction_flags[tinyram_opcode_SMULH],
-                                        libff::FMT(this->annotation_prefix, " MUL_signed")));
+                                        FMT(this->annotation_prefix, " MUL_signed")));
 
 
         components[tinyram_opcode_UDIV].reset(
@@ -143,7 +143,7 @@ public:
                                           instruction_flags[tinyram_opcode_UDIV],
                                           instruction_results[tinyram_opcode_UMOD],
                                           instruction_flags[tinyram_opcode_UMOD],
-                                          libff::FMT(this->annotation_prefix, " DIV")));
+                                          FMT(this->annotation_prefix, " DIV")));
 
         components[tinyram_opcode_SHR].reset(
             new ALU_shr_shl_gadget<FieldT>(pb, opcode_indicators, desval, arg1val, arg2val, flag,
@@ -151,23 +151,23 @@ public:
                                            instruction_flags[tinyram_opcode_SHR],
                                            instruction_results[tinyram_opcode_SHL],
                                            instruction_flags[tinyram_opcode_SHL],
-                                           libff::FMT(this->annotation_prefix, " SHR_SHL")));
+                                           FMT(this->annotation_prefix, " SHR_SHL")));
 
         /* control flow */
         components[tinyram_opcode_JMP].reset(
             new ALU_jmp_gadget<FieldT>(pb, pc, arg2val, flag,
                                        instruction_results[tinyram_opcode_JMP],
-                                       libff::FMT(this->annotation_prefix, " JMP")));
+                                       FMT(this->annotation_prefix, " JMP")));
 
         components[tinyram_opcode_CJMP].reset(
             new ALU_cjmp_gadget<FieldT>(pb, pc, arg2val, flag,
                                         instruction_results[tinyram_opcode_CJMP],
-                                        libff::FMT(this->annotation_prefix, " CJMP")));
+                                        FMT(this->annotation_prefix, " CJMP")));
 
         components[tinyram_opcode_CNJMP].reset(
             new ALU_cnjmp_gadget<FieldT>(pb, pc, arg2val, flag,
                                          instruction_results[tinyram_opcode_CNJMP],
-                                         libff::FMT(this->annotation_prefix, " CNJMP")));
+                                         FMT(this->annotation_prefix, " CNJMP")));
     }
 
     void generate_r1cs_constraints();

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/argument_decoder_gadget.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/argument_decoder_gadget.tcc
@@ -42,26 +42,26 @@ argument_decoder_gadget<FieldT>::argument_decoder_gadget(tinyram_protoboard<Fiel
     assert(arg2idx.size() == pb.ap.reg_arg_or_imm_width());
 
     /* decode accordingly */
-    packed_desidx.allocate(pb, libff::FMT(this->annotation_prefix, " packed_desidx"));
-    packed_arg1idx.allocate(pb, libff::FMT(this->annotation_prefix, " packed_arg1idx"));
-    packed_arg2idx.allocate(pb, libff::FMT(this->annotation_prefix, " packed_arg2idx"));
+    packed_desidx.allocate(pb, FMT(this->annotation_prefix, " packed_desidx"));
+    packed_arg1idx.allocate(pb, FMT(this->annotation_prefix, " packed_arg1idx"));
+    packed_arg2idx.allocate(pb, FMT(this->annotation_prefix, " packed_arg2idx"));
 
-    pack_desidx.reset(new packing_gadget<FieldT>(pb, desidx, packed_desidx, libff::FMT(this->annotation_prefix, "pack_desidx")));
-    pack_arg1idx.reset(new packing_gadget<FieldT>(pb, arg1idx, packed_arg1idx, libff::FMT(this->annotation_prefix, "pack_arg1idx")));
-    pack_arg2idx.reset(new packing_gadget<FieldT>(pb, arg2idx, packed_arg2idx, libff::FMT(this->annotation_prefix, "pack_arg2idx")));
+    pack_desidx.reset(new packing_gadget<FieldT>(pb, desidx, packed_desidx, FMT(this->annotation_prefix, "pack_desidx")));
+    pack_arg1idx.reset(new packing_gadget<FieldT>(pb, arg1idx, packed_arg1idx, FMT(this->annotation_prefix, "pack_arg1idx")));
+    pack_arg2idx.reset(new packing_gadget<FieldT>(pb, arg2idx, packed_arg2idx, FMT(this->annotation_prefix, "pack_arg2idx")));
 
-    arg2_demux_result.allocate(pb, libff::FMT(this->annotation_prefix, " arg2_demux_result"));
-    arg2_demux_success.allocate(pb, libff::FMT(this->annotation_prefix, " arg2_demux_success"));
+    arg2_demux_result.allocate(pb, FMT(this->annotation_prefix, " arg2_demux_result"));
+    arg2_demux_success.allocate(pb, FMT(this->annotation_prefix, " arg2_demux_success"));
 
     demux_des.reset(
         new loose_multiplexing_gadget<FieldT>(pb, packed_registers, packed_desidx, packed_desval, ONE,
-                                              libff::FMT(this->annotation_prefix, " demux_des")));
+                                              FMT(this->annotation_prefix, " demux_des")));
     demux_arg1.reset(
         new loose_multiplexing_gadget<FieldT>(pb, packed_registers, packed_arg1idx, packed_arg1val, ONE,
-                                              libff::FMT(this->annotation_prefix, " demux_arg1")));
+                                              FMT(this->annotation_prefix, " demux_arg1")));
     demux_arg2.reset(
         new loose_multiplexing_gadget<FieldT>(pb, packed_registers, packed_arg2idx, arg2_demux_result, arg2_demux_success,
-                                              libff::FMT(this->annotation_prefix, " demux_arg2")));
+                                              FMT(this->annotation_prefix, " demux_arg2")));
 }
 
 template<typename FieldT>
@@ -85,7 +85,7 @@ void argument_decoder_gadget<FieldT>::generate_r1cs_constraints()
         r1cs_constraint<FieldT>({ ONE, arg2_is_imm * (-1) },
             { ONE, arg2_demux_success * (-1) },
             { ONE * 0 }),
-        libff::FMT(this->annotation_prefix, " ensure_correc_demux"));
+        FMT(this->annotation_prefix, " ensure_correc_demux"));
 
     /*
       arg2val = arg2_is_imm * packed_arg2idx +
@@ -97,7 +97,7 @@ void argument_decoder_gadget<FieldT>::generate_r1cs_constraints()
         r1cs_constraint<FieldT>({ arg2_is_imm },
             { packed_arg2idx, arg2_demux_result * (-1) },
             { packed_arg2val, arg2_demux_result * (-1) }),
-        libff::FMT(this->annotation_prefix, " compute_arg2val"));
+        FMT(this->annotation_prefix, " compute_arg2val"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/consistency_enforcer_gadget.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/consistency_enforcer_gadget.tcc
@@ -45,29 +45,29 @@ consistency_enforcer_gadget<FieldT>::consistency_enforcer_gadget(tinyram_protobo
 {
     assert(desidx.size() == pb.ap.reg_arg_width());
 
-    packed_outgoing_desval.allocate(pb, libff::FMT(this->annotation_prefix, " packed_outgoing_desval"));
-    is_register_instruction.allocate(pb, libff::FMT(this->annotation_prefix, " is_register_instruction"));
-    is_control_flow_instruction.allocate(pb, libff::FMT(this->annotation_prefix, " is_control_flow_instruction"));
-    is_stall_instruction.allocate(pb, libff::FMT(this->annotation_prefix, " is_stall_instruction"));
+    packed_outgoing_desval.allocate(pb, FMT(this->annotation_prefix, " packed_outgoing_desval"));
+    is_register_instruction.allocate(pb, FMT(this->annotation_prefix, " is_register_instruction"));
+    is_control_flow_instruction.allocate(pb, FMT(this->annotation_prefix, " is_control_flow_instruction"));
+    is_stall_instruction.allocate(pb, FMT(this->annotation_prefix, " is_stall_instruction"));
 
-    packed_desidx.allocate(pb, libff::FMT(this->annotation_prefix, " packed_desidx"));
-    pack_desidx.reset(new packing_gadget<FieldT>(pb, desidx, packed_desidx, libff::FMT(this->annotation_prefix, "pack_desidx")));
+    packed_desidx.allocate(pb, FMT(this->annotation_prefix, " packed_desidx"));
+    pack_desidx.reset(new packing_gadget<FieldT>(pb, desidx, packed_desidx, FMT(this->annotation_prefix, "pack_desidx")));
 
-    computed_result.allocate(pb,  libff::FMT(this->annotation_prefix, " computed_result"));
-    computed_flag.allocate(pb, libff::FMT(this->annotation_prefix, " computed_flag"));
+    computed_result.allocate(pb,  FMT(this->annotation_prefix, " computed_result"));
+    computed_flag.allocate(pb, FMT(this->annotation_prefix, " computed_flag"));
 
     compute_computed_result.reset(
         new inner_product_gadget<FieldT>(pb, opcode_indicators, instruction_results, computed_result,
-                                         libff::FMT(this->annotation_prefix, " compute_computed_result")));
+                                         FMT(this->annotation_prefix, " compute_computed_result")));
     compute_computed_flag.reset(
         new inner_product_gadget<FieldT>(pb, opcode_indicators, instruction_flags, computed_flag,
-                                         libff::FMT(this->annotation_prefix, " compute_computed_flag")));
+                                         FMT(this->annotation_prefix, " compute_computed_flag")));
 
-    pc_from_cf_or_zero.allocate(pb, libff::FMT(this->annotation_prefix, " pc_from_cf_or_zero"));
+    pc_from_cf_or_zero.allocate(pb, FMT(this->annotation_prefix, " pc_from_cf_or_zero"));
 
     demux_packed_outgoing_desval.reset(
         new loose_multiplexing_gadget<FieldT>(pb, packed_outgoing_registers, packed_desidx, packed_outgoing_desval, ONE,
-                                              libff::FMT(this->annotation_prefix, " demux_packed_outgoing_desval")));
+                                              FMT(this->annotation_prefix, " demux_packed_outgoing_desval")));
 
 }
 
@@ -88,7 +88,7 @@ void consistency_enforcer_gadget<FieldT>::generate_r1cs_constraints()
         reg_b.add_term(opcode_indicators[tinyram_opcodes_register[i]], 1);
     }
     reg_c.add_term(is_register_instruction, 1);
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(reg_a, reg_b, reg_c), libff::FMT(this->annotation_prefix, " is_register_instruction"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(reg_a, reg_b, reg_c), FMT(this->annotation_prefix, " is_register_instruction"));
 
     /* is_control_flow_instruction */
     linear_combination<FieldT> cf_a, cf_b, cf_c;
@@ -98,7 +98,7 @@ void consistency_enforcer_gadget<FieldT>::generate_r1cs_constraints()
         cf_b.add_term(opcode_indicators[tinyram_opcodes_control_flow[i]], 1);
     }
     cf_c.add_term(is_control_flow_instruction, 1);
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(cf_a, cf_b, cf_c), libff::FMT(this->annotation_prefix, " is_control_flow_instruction"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(cf_a, cf_b, cf_c), FMT(this->annotation_prefix, " is_control_flow_instruction"));
 
     /* is_stall_instruction */
     linear_combination<FieldT> stall_a, stall_b, stall_c;
@@ -108,7 +108,7 @@ void consistency_enforcer_gadget<FieldT>::generate_r1cs_constraints()
         stall_b.add_term(opcode_indicators[tinyram_opcodes_stall[i]], 1);
     }
     stall_c.add_term(is_stall_instruction, 1);
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(stall_a, stall_b, stall_c), libff::FMT(this->annotation_prefix, " is_stall_instruction"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(stall_a, stall_b, stall_c), FMT(this->annotation_prefix, " is_stall_instruction"));
 
     /* compute actual result/actual flag */
     compute_computed_result->generate_r1cs_constraints();
@@ -125,14 +125,14 @@ void consistency_enforcer_gadget<FieldT>::generate_r1cs_constraints()
             computed_result,
             is_control_flow_instruction,
             pc_from_cf_or_zero),
-        libff::FMT(this->annotation_prefix, " pc_from_cf_or_zero"));
+        FMT(this->annotation_prefix, " pc_from_cf_or_zero"));
 
     this->pb.add_r1cs_constraint(
         r1cs_constraint<FieldT>(
             packed_incoming_pc,
             1 - is_control_flow_instruction,
             packed_outgoing_pc - pc_from_cf_or_zero - (1 - is_control_flow_instruction - is_stall_instruction)),
-        libff::FMT(this->annotation_prefix, " packed_outgoing_pc"));
+        FMT(this->annotation_prefix, " packed_outgoing_pc"));
 
     /*
       enforce new flag:
@@ -145,7 +145,7 @@ void consistency_enforcer_gadget<FieldT>::generate_r1cs_constraints()
             { computed_flag, incoming_flag * (-1) },
             { is_register_instruction },
             { outgoing_flag, incoming_flag * (-1) }),
-        libff::FMT(this->annotation_prefix, " outgoing_flag"));
+        FMT(this->annotation_prefix, " outgoing_flag"));
 
     /*
       force carryover of unchanged registers
@@ -162,7 +162,7 @@ void consistency_enforcer_gadget<FieldT>::generate_r1cs_constraints()
                 { ONE, demux_packed_outgoing_desval->alpha[i] * (-1) },
                 { packed_outgoing_registers[i], packed_incoming_registers[i] * (-1) },
                 { ONE * 0 }),
-            libff::FMT(this->annotation_prefix, " register_carryover_%zu", i));
+            FMT(this->annotation_prefix, " register_carryover_%zu", i));
     }
 
     /*
@@ -176,7 +176,7 @@ void consistency_enforcer_gadget<FieldT>::generate_r1cs_constraints()
             { computed_result, packed_incoming_desval * (-1) },
             { is_register_instruction },
             { packed_outgoing_desval, packed_incoming_desval * (-1) }),
-        libff::FMT(this->annotation_prefix, " packed_outgoing_desval"));
+        FMT(this->annotation_prefix, " packed_outgoing_desval"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/instruction_packing_gadget.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/instruction_packing_gadget.tcc
@@ -39,14 +39,14 @@ tinyram_instruction_packing_gadget<FieldT>::tinyram_instruction_packing_gadget(t
     all_bits.insert(all_bits.begin(), arg2_is_imm);
     all_bits.insert(all_bits.begin(), desidx.begin(), desidx.end());
     all_bits.insert(all_bits.begin(), arg1idx.begin(), arg1idx.end());
-    dummy.allocate(pb, pb.ap.w-all_bits.size(), libff::FMT(this->annotation_prefix, " dummy"));
+    dummy.allocate(pb, pb.ap.w-all_bits.size(), FMT(this->annotation_prefix, " dummy"));
     all_bits.insert(all_bits.begin(), dummy.begin(), dummy.end());
     all_bits.insert(all_bits.begin(), arg2idx.begin(), arg2idx.end());
 
     assert(all_bits.size() == 2*pb.ap.w);
 
     pack_instruction.reset(
-        new packing_gadget<FieldT>(pb, all_bits, packed_instruction, libff::FMT(this->annotation_prefix, " pack_instruction")));
+        new packing_gadget<FieldT>(pb, all_bits, packed_instruction, FMT(this->annotation_prefix, " pack_instruction")));
 }
 
 
@@ -120,11 +120,11 @@ void test_instruction_packing()
 
     for (size_t i = 0; i < 2; ++i)
     {
-        opcode[i].allocate(pb, ap.s, libff::FMT("", "opcode_%zu", i));
-        arg2_is_imm[i].allocate(pb, libff::FMT("", "arg2_is_imm_%zu", i));
-        desidx[i].allocate(pb, ap.reg_arg_width(), libff::FMT("", "desidx_%zu", i));
-        arg1idx[i].allocate(pb, ap.reg_arg_width(), libff::FMT("", "arg1idx_%zu", i));
-        arg2idx[i].allocate(pb, ap.reg_arg_or_imm_width(), libff::FMT("", "arg2idx_%zu", i));
+        opcode[i].allocate(pb, ap.s, FMT("", "opcode_%zu", i));
+        arg2_is_imm[i].allocate(pb, FMT("", "arg2_is_imm_%zu", i));
+        desidx[i].allocate(pb, ap.reg_arg_width(), FMT("", "desidx_%zu", i));
+        arg1idx[i].allocate(pb, ap.reg_arg_width(), FMT("", "arg1idx_%zu", i));
+        arg2idx[i].allocate(pb, ap.reg_arg_or_imm_width(), FMT("", "arg2idx_%zu", i));
     }
 
     pb_variable<FieldT> packed_instr;

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/memory_masking_gadget.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/memory_masking_gadget.tcc
@@ -40,10 +40,10 @@ memory_masking_gadget<FieldT>::memory_masking_gadget(tinyram_protoboard<FieldT> 
       We use little-endian indexing here (least significant
       bit/byte/word has the smallest address).
     */
-    is_word0.allocate(pb, libff::FMT(this->annotation_prefix, " is_word0"));
-    is_word1.allocate(pb, libff::FMT(this->annotation_prefix, " is_word1"));
-    is_subaddress.allocate(pb, 2 * pb.ap.bytes_in_word(), libff::FMT(this->annotation_prefix, " is_sub_address"));
-    is_byte.allocate(pb, 2 * pb.ap.bytes_in_word(), libff::FMT(this->annotation_prefix, " is_byte"));
+    is_word0.allocate(pb, FMT(this->annotation_prefix, " is_word0"));
+    is_word1.allocate(pb, FMT(this->annotation_prefix, " is_word1"));
+    is_subaddress.allocate(pb, 2 * pb.ap.bytes_in_word(), FMT(this->annotation_prefix, " is_sub_address"));
+    is_byte.allocate(pb, 2 * pb.ap.bytes_in_word(), FMT(this->annotation_prefix, " is_byte"));
 
     /*
       Get value of the dw_contents_prev for which the specified entity
@@ -83,9 +83,9 @@ memory_masking_gadget<FieldT>::memory_masking_gadget(tinyram_protoboard<FieldT> 
     masked_out_results.emplace_back(masked_out_word1);
     masked_out_results.insert(masked_out_results.end(), masked_out_bytes.begin(), masked_out_bytes.end());
 
-    masked_out_dw_contents_prev.allocate(pb, libff::FMT(this->annotation_prefix, " masked_out_dw_contents_prev"));
+    masked_out_dw_contents_prev.allocate(pb, FMT(this->annotation_prefix, " masked_out_dw_contents_prev"));
     get_masked_out_dw_contents_prev.reset(new inner_product_gadget<FieldT>(pb, masked_out_indicators, masked_out_results, masked_out_dw_contents_prev,
-                                                                           libff::FMT(this->annotation_prefix, " get_masked_out_dw_contents_prev")));
+                                                                           FMT(this->annotation_prefix, " get_masked_out_dw_contents_prev")));
 
     /*
       Define shift so that masked_out_dw_contents_prev + shift * subcontents = dw_contents_next
@@ -106,22 +106,22 @@ void memory_masking_gadget<FieldT>::generate_r1cs_constraints()
     for (size_t i = 0; i < 2 * this->pb.ap.bytes_in_word(); ++i)
     {
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(is_subaddress[i], subaddress.packed - i, 0),
-                                     libff::FMT(this->annotation_prefix, " is_subaddress_%zu", i));
+                                     FMT(this->annotation_prefix, " is_subaddress_%zu", i));
     }
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, pb_sum<FieldT>(is_subaddress), 1), libff::FMT(this->annotation_prefix, " is_subaddress"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, pb_sum<FieldT>(is_subaddress), 1), FMT(this->annotation_prefix, " is_subaddress"));
 
     /* get indicator variables is_byte_X */
     for (size_t i = 0; i < 2 * this->pb.ap.bytes_in_word(); ++i)
     {
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(access_is_byte, is_subaddress[i], is_byte[i]),
-                                     libff::FMT(this->annotation_prefix, " is_byte_%zu", i));
+                                     FMT(this->annotation_prefix, " is_byte_%zu", i));
     }
 
     /* get indicator variables is_word_0/is_word_1 */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(access_is_word, 1 - subaddress.bits[this->pb.ap.subaddr_len()-1], is_word0),
-                                 libff::FMT(this->annotation_prefix, " is_word_0"));
+                                 FMT(this->annotation_prefix, " is_word_0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(access_is_word, subaddress.bits[this->pb.ap.subaddr_len()-1], is_word1),
-                                 libff::FMT(this->annotation_prefix, " is_word_1"));
+                                 FMT(this->annotation_prefix, " is_word_1"));
 
     /* compute masked_out_dw_contents_prev */
     get_masked_out_dw_contents_prev->generate_r1cs_constraints();
@@ -130,7 +130,7 @@ void memory_masking_gadget<FieldT>::generate_r1cs_constraints()
        masked_out_dw_contents_prev + shift * subcontents = dw_contents_next
      */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(shift, subcontents, dw_contents_next.packed - masked_out_dw_contents_prev),
-                                 libff::FMT(this->annotation_prefix, " mask_difference"));
+                                 FMT(this->annotation_prefix, " mask_difference"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
@@ -52,8 +52,8 @@ tinyram_standard_gadget<FieldT>(pb, annotation_prefix), prev_pc_addr(prev_pc_add
     pb_variable_array<FieldT> packed_prev_registers, packed_next_registers;
     for (size_t i = 0; i < pb.ap.k; ++i)
     {
-        prev_registers.emplace_back(word_variable_gadget<FieldT>(pb, pb_variable_array<FieldT>(prev_state.begin() + i * pb.ap.w, prev_state.begin() + (i + 1) * pb.ap.w), libff::FMT(annotation_prefix, " prev_registers_%zu", i)));
-        next_registers.emplace_back(word_variable_gadget<FieldT>(pb, pb_variable_array<FieldT>(next_state.begin() + i * pb.ap.w, next_state.begin() + (i + 1) * pb.ap.w), libff::FMT(annotation_prefix, " next_registers_%zu", i)));
+        prev_registers.emplace_back(word_variable_gadget<FieldT>(pb, pb_variable_array<FieldT>(prev_state.begin() + i * pb.ap.w, prev_state.begin() + (i + 1) * pb.ap.w), FMT(annotation_prefix, " prev_registers_%zu", i)));
+        next_registers.emplace_back(word_variable_gadget<FieldT>(pb, pb_variable_array<FieldT>(next_state.begin() + i * pb.ap.w, next_state.begin() + (i + 1) * pb.ap.w), FMT(annotation_prefix, " next_registers_%zu", i)));
 
         packed_prev_registers.emplace_back(prev_registers[i].packed);
         packed_next_registers.emplace_back(next_registers[i].packed);
@@ -64,33 +64,33 @@ tinyram_standard_gadget<FieldT>(pb, annotation_prefix), prev_pc_addr(prev_pc_add
     next_tape1_exhausted = *(next_state.rbegin());
 
     /* decode arguments */
-    prev_pc_addr_as_word_variable.reset(new word_variable_gadget<FieldT>(pb, prev_pc_addr, libff::FMT(annotation_prefix, " prev_pc_addr_as_word_variable")));
-    desval.reset(new word_variable_gadget<FieldT>(pb, libff::FMT(annotation_prefix, " desval")));
-    arg1val.reset(new word_variable_gadget<FieldT>(pb, libff::FMT(annotation_prefix, " arg1val")));
-    arg2val.reset(new word_variable_gadget<FieldT>(pb, libff::FMT(annotation_prefix, " arg2val")));
+    prev_pc_addr_as_word_variable.reset(new word_variable_gadget<FieldT>(pb, prev_pc_addr, FMT(annotation_prefix, " prev_pc_addr_as_word_variable")));
+    desval.reset(new word_variable_gadget<FieldT>(pb, FMT(annotation_prefix, " desval")));
+    arg1val.reset(new word_variable_gadget<FieldT>(pb, FMT(annotation_prefix, " arg1val")));
+    arg2val.reset(new word_variable_gadget<FieldT>(pb, FMT(annotation_prefix, " arg2val")));
 
     decode_arguments.reset(new argument_decoder_gadget<FieldT>(pb, arg2_is_imm, desidx, arg1idx, arg2idx, packed_prev_registers,
                                                                desval->packed, arg1val->packed, arg2val->packed,
-                                                               libff::FMT(annotation_prefix, " decode_arguments")));
+                                                               FMT(annotation_prefix, " decode_arguments")));
 
     /* create indicator variables for opcodes */
-    opcode_indicators.allocate(pb, 1ul<<pb.ap.opcode_width(), libff::FMT(annotation_prefix, " opcode_indicators"));
+    opcode_indicators.allocate(pb, 1ul<<pb.ap.opcode_width(), FMT(annotation_prefix, " opcode_indicators"));
 
     /* perform the ALU operations */
-    instruction_results.allocate(pb, 1ul<<pb.ap.opcode_width(), libff::FMT(annotation_prefix, " instruction_results"));
-    instruction_flags.allocate(pb, 1ul<<pb.ap.opcode_width(), libff::FMT(annotation_prefix, " instruction_flags"));
+    instruction_results.allocate(pb, 1ul<<pb.ap.opcode_width(), FMT(annotation_prefix, " instruction_results"));
+    instruction_flags.allocate(pb, 1ul<<pb.ap.opcode_width(), FMT(annotation_prefix, " instruction_flags"));
 
     ALU.reset(new ALU_gadget<FieldT>(pb, opcode_indicators, *prev_pc_addr_as_word_variable, *desval, *arg1val, *arg2val, prev_flag, instruction_results, instruction_flags,
-                                     libff::FMT(annotation_prefix, " ALU")));
+                                     FMT(annotation_prefix, " ALU")));
 
     /* check correctness of memory operations */
-    ls_prev_val_as_doubleword_variable.reset(new doubleword_variable_gadget<FieldT>(pb, ls_prev_val, libff::FMT(annotation_prefix, " ls_prev_val_as_doubleword_variable")))
+    ls_prev_val_as_doubleword_variable.reset(new doubleword_variable_gadget<FieldT>(pb, ls_prev_val, FMT(annotation_prefix, " ls_prev_val_as_doubleword_variable")))
 ;
-    ls_next_val_as_doubleword_variable.reset(new doubleword_variable_gadget<FieldT>(pb, ls_next_val, libff::FMT(annotation_prefix, " ls_next_val_as_doubleword_variable")));
+    ls_next_val_as_doubleword_variable.reset(new doubleword_variable_gadget<FieldT>(pb, ls_next_val, FMT(annotation_prefix, " ls_next_val_as_doubleword_variable")));
     memory_subaddress.reset(new dual_variable_gadget<FieldT>(pb, pb_variable_array<FieldT>(arg2val->bits.begin(), arg2val->bits.begin() + pb.ap.subaddr_len()),
-                                                             libff::FMT(annotation_prefix, " memory_subaddress")));
+                                                             FMT(annotation_prefix, " memory_subaddress")));
 
-    memory_subcontents.allocate(pb, libff::FMT(annotation_prefix, " memory_subcontents"));
+    memory_subcontents.allocate(pb, FMT(annotation_prefix, " memory_subcontents"));
     memory_access_is_word.assign(pb, 1 - (opcode_indicators[tinyram_opcode_LOADB] + opcode_indicators[tinyram_opcode_STOREB]));
     memory_access_is_byte.assign(pb, opcode_indicators[tinyram_opcode_LOADB] + opcode_indicators[tinyram_opcode_STOREB]);
 
@@ -101,13 +101,13 @@ tinyram_standard_gadget<FieldT>(pb, annotation_prefix), prev_pc_addr(prev_pc_add
                                                          memory_access_is_word,
                                                          memory_access_is_byte,
                                                          *ls_next_val_as_doubleword_variable,
-                                                         libff::FMT(annotation_prefix, " check_memory")));
+                                                         FMT(annotation_prefix, " check_memory")));
 
     /* handle reads */
-    read_not1.allocate(pb, libff::FMT(annotation_prefix, " read_not1"));
+    read_not1.allocate(pb, FMT(annotation_prefix, " read_not1"));
 
     /* check consistency of the states according to the ALU results */
-    next_pc_addr_as_word_variable.reset(new word_variable_gadget<FieldT>(pb, next_pc_addr, libff::FMT(annotation_prefix, " next_pc_addr_as_word_variable")));
+    next_pc_addr_as_word_variable.reset(new word_variable_gadget<FieldT>(pb, next_pc_addr, FMT(annotation_prefix, " next_pc_addr_as_word_variable")));
 
     consistency_enforcer.reset(new consistency_enforcer_gadget<FieldT>(pb, opcode_indicators, instruction_results, instruction_flags,
                                                                        desidx, prev_pc_addr_as_word_variable->packed,
@@ -117,7 +117,7 @@ tinyram_standard_gadget<FieldT>(pb, annotation_prefix), prev_pc_addr(prev_pc_add
                                                                        next_pc_addr_as_word_variable->packed,
                                                                        packed_next_registers,
                                                                        next_flag,
-                                                                       libff::FMT(annotation_prefix, " consistency_enforcer")));
+                                                                       FMT(annotation_prefix, " consistency_enforcer")));
 }
 
 template<typename FieldT>
@@ -129,10 +129,10 @@ void tinyram_cpu_checker<FieldT>::generate_r1cs_constraints()
     for (size_t i = 0; i < 1ul<<this->pb.ap.opcode_width(); ++i)
     {
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(opcode_indicators[i], pb_packing_sum<FieldT>(opcode) - i, 0),
-                                     libff::FMT(this->annotation_prefix, " opcode_indicators_%zu", i));
+                                     FMT(this->annotation_prefix, " opcode_indicators_%zu", i));
     }
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, pb_sum<FieldT>(opcode_indicators), 1),
-                                 libff::FMT(this->annotation_prefix, " opcode_indicators_sum_to_1"));
+                                 FMT(this->annotation_prefix, " opcode_indicators_sum_to_1"));
 
     /* consistency checks for repacked variables */
     for (size_t i = 0; i < this->pb.ap.k; ++i)
@@ -161,7 +161,7 @@ void tinyram_cpu_checker<FieldT>::generate_r1cs_constraints()
                                                              pb_variable_array<FieldT>(arg2val->bits.begin() + this->pb.ap.subaddr_len(),
                                                                                        arg2val->bits.end())),
                                                          pb_packing_sum<FieldT>(ls_addr)),
-                                 libff::FMT(this->annotation_prefix, " ls_addr_is_arg2val_minus_subaddress"));
+                                 FMT(this->annotation_prefix, " ls_addr_is_arg2val_minus_subaddress"));
 
     /* We require that if opcode is one of load.{b,w}, then
        subcontents is appropriately stored in instruction_results. If
@@ -174,35 +174,35 @@ void tinyram_cpu_checker<FieldT>::generate_r1cs_constraints()
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(opcode_indicators[tinyram_opcode_LOADB],
                                                          memory_subcontents - instruction_results[tinyram_opcode_LOADB],
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " handle_loadb"));
+                                 FMT(this->annotation_prefix, " handle_loadb"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(opcode_indicators[tinyram_opcode_LOADW],
                                                          memory_subcontents - instruction_results[tinyram_opcode_LOADW],
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " handle_loadw"));
+                                 FMT(this->annotation_prefix, " handle_loadw"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(opcode_indicators[tinyram_opcode_STOREB],
                                                          memory_subcontents - pb_packing_sum<FieldT>(
                                                              pb_variable_array<FieldT>(desval->bits.begin(),
                                                                                        desval->bits.begin() + 8)),
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " handle_storeb"));
+                                 FMT(this->annotation_prefix, " handle_storeb"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(opcode_indicators[tinyram_opcode_STOREW],
                                                          memory_subcontents - desval->packed,
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " handle_storew"));
+                                 FMT(this->annotation_prefix, " handle_storew"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1 - (opcode_indicators[tinyram_opcode_STOREB] + opcode_indicators[tinyram_opcode_STOREW]),
                                                          ls_prev_val_as_doubleword_variable->packed - ls_next_val_as_doubleword_variable->packed,
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " non_store_instructions_dont_change_memory"));
+                                 FMT(this->annotation_prefix, " non_store_instructions_dont_change_memory"));
 
     /* specify that accepting state implies opcode = answer && arg2val == 0 */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(next_has_accepted,
                                                          1 - opcode_indicators[tinyram_opcode_ANSWER],
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " accepting_requires_answer"));
+                                 FMT(this->annotation_prefix, " accepting_requires_answer"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(next_has_accepted,
                                                          arg2val->packed,
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " accepting_requires_arg2val_equal_zero"));
+                                 FMT(this->annotation_prefix, " accepting_requires_arg2val_equal_zero"));
 
     /*
        handle tapes:
@@ -216,23 +216,23 @@ void tinyram_cpu_checker<FieldT>::generate_r1cs_constraints()
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(prev_tape1_exhausted,
                                                          1 - next_tape1_exhausted,
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " prev_tape1_exhausted_implies_next_tape1_exhausted"));
+                                 FMT(this->annotation_prefix, " prev_tape1_exhausted_implies_next_tape1_exhausted"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(prev_tape1_exhausted,
                                                          1 - instruction_flags[tinyram_opcode_READ],
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " prev_tape1_exhausted_implies_flag"));
+                                 FMT(this->annotation_prefix, " prev_tape1_exhausted_implies_flag"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(opcode_indicators[tinyram_opcode_READ],
                                                          1 - arg2val->packed,
                                                          read_not1),
-                                 libff::FMT(this->annotation_prefix, " read_not1")); /* will be nonzero for read X for X != 1 */
+                                 FMT(this->annotation_prefix, " read_not1")); /* will be nonzero for read X for X != 1 */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(read_not1,
                                                          1 - instruction_flags[tinyram_opcode_READ],
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " other_reads_imply_flag"));
+                                 FMT(this->annotation_prefix, " other_reads_imply_flag"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(instruction_flags[tinyram_opcode_READ],
                                                          instruction_results[tinyram_opcode_READ],
                                                          0),
-                                 libff::FMT(this->annotation_prefix, " read_flag_implies_result_0"));
+                                 FMT(this->annotation_prefix, " read_flag_implies_result_0"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
+++ b/src/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
@@ -23,8 +23,8 @@ G1_variable<ppT>::G1_variable(protoboard<FieldT> &pb,
 {
     pb_variable<FieldT> X_var, Y_var;
 
-    X_var.allocate(pb, libff::FMT(annotation_prefix, " X"));
-    Y_var.allocate(pb, libff::FMT(annotation_prefix, " Y"));
+    X_var.allocate(pb, FMT(annotation_prefix, " X"));
+    Y_var.allocate(pb, FMT(annotation_prefix, " Y"));
 
     X = pb_linear_combination<FieldT>(X_var);
     Y = pb_linear_combination<FieldT>(Y_var);
@@ -76,8 +76,8 @@ template<typename ppT>
 G1_checker_gadget<ppT>::G1_checker_gadget(protoboard<FieldT> &pb, const G1_variable<ppT> &P, const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix), P(P)
 {
-    P_X_squared.allocate(pb, libff::FMT(annotation_prefix, " P_X_squared"));
-    P_Y_squared.allocate(pb, libff::FMT(annotation_prefix, " P_Y_squared"));
+    P_X_squared.allocate(pb, FMT(annotation_prefix, " P_X_squared"));
+    P_Y_squared.allocate(pb, FMT(annotation_prefix, " P_Y_squared"));
 }
 
 template<typename ppT>
@@ -87,17 +87,17 @@ void G1_checker_gadget<ppT>::generate_r1cs_constraints()
         { P.X },
         { P.X },
         { P_X_squared }),
-        libff::FMT(this->annotation_prefix, " P_X_squared"));
+        FMT(this->annotation_prefix, " P_X_squared"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { P.Y },
         { P.Y },
         { P_Y_squared }),
-        libff::FMT(this->annotation_prefix, " P_Y_squared"));
+        FMT(this->annotation_prefix, " P_Y_squared"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { P.X },
         { P_X_squared, ONE * libff::G1<other_curve<ppT> >::coeff_a },
         { P_Y_squared, ONE * (-libff::G1<other_curve<ppT> >::coeff_b) }),
-        libff::FMT(this->annotation_prefix, " curve_equation"));
+        FMT(this->annotation_prefix, " curve_equation"));
 }
 
 template<typename ppT>
@@ -135,8 +135,8 @@ G1_add_gadget<ppT>::G1_add_gadget(protoboard<FieldT> &pb,
       So we need to check that A.x - B.x != 0, which can be done by
       enforcing I * (B.x - A.x) = 1
     */
-    lambda.allocate(pb, libff::FMT(annotation_prefix, " lambda"));
-    inv.allocate(pb, libff::FMT(annotation_prefix, " inv"));
+    lambda.allocate(pb, FMT(annotation_prefix, " lambda"));
+    inv.allocate(pb, FMT(annotation_prefix, " inv"));
 }
 
 template<typename ppT>
@@ -146,25 +146,25 @@ void G1_add_gadget<ppT>::generate_r1cs_constraints()
         { lambda },
         { B.X, A.X * (-1) },
         { B.Y, A.Y * (-1) }),
-        libff::FMT(this->annotation_prefix, " calc_lambda"));
+        FMT(this->annotation_prefix, " calc_lambda"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { lambda },
         { lambda },
         { C.X, A.X, B.X }),
-        libff::FMT(this->annotation_prefix, " calc_X"));
+        FMT(this->annotation_prefix, " calc_X"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { lambda },
         { A.X, C.X * (-1) },
         { C.Y, A.Y }),
-        libff::FMT(this->annotation_prefix, " calc_Y"));
+        FMT(this->annotation_prefix, " calc_Y"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { inv },
         { B.X, A.X * (-1) },
         { ONE }),
-        libff::FMT(this->annotation_prefix, " no_special_cases"));
+        FMT(this->annotation_prefix, " no_special_cases"));
 }
 
 template<typename ppT>
@@ -185,8 +185,8 @@ G1_dbl_gadget<ppT>::G1_dbl_gadget(protoboard<FieldT> &pb,
     A(A),
     B(B)
 {
-    Xsquared.allocate(pb, libff::FMT(annotation_prefix, " X_squared"));
-    lambda.allocate(pb, libff::FMT(annotation_prefix, " lambda"));
+    Xsquared.allocate(pb, FMT(annotation_prefix, " X_squared"));
+    lambda.allocate(pb, FMT(annotation_prefix, " lambda"));
 }
 
 template<typename ppT>
@@ -196,25 +196,25 @@ void G1_dbl_gadget<ppT>::generate_r1cs_constraints()
         { A.X },
         { A.X },
         { Xsquared }),
-        libff::FMT(this->annotation_prefix, " calc_Xsquared"));
+        FMT(this->annotation_prefix, " calc_Xsquared"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { lambda * 2 },
         { A.Y },
         { Xsquared * 3, ONE * libff::G1<other_curve<ppT> >::coeff_a }),
-        libff::FMT(this->annotation_prefix, " calc_lambda"));
+        FMT(this->annotation_prefix, " calc_lambda"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { lambda },
         { lambda },
         { B.X, A.X * 2 }),
-        libff::FMT(this->annotation_prefix, " calc_X"));
+        FMT(this->annotation_prefix, " calc_X"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         { lambda },
         { A.X, B.X * (-1) },
         { B.Y, A.Y }),
-        libff::FMT(this->annotation_prefix, " calc_Y"));
+        FMT(this->annotation_prefix, " calc_Y"));
 }
 
 template<typename ppT>
@@ -251,25 +251,25 @@ G1_multiscalar_mul_gadget<ppT>::G1_multiscalar_mul_gadget(protoboard<FieldT> &pb
         points_and_powers.emplace_back(points[i]);
         for (size_t j = 0; j < elt_size - 1; ++j)
         {
-            points_and_powers.emplace_back(G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " points_%zu_times_2_to_%zu", i, j+1)));
-            doublers.emplace_back(G1_dbl_gadget<ppT>(pb, points_and_powers[i*elt_size + j], points_and_powers[i*elt_size + j + 1], libff::FMT(annotation_prefix, " double_%zu_to_2_to_%zu", i, j+1)));
+            points_and_powers.emplace_back(G1_variable<ppT>(pb, FMT(annotation_prefix, " points_%zu_times_2_to_%zu", i, j+1)));
+            doublers.emplace_back(G1_dbl_gadget<ppT>(pb, points_and_powers[i*elt_size + j], points_and_powers[i*elt_size + j + 1], FMT(annotation_prefix, " double_%zu_to_2_to_%zu", i, j+1)));
         }
     }
 
     chosen_results.emplace_back(base);
     for (size_t i = 0; i < scalar_size; ++i)
     {
-        computed_results.emplace_back(G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " computed_results_%zu")));
+        computed_results.emplace_back(G1_variable<ppT>(pb, FMT(annotation_prefix, " computed_results_%zu")));
         if (i < scalar_size-1)
         {
-            chosen_results.emplace_back(G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " chosen_results_%zu")));
+            chosen_results.emplace_back(G1_variable<ppT>(pb, FMT(annotation_prefix, " chosen_results_%zu")));
         }
         else
         {
             chosen_results.emplace_back(result);
         }
 
-        adders.emplace_back(G1_add_gadget<ppT>(pb, chosen_results[i], points_and_powers[i], computed_results[i], libff::FMT(annotation_prefix, " adders_%zu")));
+        adders.emplace_back(G1_add_gadget<ppT>(pb, chosen_results[i], points_and_powers[i], computed_results[i], FMT(annotation_prefix, " adders_%zu")));
     }
 }
 
@@ -294,11 +294,11 @@ void G1_multiscalar_mul_gadget<ppT>::generate_r1cs_constraints()
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(scalars[i],
                                                              computed_results[i].X - chosen_results[i].X,
                                                              chosen_results[i+1].X - chosen_results[i].X),
-                                     libff::FMT(this->annotation_prefix, " chosen_results_%zu_X", i+1));
+                                     FMT(this->annotation_prefix, " chosen_results_%zu_X", i+1));
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(scalars[i],
                                                              computed_results[i].Y - chosen_results[i].Y,
                                                              chosen_results[i+1].Y - chosen_results[i].Y),
-                                     libff::FMT(this->annotation_prefix, " chosen_results_%zu_Y", i+1));
+                                     FMT(this->annotation_prefix, " chosen_results_%zu_Y", i+1));
     }
 
     const size_t num_constraints_after = this->pb.num_constraints();

--- a/src/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.tcc
+++ b/src/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.tcc
@@ -23,8 +23,8 @@ G2_variable<ppT>::G2_variable(protoboard<FieldT> &pb,
                               const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix)
 {
-    X.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " X")));
-    Y.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " Y")));
+    X.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " X")));
+    Y.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " Y")));
 
     all_vars.insert(all_vars.end(), X->all_vars.begin(), X->all_vars.end());
     all_vars.insert(all_vars.end(), Y->all_vars.begin(), Y->all_vars.end());
@@ -39,8 +39,8 @@ G2_variable<ppT>::G2_variable(protoboard<FieldT> &pb,
     libff::G2<other_curve<ppT> > Q_copy = Q;
     Q_copy.to_affine_coordinates();
 
-    X.reset(new Fqe_variable<ppT>(pb, Q_copy.X(), libff::FMT(annotation_prefix, " X")));
-    Y.reset(new Fqe_variable<ppT>(pb, Q_copy.Y(), libff::FMT(annotation_prefix, " Y")));
+    X.reset(new Fqe_variable<ppT>(pb, Q_copy.X(), FMT(annotation_prefix, " X")));
+    Y.reset(new Fqe_variable<ppT>(pb, Q_copy.Y(), FMT(annotation_prefix, " Y")));
 
     all_vars.insert(all_vars.end(), X->all_vars.begin(), X->all_vars.end());
     all_vars.insert(all_vars.end(), Y->all_vars.begin(), Y->all_vars.end());
@@ -75,16 +75,16 @@ G2_checker_gadget<ppT>::G2_checker_gadget(protoboard<FieldT> &pb,
     gadget<FieldT>(pb, annotation_prefix),
     Q(Q)
 {
-    Xsquared.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " Xsquared")));
-    Ysquared.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " Ysquared")));
+    Xsquared.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " Xsquared")));
+    Ysquared.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " Ysquared")));
 
-    compute_Xsquared.reset(new Fqe_sqr_gadget<ppT>(pb, *(Q.X), *Xsquared, libff::FMT(annotation_prefix, " compute_Xsquared")));
-    compute_Ysquared.reset(new Fqe_sqr_gadget<ppT>(pb, *(Q.Y), *Ysquared, libff::FMT(annotation_prefix, " compute_Ysquared")));
+    compute_Xsquared.reset(new Fqe_sqr_gadget<ppT>(pb, *(Q.X), *Xsquared, FMT(annotation_prefix, " compute_Xsquared")));
+    compute_Ysquared.reset(new Fqe_sqr_gadget<ppT>(pb, *(Q.Y), *Ysquared, FMT(annotation_prefix, " compute_Ysquared")));
 
     Xsquared_plus_a.reset(new Fqe_variable<ppT>((*Xsquared) + libff::G2<other_curve<ppT> >::coeff_a));
     Ysquared_minus_b.reset(new Fqe_variable<ppT>((*Ysquared) + (-libff::G2<other_curve<ppT> >::coeff_b)));
 
-    curve_equation.reset(new Fqe_mul_gadget<ppT>(pb, *(Q.X), *Xsquared_plus_a, *Ysquared_minus_b, libff::FMT(annotation_prefix, " curve_equation")));
+    curve_equation.reset(new Fqe_mul_gadget<ppT>(pb, *(Q.X), *Xsquared_plus_a, *Ysquared_minus_b, FMT(annotation_prefix, " curve_equation")));
 }
 
 template<typename ppT>

--- a/src/gadgetlib1/gadgets/fields/exponentiation_gadget.tcc
+++ b/src/gadgetlib1/gadgets/fields/exponentiation_gadget.tcc
@@ -58,10 +58,10 @@ exponentiation_gadget<FpkT, Fpk_variableT, Fpk_mul_gadgetT, Fpk_sqr_gadgetT, m>:
     }
 
     intermediate.resize(intermed_count);
-    intermediate[0].reset(new Fpk_variableT<FpkT>(pb, FpkT::one(), libff::FMT(annotation_prefix, " intermediate_0")));
+    intermediate[0].reset(new Fpk_variableT<FpkT>(pb, FpkT::one(), FMT(annotation_prefix, " intermediate_0")));
     for (size_t i = 1; i < intermed_count; ++i)
     {
-        intermediate[i].reset(new Fpk_variableT<FpkT>(pb, libff::FMT(annotation_prefix, " intermediate_%zu", i)));
+        intermediate[i].reset(new Fpk_variableT<FpkT>(pb, FMT(annotation_prefix, " intermediate_%zu", i)));
     }
     addition_steps.resize(add_count);
     subtraction_steps.resize(sub_count);
@@ -78,7 +78,7 @@ exponentiation_gadget<FpkT, Fpk_variableT, Fpk_mul_gadgetT, Fpk_sqr_gadgetT, m>:
             doubling_steps[dbl_id].reset(new Fpk_sqr_gadgetT<FpkT>(pb,
                                                                    *intermediate[intermed_id],
                                                                    (intermed_id + 1 == intermed_count ? result : *intermediate[intermed_id+1]),
-                                                                   libff::FMT(annotation_prefix, " doubling_steps_%zu", dbl_count)));
+                                                                   FMT(annotation_prefix, " doubling_steps_%zu", dbl_count)));
             ++intermed_id;
             ++dbl_id;
         }
@@ -94,7 +94,7 @@ exponentiation_gadget<FpkT, Fpk_variableT, Fpk_mul_gadgetT, Fpk_sqr_gadgetT, m>:
                                                                        *intermediate[intermed_id],
                                                                        elt,
                                                                        (intermed_id + 1 == intermed_count ? result : *intermediate[intermed_id+1]),
-                                                                       libff::FMT(annotation_prefix, " addition_steps_%zu", dbl_count)));
+                                                                       FMT(annotation_prefix, " addition_steps_%zu", dbl_count)));
                 ++add_id;
                 ++intermed_id;
             }
@@ -105,7 +105,7 @@ exponentiation_gadget<FpkT, Fpk_variableT, Fpk_mul_gadgetT, Fpk_sqr_gadgetT, m>:
                                                                           (intermed_id + 1 == intermed_count ? result : *intermediate[intermed_id+1]),
                                                                           elt,
                                                                           *intermediate[intermed_id],
-                                                                          libff::FMT(annotation_prefix, " subtraction_steps_%zu", dbl_count)));
+                                                                          FMT(annotation_prefix, " subtraction_steps_%zu", dbl_count)));
                 ++sub_id;
                 ++intermed_id;
             }

--- a/src/gadgetlib1/gadgets/fields/fp2_gadgets.tcc
+++ b/src/gadgetlib1/gadgets/fields/fp2_gadgets.tcc
@@ -22,8 +22,8 @@ Fp2_variable<Fp2T>::Fp2_variable(protoboard<FieldT> &pb,
     gadget<FieldT>(pb, annotation_prefix)
 {
     pb_variable<FieldT> c0_var, c1_var;
-    c0_var.allocate(pb, libff::FMT(annotation_prefix, " c0"));
-    c1_var.allocate(pb, libff::FMT(annotation_prefix, " c1"));
+    c0_var.allocate(pb, FMT(annotation_prefix, " c0"));
+    c1_var.allocate(pb, FMT(annotation_prefix, " c1"));
 
     c0 = pb_linear_combination<FieldT>(c0_var);
     c1 = pb_linear_combination<FieldT>(c1_var);
@@ -77,9 +77,9 @@ template<typename Fp2T>
 void Fp2_variable<Fp2T>::generate_r1cs_equals_const_constraints(const Fp2T &el)
 {
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, el.c0, c0),
-                                 libff::FMT(this->annotation_prefix, " c0"));
+                                 FMT(this->annotation_prefix, " c0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, el.c1, c1),
-                                 libff::FMT(this->annotation_prefix, " c1"));
+                                 FMT(this->annotation_prefix, " c1"));
 }
 
 template<typename Fp2T>
@@ -104,7 +104,7 @@ Fp2_variable<Fp2T> Fp2_variable<Fp2T>::operator*(const FieldT &coeff) const
     pb_linear_combination<FieldT> new_c0, new_c1;
     new_c0.assign(this->pb, this->c0 * coeff);
     new_c1.assign(this->pb, this->c1 * coeff);
-    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, libff::FMT(this->annotation_prefix, " operator*"));
+    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, FMT(this->annotation_prefix, " operator*"));
 }
 
 template<typename Fp2T>
@@ -113,7 +113,7 @@ Fp2_variable<Fp2T> Fp2_variable<Fp2T>::operator+(const Fp2_variable<Fp2T> &other
     pb_linear_combination<FieldT> new_c0, new_c1;
     new_c0.assign(this->pb, this->c0 + other.c0);
     new_c1.assign(this->pb, this->c1 + other.c1);
-    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, libff::FMT(this->annotation_prefix, " operator+"));
+    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, FMT(this->annotation_prefix, " operator+"));
 }
 
 template<typename Fp2T>
@@ -122,7 +122,7 @@ Fp2_variable<Fp2T> Fp2_variable<Fp2T>::operator+(const Fp2T &other) const
     pb_linear_combination<FieldT> new_c0, new_c1;
     new_c0.assign(this->pb, this->c0 + other.c0);
     new_c1.assign(this->pb, this->c1 + other.c1);
-    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, libff::FMT(this->annotation_prefix, " operator+"));
+    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, FMT(this->annotation_prefix, " operator+"));
 }
 
 template<typename Fp2T>
@@ -131,7 +131,7 @@ Fp2_variable<Fp2T> Fp2_variable<Fp2T>::mul_by_X() const
     pb_linear_combination<FieldT> new_c0, new_c1;
     new_c0.assign(this->pb, this->c1 * Fp2T::non_residue);
     new_c1.assign(this->pb, this->c0);
-    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, libff::FMT(this->annotation_prefix, " mul_by_X"));
+    return Fp2_variable<Fp2T>(this->pb, new_c0, new_c1, FMT(this->annotation_prefix, " mul_by_X"));
 }
 
 template<typename Fp2T>
@@ -167,7 +167,7 @@ Fp2_mul_gadget<Fp2T>::Fp2_mul_gadget(protoboard<FieldT> &pb,
                                      const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix), A(A), B(B), result(result)
 {
-    v1.allocate(pb, libff::FMT(annotation_prefix, " v1"));
+    v1.allocate(pb, FMT(annotation_prefix, " v1"));
 }
 
 template<typename Fp2T>
@@ -190,12 +190,12 @@ void Fp2_mul_gadget<Fp2T>::generate_r1cs_constraints()
         Devegili, OhEigeartaigh, Scott, Dahab
 */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c1, B.c1, v1),
-                                 libff::FMT(this->annotation_prefix, " v1"));
+                                 FMT(this->annotation_prefix, " v1"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0, B.c0, result.c0 + v1 * (-Fp2T::non_residue)),
-                                 libff::FMT(this->annotation_prefix, " result.c0"));
+                                 FMT(this->annotation_prefix, " result.c0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0 + A.c1, B.c0 + B.c1,
                                                          result.c1 + result.c0 + v1 * (FieldT::one() - Fp2T::non_residue)),
-                                 libff::FMT(this->annotation_prefix, " result.c1"));
+                                 FMT(this->annotation_prefix, " result.c1"));
 }
 
 template<typename Fp2T>
@@ -221,9 +221,9 @@ template<typename Fp2T>
 void Fp2_mul_by_lc_gadget<Fp2T>::generate_r1cs_constraints()
 {
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0, lc, result.c0),
-                                 libff::FMT(this->annotation_prefix, " result.c0"));
+                                 FMT(this->annotation_prefix, " result.c0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c1, lc, result.c1),
-                                 libff::FMT(this->annotation_prefix, " result.c1"));
+                                 FMT(this->annotation_prefix, " result.c1"));
 }
 
 template<typename Fp2T>
@@ -260,11 +260,11 @@ void Fp2_sqr_gadget<Fp2T>::generate_r1cs_constraints()
         Devegili, OhEigeartaigh, Scott, Dahab
 */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(2 * A.c0, A.c1, result.c1),
-                                 libff::FMT(this->annotation_prefix, " result.c1"));
+                                 FMT(this->annotation_prefix, " result.c1"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0 + A.c1,
                                                          A.c0 + Fp2T::non_residue * A.c1,
                                                          result.c0 + result.c1 * (FieldT::one() + Fp2T::non_residue) * FieldT(2).inverse()),
-                                 libff::FMT(this->annotation_prefix, " result.c0"));
+                                 FMT(this->annotation_prefix, " result.c0"));
 }
 
 template<typename Fp2T>

--- a/src/gadgetlib1/gadgets/fields/fp3_gadgets.tcc
+++ b/src/gadgetlib1/gadgets/fields/fp3_gadgets.tcc
@@ -22,9 +22,9 @@ Fp3_variable<Fp3T>::Fp3_variable(protoboard<FieldT> &pb,
     gadget<FieldT>(pb, annotation_prefix)
 {
     pb_variable<FieldT> c0_var, c1_var, c2_var;
-    c0_var.allocate(pb, libff::FMT(annotation_prefix, " c0"));
-    c1_var.allocate(pb, libff::FMT(annotation_prefix, " c1"));
-    c2_var.allocate(pb, libff::FMT(annotation_prefix, " c2"));
+    c0_var.allocate(pb, FMT(annotation_prefix, " c0"));
+    c1_var.allocate(pb, FMT(annotation_prefix, " c1"));
+    c2_var.allocate(pb, FMT(annotation_prefix, " c2"));
 
     c0 = pb_linear_combination<FieldT>(c0_var);
     c1 = pb_linear_combination<FieldT>(c1_var);
@@ -87,11 +87,11 @@ template<typename Fp3T>
 void Fp3_variable<Fp3T>::generate_r1cs_equals_const_constraints(const Fp3T &el)
 {
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, el.c0, c0),
-                                 libff::FMT(this->annotation_prefix, " c0"));
+                                 FMT(this->annotation_prefix, " c0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, el.c1, c1),
-                                 libff::FMT(this->annotation_prefix, " c1"));
+                                 FMT(this->annotation_prefix, " c1"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, el.c2, c2),
-                                 libff::FMT(this->annotation_prefix, " c2"));
+                                 FMT(this->annotation_prefix, " c2"));
 }
 
 template<typename Fp3T>
@@ -119,7 +119,7 @@ Fp3_variable<Fp3T> Fp3_variable<Fp3T>::operator*(const FieldT &coeff) const
     new_c0.assign(this->pb, this->c0 * coeff);
     new_c1.assign(this->pb, this->c1 * coeff);
     new_c2.assign(this->pb, this->c2 * coeff);
-    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, libff::FMT(this->annotation_prefix, " operator*"));
+    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, FMT(this->annotation_prefix, " operator*"));
 }
 
 template<typename Fp3T>
@@ -129,7 +129,7 @@ Fp3_variable<Fp3T> Fp3_variable<Fp3T>::operator+(const Fp3_variable<Fp3T> &other
     new_c0.assign(this->pb, this->c0 + other.c0);
     new_c1.assign(this->pb, this->c1 + other.c1);
     new_c2.assign(this->pb, this->c2 + other.c2);
-    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, libff::FMT(this->annotation_prefix, " operator+"));
+    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, FMT(this->annotation_prefix, " operator+"));
 }
 
 template<typename Fp3T>
@@ -139,7 +139,7 @@ Fp3_variable<Fp3T> Fp3_variable<Fp3T>::operator+(const Fp3T &other) const
     new_c0.assign(this->pb, this->c0 + other.c0);
     new_c1.assign(this->pb, this->c1 + other.c1);
     new_c2.assign(this->pb, this->c2 + other.c2);
-    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, libff::FMT(this->annotation_prefix, " operator+"));
+    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, FMT(this->annotation_prefix, " operator+"));
 }
 
 template<typename Fp3T>
@@ -149,7 +149,7 @@ Fp3_variable<Fp3T> Fp3_variable<Fp3T>::mul_by_X() const
     new_c0.assign(this->pb, this->c2 * Fp3T::non_residue);
     new_c1.assign(this->pb, this->c0);
     new_c2.assign(this->pb, this->c1);
-    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, libff::FMT(this->annotation_prefix, " mul_by_X"));
+    return Fp3_variable<Fp3T>(this->pb, new_c0, new_c1, new_c2, FMT(this->annotation_prefix, " mul_by_X"));
 }
 
 template<typename Fp3T>
@@ -186,8 +186,8 @@ Fp3_mul_gadget<Fp3T>::Fp3_mul_gadget(protoboard<FieldT> &pb,
                                      const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix), A(A), B(B), result(result)
 {
-    v0.allocate(pb, libff::FMT(annotation_prefix, " v0"));
-    v4.allocate(pb, libff::FMT(annotation_prefix, " v4"));
+    v0.allocate(pb, FMT(annotation_prefix, " v0"));
+    v4.allocate(pb, FMT(annotation_prefix, " v4"));
 }
 
 template<typename Fp3T>
@@ -228,23 +228,23 @@ void Fp3_mul_gadget<Fp3T>::generate_r1cs_constraints()
                 c2 == -v0 + (1/2) v1 + (1/2) v2 - v4}, #] // FullSimplify) & /@
     Subsets[{v0, v1, v2, v3, v4}, {3}]
 */
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0, B.c0, v0), libff::FMT(this->annotation_prefix, " v0"));
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c2, B.c2, v4), libff::FMT(this->annotation_prefix, " v4"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0, B.c0, v0), FMT(this->annotation_prefix, " v0"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c2, B.c2, v4), FMT(this->annotation_prefix, " v4"));
 
     const FieldT beta = Fp3T::non_residue;
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0 + A.c1 + A.c2,
                                                          B.c0 + B.c1 + B.c2,
                                                          result.c1 + result.c2 + result.c0 * beta.inverse() + v0 * (FieldT(1) - beta.inverse()) + v4 * (FieldT(1) - beta)),
-                                 libff::FMT(this->annotation_prefix, " v1"));
+                                 FMT(this->annotation_prefix, " v1"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0 - A.c1 + A.c2,
                                                          B.c0 - B.c1 + B.c2,
                                                          -result.c1 + result.c2 + v0 * (FieldT(1) + beta.inverse()) - result.c0 * beta.inverse() + v4 * (FieldT(1) + beta)),
-                                 libff::FMT(this->annotation_prefix, " v2"));
+                                 FMT(this->annotation_prefix, " v2"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0 + 2 * A.c1 + 4 * A.c2,
                                                          B.c0 + 2 * B.c1 + 4 * B.c2,
                                                          2 * result.c1 + 4 * result.c2 + result.c0 * (FieldT(8) * beta.inverse()) + v0 * (FieldT(1) - FieldT(8) * beta.inverse()) + v4 * (FieldT(16) - FieldT(2) * beta)),
-                                 libff::FMT(this->annotation_prefix, " v3"));
+                                 FMT(this->annotation_prefix, " v3"));
 }
 
 template<typename Fp3T>
@@ -273,11 +273,11 @@ template<typename Fp3T>
 void Fp3_mul_by_lc_gadget<Fp3T>::generate_r1cs_constraints()
 {
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0, lc, result.c0),
-                                 libff::FMT(this->annotation_prefix, " result.c0"));
+                                 FMT(this->annotation_prefix, " result.c0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c1, lc, result.c1),
-                                 libff::FMT(this->annotation_prefix, " result.c1"));
+                                 FMT(this->annotation_prefix, " result.c1"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c2, lc, result.c2),
-                                 libff::FMT(this->annotation_prefix, " result.c2"));
+                                 FMT(this->annotation_prefix, " result.c2"));
 }
 
 template<typename Fp3T>
@@ -295,7 +295,7 @@ Fp3_sqr_gadget<Fp3T>::Fp3_sqr_gadget(protoboard<FieldT> &pb,
                                      const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix), A(A), result(result)
 {
-    mul.reset(new Fp3_mul_gadget<Fp3T>(pb, A, A, result, libff::FMT(annotation_prefix, " mul")));
+    mul.reset(new Fp3_mul_gadget<Fp3T>(pb, A, A, result, FMT(annotation_prefix, " mul")));
 }
 
 template<typename Fp3T>

--- a/src/gadgetlib1/gadgets/fields/fp4_gadgets.tcc
+++ b/src/gadgetlib1/gadgets/fields/fp4_gadgets.tcc
@@ -18,7 +18,7 @@ namespace libsnark {
 
 template<typename Fp4T>
 Fp4_variable<Fp4T>::Fp4_variable(protoboard<FieldT> &pb, const std::string &annotation_prefix) :
-    gadget<FieldT>(pb, annotation_prefix), c0(pb, libff::FMT(annotation_prefix, " c0")), c1(pb, libff::FMT(annotation_prefix, " c1"))
+    gadget<FieldT>(pb, annotation_prefix), c0(pb, FMT(annotation_prefix, " c0")), c1(pb, FMT(annotation_prefix, " c1"))
 {
 }
 
@@ -26,7 +26,7 @@ template<typename Fp4T>
 Fp4_variable<Fp4T>::Fp4_variable(protoboard<FieldT> &pb,
                                  const Fp4T &el,
                                  const std::string &annotation_prefix) :
-    gadget<FieldT>(pb, annotation_prefix), c0(pb, el.c0, libff::FMT(annotation_prefix, " c0")), c1(pb, el.c1, libff::FMT(annotation_prefix, " c1"))
+    gadget<FieldT>(pb, annotation_prefix), c0(pb, el.c0, FMT(annotation_prefix, " c0")), c1(pb, el.c1, FMT(annotation_prefix, " c1"))
 {
 }
 
@@ -69,9 +69,9 @@ Fp4_variable<Fp4T> Fp4_variable<Fp4T>::Frobenius_map(const size_t power) const
     new_c1c1.assign(this->pb, c1.c1 * Fp4T::Frobenius_coeffs_c1[power % 4] * Fp2T::Frobenius_coeffs_c1[power % 2]);
 
     return Fp4_variable<Fp4T>(this->pb,
-                              Fp2_variable<Fp2T>(this->pb, new_c0c0, new_c0c1, libff::FMT(this->annotation_prefix, " Frobenius_map_c0")),
-                              Fp2_variable<Fp2T>(this->pb, new_c1c0, new_c1c1, libff::FMT(this->annotation_prefix, " Frobenius_map_c1")),
-                              libff::FMT(this->annotation_prefix, " Frobenius_map"));
+                              Fp2_variable<Fp2T>(this->pb, new_c0c0, new_c0c1, FMT(this->annotation_prefix, " Frobenius_map_c0")),
+                              Fp2_variable<Fp2T>(this->pb, new_c1c0, new_c1c1, FMT(this->annotation_prefix, " Frobenius_map_c1")),
+                              FMT(this->annotation_prefix, " Frobenius_map"));
 }
 
 template<typename Fp4T>
@@ -106,29 +106,29 @@ Fp4_tower_mul_gadget<Fp4T>::Fp4_tower_mul_gadget(protoboard<FieldT> &pb,
   "Multiplication and Squaring on Pairing-Friendly Fields"
   Devegili, OhEigeartaigh, Scott, Dahab
 */
-    v1.reset(new Fp2_variable<Fp2T>(pb, libff::FMT(annotation_prefix, " v1")));
+    v1.reset(new Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " v1")));
 
-    compute_v1.reset(new Fp2_mul_gadget<Fp2T>(pb, A.c1, B.c1, *v1, libff::FMT(annotation_prefix, " compute_v1")));
+    compute_v1.reset(new Fp2_mul_gadget<Fp2T>(pb, A.c1, B.c1, *v1, FMT(annotation_prefix, " compute_v1")));
 
     v0_c0.assign(pb, result.c0.c0 - Fp4T::non_residue * v1->c1);
     v0_c1.assign(pb, result.c0.c1 - v1->c0);
-    v0.reset(new Fp2_variable<Fp2T>(pb, v0_c0, v0_c1, libff::FMT(annotation_prefix, " v0")));
+    v0.reset(new Fp2_variable<Fp2T>(pb, v0_c0, v0_c1, FMT(annotation_prefix, " v0")));
 
-    compute_v0.reset(new Fp2_mul_gadget<Fp2T>(pb, A.c0, B.c0, *v0, libff::FMT(annotation_prefix, " compute_v0")));
+    compute_v0.reset(new Fp2_mul_gadget<Fp2T>(pb, A.c0, B.c0, *v0, FMT(annotation_prefix, " compute_v0")));
 
     Ac0_plus_Ac1_c0.assign(pb, A.c0.c0 + A.c1.c0);
     Ac0_plus_Ac1_c1.assign(pb, A.c0.c1 + A.c1.c1);
-    Ac0_plus_Ac1.reset(new Fp2_variable<Fp2T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, libff::FMT(annotation_prefix, " Ac0_plus_Ac1")));
+    Ac0_plus_Ac1.reset(new Fp2_variable<Fp2T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, FMT(annotation_prefix, " Ac0_plus_Ac1")));
 
     Bc0_plus_Bc1_c0.assign(pb, B.c0.c0 + B.c1.c0);
     Bc0_plus_Bc1_c1.assign(pb, B.c0.c1 + B.c1.c1);
-    Bc0_plus_Bc1.reset(new Fp2_variable<Fp2T>(pb, Bc0_plus_Bc1_c0, Bc0_plus_Bc1_c1, libff::FMT(annotation_prefix, " Bc0_plus_Bc1")));
+    Bc0_plus_Bc1.reset(new Fp2_variable<Fp2T>(pb, Bc0_plus_Bc1_c0, Bc0_plus_Bc1_c1, FMT(annotation_prefix, " Bc0_plus_Bc1")));
 
     result_c1_plus_v0_plus_v1_c0.assign(pb, result.c1.c0 + v0->c0 + v1->c0);
     result_c1_plus_v0_plus_v1_c1.assign(pb, result.c1.c1 + v0->c1 + v1->c1);
-    result_c1_plus_v0_plus_v1.reset(new Fp2_variable<Fp2T>(pb, result_c1_plus_v0_plus_v1_c0, result_c1_plus_v0_plus_v1_c1, libff::FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
+    result_c1_plus_v0_plus_v1.reset(new Fp2_variable<Fp2T>(pb, result_c1_plus_v0_plus_v1_c0, result_c1_plus_v0_plus_v1_c1, FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
 
-    compute_result_c1.reset(new Fp2_mul_gadget<Fp2T>(pb, *Ac0_plus_Ac1, *Bc0_plus_Bc1, *result_c1_plus_v0_plus_v1, libff::FMT(annotation_prefix, " compute_result_c1")));
+    compute_result_c1.reset(new Fp2_mul_gadget<Fp2T>(pb, *Ac0_plus_Ac1, *Bc0_plus_Bc1, *result_c1_plus_v0_plus_v1, FMT(annotation_prefix, " compute_result_c1")));
 }
 
 template<typename Fp4T>
@@ -215,9 +215,9 @@ Fp4_direct_mul_gadget<Fp4T>::Fp4_direct_mul_gadget(protoboard<FieldT> &pb,
 
     and simplified by multiplying the selected result by (1-beta)
 */
-    v1.allocate(pb, libff::FMT(annotation_prefix, " v1"));
-    v2.allocate(pb, libff::FMT(annotation_prefix, " v2"));
-    v6.allocate(pb, libff::FMT(annotation_prefix, " v6"));
+    v1.allocate(pb, FMT(annotation_prefix, " v1"));
+    v2.allocate(pb, FMT(annotation_prefix, " v2"));
+    v6.allocate(pb, FMT(annotation_prefix, " v6"));
 }
 
 template<typename Fp4T>
@@ -235,39 +235,39 @@ void Fp4_direct_mul_gadget<Fp4T>::generate_r1cs_constraints()
         a0 + a1 + a2 + a3,
         b0 + b1 + b2 + b3,
         v1),
-                                 libff::FMT(this->annotation_prefix, " v1"));
+                                 FMT(this->annotation_prefix, " v1"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         a0 - a1 + a2 - a3,
         b0 - b1 + b2 - b3,
         v2),
-                                 libff::FMT(this->annotation_prefix, " v2"));
+                                 FMT(this->annotation_prefix, " v2"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         a3,
         b3,
         v6),
-                                 libff::FMT(this->annotation_prefix, " v6"));
+                                 FMT(this->annotation_prefix, " v6"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         a0,
         b0,
         u * c0 + beta * u * c2 - beta * u * FieldT(2).inverse() * v1 - beta * u * FieldT(2).inverse() * v2 + beta * v6),
-                                 libff::FMT(this->annotation_prefix, " v0"));
+                                 FMT(this->annotation_prefix, " v0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         a0 + FieldT(2)*a1 + FieldT(4)*a2 + FieldT(8)*a3,
         b0 + FieldT(2)*b1 + FieldT(4)*b2 + FieldT(8)*b3,
         - FieldT(15) * u * c0 - FieldT(30) * u * c1 - FieldT(3) * (FieldT(4) + beta) * u * c2 - FieldT(6) * (FieldT(4) + beta) * u * c3 + (FieldT(24) - FieldT(3) * beta * FieldT(2).inverse()) * u * v1 + (-FieldT(8) + beta * FieldT(2).inverse()) * u * v2 - FieldT(3) * (-FieldT(16) + beta) * v6),
-                                 libff::FMT(this->annotation_prefix, " v3"));
+                                 FMT(this->annotation_prefix, " v3"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         a0 - FieldT(2)*a1 + FieldT(4)*a2 - FieldT(8)*a3,
         b0 - FieldT(2)*b1 + FieldT(4)*b2 - FieldT(8)*b3,
         - FieldT(15) * u * c0 + FieldT(30) * u * c1 - FieldT(3) * (FieldT(4) + beta) * u * c2 + FieldT(6) * (FieldT(4) + beta) * u * c3 + (FieldT(24) - FieldT(3) * beta * FieldT(2).inverse()) * u * v2 + (-FieldT(8) + beta * FieldT(2).inverse()) * u * v1
         - FieldT(3) * (-FieldT(16) + beta) * v6),
-                                 libff::FMT(this->annotation_prefix, " v4"));
+                                 FMT(this->annotation_prefix, " v4"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(
         a0 + FieldT(3)*a1 + FieldT(9)*a2 + FieldT(27)*a3,
         b0 + FieldT(3)*b1 + FieldT(9)*b2 + FieldT(27)*b3,
         - FieldT(80) * u * c0 - FieldT(240) * u * c1 - FieldT(8) * (FieldT(9) + beta) * u * c2 - FieldT(24) * (FieldT(9) + beta) * u * c3 - FieldT(2) * (-FieldT(81) + beta) * u * v1 + (-FieldT(81) + beta) * u * v2 - FieldT(8) * (-FieldT(81) + beta) * v6),
-                                 libff::FMT(this->annotation_prefix, " v5"));
+                                 FMT(this->annotation_prefix, " v5"));
 }
 
 template<typename Fp4T>
@@ -314,24 +314,24 @@ Fp4_sqr_gadget<Fp4T>::Fp4_sqr_gadget(protoboard<FieldT> &pb,
   "Multiplication and Squaring on Pairing-Friendly Fields"
   Devegili, OhEigeartaigh, Scott, Dahab
 */
-    v1.reset(new Fp2_variable<Fp2T>(pb, libff::FMT(annotation_prefix, " v1")));
-    compute_v1.reset(new Fp2_sqr_gadget<Fp2T>(pb, A.c1, *v1, libff::FMT(annotation_prefix, " compute_v1")));
+    v1.reset(new Fp2_variable<Fp2T>(pb, FMT(annotation_prefix, " v1")));
+    compute_v1.reset(new Fp2_sqr_gadget<Fp2T>(pb, A.c1, *v1, FMT(annotation_prefix, " compute_v1")));
 
     v0_c0.assign(pb, result.c0.c0 - Fp4T::non_residue * v1->c1);
     v0_c1.assign(pb, result.c0.c1 - v1->c0);
-    v0.reset(new Fp2_variable<Fp2T>(pb, v0_c0, v0_c1, libff::FMT(annotation_prefix, " v0")));
+    v0.reset(new Fp2_variable<Fp2T>(pb, v0_c0, v0_c1, FMT(annotation_prefix, " v0")));
 
-    compute_v0.reset(new Fp2_sqr_gadget<Fp2T>(pb, A.c0, *v0, libff::FMT(annotation_prefix, " compute_v0")));
+    compute_v0.reset(new Fp2_sqr_gadget<Fp2T>(pb, A.c0, *v0, FMT(annotation_prefix, " compute_v0")));
 
     Ac0_plus_Ac1_c0.assign(pb, A.c0.c0 + A.c1.c0);
     Ac0_plus_Ac1_c1.assign(pb, A.c0.c1 + A.c1.c1);
-    Ac0_plus_Ac1.reset(new Fp2_variable<Fp2T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, libff::FMT(annotation_prefix, " Ac0_plus_Ac1")));
+    Ac0_plus_Ac1.reset(new Fp2_variable<Fp2T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, FMT(annotation_prefix, " Ac0_plus_Ac1")));
 
     result_c1_plus_v0_plus_v1_c0.assign(pb, result.c1.c0 + v0->c0 + v1->c0);
     result_c1_plus_v0_plus_v1_c1.assign(pb, result.c1.c1 + v0->c1 + v1->c1);
-    result_c1_plus_v0_plus_v1.reset(new Fp2_variable<Fp2T>(pb, result_c1_plus_v0_plus_v1_c0, result_c1_plus_v0_plus_v1_c1, libff::FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
+    result_c1_plus_v0_plus_v1.reset(new Fp2_variable<Fp2T>(pb, result_c1_plus_v0_plus_v1_c0, result_c1_plus_v0_plus_v1_c1, FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
 
-    compute_result_c1.reset(new Fp2_sqr_gadget<Fp2T>(pb, *Ac0_plus_Ac1, *result_c1_plus_v0_plus_v1, libff::FMT(annotation_prefix, " compute_result_c1")));
+    compute_result_c1.reset(new Fp2_sqr_gadget<Fp2T>(pb, *Ac0_plus_Ac1, *result_c1_plus_v0_plus_v1, FMT(annotation_prefix, " compute_result_c1")));
 }
 
 template<typename Fp4T>
@@ -394,18 +394,18 @@ Fp4_cyclotomic_sqr_gadget<Fp4T>::Fp4_cyclotomic_sqr_gadget(protoboard<FieldT> &p
 */
     c0_expr_c0.assign(pb, result.c0.c1 * FieldT(2).inverse());
     c0_expr_c1.assign(pb, (result.c0.c0 - FieldT(1)) * (FieldT(2) * Fp4T::non_residue).inverse());
-    c0_expr.reset(new Fp2_variable<Fp2T>(pb, c0_expr_c0, c0_expr_c1, libff::FMT(annotation_prefix, " c0_expr")));
-    compute_c0_expr.reset(new Fp2_sqr_gadget<Fp2T>(pb, A.c1, *c0_expr, libff::FMT(annotation_prefix, " compute_c0_expr")));
+    c0_expr.reset(new Fp2_variable<Fp2T>(pb, c0_expr_c0, c0_expr_c1, FMT(annotation_prefix, " c0_expr")));
+    compute_c0_expr.reset(new Fp2_sqr_gadget<Fp2T>(pb, A.c1, *c0_expr, FMT(annotation_prefix, " compute_c0_expr")));
 
     A_c0_plus_A_c1_c0.assign(pb, A.c0.c0 + A.c1.c0);
     A_c0_plus_A_c1_c1.assign(pb, A.c0.c1 + A.c1.c1);
-    A_c0_plus_A_c1.reset(new Fp2_variable<Fp2T>(pb, A_c0_plus_A_c1_c0, A_c0_plus_A_c1_c1, libff::FMT(annotation_prefix, " A_c0_plus_A_c1")));
+    A_c0_plus_A_c1.reset(new Fp2_variable<Fp2T>(pb, A_c0_plus_A_c1_c0, A_c0_plus_A_c1_c1, FMT(annotation_prefix, " A_c0_plus_A_c1")));
 
     c1_expr_c0.assign(pb, (result.c0.c1 + result.c0.c0 - FieldT(1)) * FieldT(2).inverse() + result.c1.c0 + FieldT(1));
     c1_expr_c1.assign(pb, (result.c0.c0 - FieldT(1)) * (FieldT(2) * Fp4T::non_residue).inverse() + result.c1.c1 + result.c0.c1 * FieldT(2).inverse());
-    c1_expr.reset(new Fp2_variable<Fp2T>(pb, c1_expr_c0, c1_expr_c1, libff::FMT(annotation_prefix, " c1_expr")));
+    c1_expr.reset(new Fp2_variable<Fp2T>(pb, c1_expr_c0, c1_expr_c1, FMT(annotation_prefix, " c1_expr")));
 
-    compute_c1_expr.reset(new Fp2_sqr_gadget<Fp2T>(pb, *A_c0_plus_A_c1, *c1_expr, libff::FMT(annotation_prefix, " compute_c1_expr")));
+    compute_c1_expr.reset(new Fp2_sqr_gadget<Fp2T>(pb, *A_c0_plus_A_c1, *c1_expr, FMT(annotation_prefix, " compute_c1_expr")));
 }
 
 template<typename Fp4T>

--- a/src/gadgetlib1/gadgets/fields/fp6_gadgets.tcc
+++ b/src/gadgetlib1/gadgets/fields/fp6_gadgets.tcc
@@ -18,7 +18,7 @@ namespace libsnark {
 
 template<typename Fp6T>
 Fp6_variable<Fp6T>::Fp6_variable(protoboard<FieldT> &pb, const std::string &annotation_prefix) :
-    gadget<FieldT>(pb, annotation_prefix), c0(pb, libff::FMT(annotation_prefix, " c0")), c1(pb, libff::FMT(annotation_prefix, " c1"))
+    gadget<FieldT>(pb, annotation_prefix), c0(pb, FMT(annotation_prefix, " c0")), c1(pb, FMT(annotation_prefix, " c1"))
 {
 }
 
@@ -26,7 +26,7 @@ template<typename Fp6T>
 Fp6_variable<Fp6T>::Fp6_variable(protoboard<FieldT> &pb,
                                  const Fp6T &el,
                                  const std::string &annotation_prefix) :
-    gadget<FieldT>(pb, annotation_prefix), c0(pb, el.c0, libff::FMT(annotation_prefix, " c0")), c1(pb, el.c1, libff::FMT(annotation_prefix, " c1"))
+    gadget<FieldT>(pb, annotation_prefix), c0(pb, el.c0, FMT(annotation_prefix, " c0")), c1(pb, el.c1, FMT(annotation_prefix, " c1"))
 {
 }
 
@@ -71,9 +71,9 @@ Fp6_variable<Fp6T> Fp6_variable<Fp6T>::Frobenius_map(const size_t power) const
     new_c1c2.assign(this->pb, c1.c2 * (Fp6T::Frobenius_coeffs_c1[power % 6] * Fp3T::Frobenius_coeffs_c2[power % 3]));
 
     return Fp6_variable<Fp6T>(this->pb,
-                              Fp3_variable<Fp3T>(this->pb, new_c0c0, new_c0c1, new_c0c2, libff::FMT(this->annotation_prefix, " Frobenius_map_c0")),
-                              Fp3_variable<Fp3T>(this->pb, new_c1c0, new_c1c1, new_c1c2, libff::FMT(this->annotation_prefix, " Frobenius_map_c1")),
-                              libff::FMT(this->annotation_prefix, " Frobenius_map"));
+                              Fp3_variable<Fp3T>(this->pb, new_c0c0, new_c0c1, new_c0c2, FMT(this->annotation_prefix, " Frobenius_map_c0")),
+                              Fp3_variable<Fp3T>(this->pb, new_c1c0, new_c1c1, new_c1c2, FMT(this->annotation_prefix, " Frobenius_map_c1")),
+                              FMT(this->annotation_prefix, " Frobenius_map"));
 }
 
 template<typename Fp6T>
@@ -108,26 +108,26 @@ Fp6_mul_gadget<Fp6T>::Fp6_mul_gadget(protoboard<FieldT> &pb,
         "Multiplication and Squaring on Pairing-Friendly Fields"
         Devegili, OhEigeartaigh, Scott, Dahab
 */
-    v1.reset(new Fp3_variable<Fp3T>(pb, libff::FMT(annotation_prefix, " v1")));
+    v1.reset(new Fp3_variable<Fp3T>(pb, FMT(annotation_prefix, " v1")));
 
-    compute_v1.reset(new Fp3_mul_gadget<Fp3T>(pb, A.c1, B.c1, *v1, libff::FMT(annotation_prefix, " compute_v1")));
+    compute_v1.reset(new Fp3_mul_gadget<Fp3T>(pb, A.c1, B.c1, *v1, FMT(annotation_prefix, " compute_v1")));
 
     v0_c0.assign(pb, result.c0.c0 - Fp6T::non_residue * v1->c2);
     v0_c1.assign(pb, result.c0.c1 - v1->c0);
     v0_c2.assign(pb, result.c0.c2 - v1->c1);
-    v0.reset(new Fp3_variable<Fp3T>(pb, v0_c0, v0_c1, v0_c2, libff::FMT(annotation_prefix, " v0")));
+    v0.reset(new Fp3_variable<Fp3T>(pb, v0_c0, v0_c1, v0_c2, FMT(annotation_prefix, " v0")));
 
-    compute_v0.reset(new Fp3_mul_gadget<Fp3T>(pb, A.c0, B.c0, *v0, libff::FMT(annotation_prefix, " compute_v0")));
+    compute_v0.reset(new Fp3_mul_gadget<Fp3T>(pb, A.c0, B.c0, *v0, FMT(annotation_prefix, " compute_v0")));
 
     Ac0_plus_Ac1_c0.assign(pb, A.c0.c0 + A.c1.c0);
     Ac0_plus_Ac1_c1.assign(pb, A.c0.c1 + A.c1.c1);
     Ac0_plus_Ac1_c2.assign(pb, A.c0.c2 + A.c1.c2);
-    Ac0_plus_Ac1.reset(new Fp3_variable<Fp3T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, Ac0_plus_Ac1_c2, libff::FMT(annotation_prefix, " Ac0_plus_Ac1")));
+    Ac0_plus_Ac1.reset(new Fp3_variable<Fp3T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, Ac0_plus_Ac1_c2, FMT(annotation_prefix, " Ac0_plus_Ac1")));
 
     Bc0_plus_Bc1_c0.assign(pb, B.c0.c0 + B.c1.c0);
     Bc0_plus_Bc1_c1.assign(pb, B.c0.c1 + B.c1.c1);
     Bc0_plus_Bc1_c2.assign(pb, B.c0.c2 + B.c1.c2);
-    Bc0_plus_Bc1.reset(new Fp3_variable<Fp3T>(pb, Bc0_plus_Bc1_c0, Bc0_plus_Bc1_c1, Bc0_plus_Bc1_c2, libff::FMT(annotation_prefix, " Bc0_plus_Bc1")));
+    Bc0_plus_Bc1.reset(new Fp3_variable<Fp3T>(pb, Bc0_plus_Bc1_c0, Bc0_plus_Bc1_c1, Bc0_plus_Bc1_c2, FMT(annotation_prefix, " Bc0_plus_Bc1")));
 
     result_c1_plus_v0_plus_v1_c0.assign(pb, result.c1.c0 + v0->c0 + v1->c0);
     result_c1_plus_v0_plus_v1_c1.assign(pb, result.c1.c1 + v0->c1 + v1->c1);
@@ -136,9 +136,9 @@ Fp6_mul_gadget<Fp6T>::Fp6_mul_gadget(protoboard<FieldT> &pb,
                                                            result_c1_plus_v0_plus_v1_c0,
                                                            result_c1_plus_v0_plus_v1_c1,
                                                            result_c1_plus_v0_plus_v1_c2,
-                                                           libff::FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
+                                                           FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
 
-    compute_result_c1.reset(new Fp3_mul_gadget<Fp3T>(pb, *Ac0_plus_Ac1, *Bc0_plus_Bc1, *result_c1_plus_v0_plus_v1, libff::FMT(annotation_prefix, " compute_result_c1")));
+    compute_result_c1.reset(new Fp3_mul_gadget<Fp3T>(pb, *Ac0_plus_Ac1, *Bc0_plus_Bc1, *result_c1_plus_v0_plus_v1, FMT(annotation_prefix, " compute_result_c1")));
 }
 
 template<typename Fp6T>
@@ -210,21 +210,21 @@ Fp6_mul_by_2345_gadget<Fp6T>::Fp6_mul_by_2345_gadget(protoboard<FieldT> &pb,
         "Multiplication and Squaring on Pairing-Friendly Fields"
         Devegili, OhEigeartaigh, Scott, Dahab
 */
-    v1.reset(new Fp3_variable<Fp3T>(pb, libff::FMT(annotation_prefix, " v1")));
-    compute_v1.reset(new Fp3_mul_gadget<Fp3T>(pb, A.c1, B.c1, *v1, libff::FMT(annotation_prefix, " compute_v1")));
+    v1.reset(new Fp3_variable<Fp3T>(pb, FMT(annotation_prefix, " v1")));
+    compute_v1.reset(new Fp3_mul_gadget<Fp3T>(pb, A.c1, B.c1, *v1, FMT(annotation_prefix, " compute_v1")));
 
     /* we inline result.c0 in v0 as follows: v0 = (result.c0.c0 - Fp6T::non_residue * v1->c2, result.c0.c1 - v1->c0, result.c0.c2 - v1->c1) */
-    v0.reset(new Fp3_variable<Fp3T>(pb, libff::FMT(annotation_prefix, " v0")));
+    v0.reset(new Fp3_variable<Fp3T>(pb, FMT(annotation_prefix, " v0")));
 
     Ac0_plus_Ac1_c0.assign(pb, A.c0.c0 + A.c1.c0);
     Ac0_plus_Ac1_c1.assign(pb, A.c0.c1 + A.c1.c1);
     Ac0_plus_Ac1_c2.assign(pb, A.c0.c2 + A.c1.c2);
-    Ac0_plus_Ac1.reset(new Fp3_variable<Fp3T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, Ac0_plus_Ac1_c2, libff::FMT(annotation_prefix, " Ac0_plus_Ac1")));
+    Ac0_plus_Ac1.reset(new Fp3_variable<Fp3T>(pb, Ac0_plus_Ac1_c0, Ac0_plus_Ac1_c1, Ac0_plus_Ac1_c2, FMT(annotation_prefix, " Ac0_plus_Ac1")));
 
     Bc0_plus_Bc1_c0.assign(pb, B.c0.c0 + B.c1.c0);
     Bc0_plus_Bc1_c1.assign(pb, B.c0.c1 + B.c1.c1);
     Bc0_plus_Bc1_c2.assign(pb, B.c0.c2 + B.c1.c2);
-    Bc0_plus_Bc1.reset(new Fp3_variable<Fp3T>(pb, Bc0_plus_Bc1_c0, Bc0_plus_Bc1_c1, Bc0_plus_Bc1_c2, libff::FMT(annotation_prefix, " Bc0_plus_Bc1")));
+    Bc0_plus_Bc1.reset(new Fp3_variable<Fp3T>(pb, Bc0_plus_Bc1_c0, Bc0_plus_Bc1_c1, Bc0_plus_Bc1_c2, FMT(annotation_prefix, " Bc0_plus_Bc1")));
 
     result_c1_plus_v0_plus_v1_c0.assign(pb, result.c1.c0 + v0->c0 + v1->c0);
     result_c1_plus_v0_plus_v1_c1.assign(pb, result.c1.c1 + v0->c1 + v1->c1);
@@ -233,9 +233,9 @@ Fp6_mul_by_2345_gadget<Fp6T>::Fp6_mul_by_2345_gadget(protoboard<FieldT> &pb,
                                                            result_c1_plus_v0_plus_v1_c0,
                                                            result_c1_plus_v0_plus_v1_c1,
                                                            result_c1_plus_v0_plus_v1_c2,
-                                                           libff::FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
+                                                           FMT(annotation_prefix, " result_c1_plus_v0_plus_v1")));
 
-    compute_result_c1.reset(new Fp3_mul_gadget<Fp3T>(pb, *Ac0_plus_Ac1, *Bc0_plus_Bc1, *result_c1_plus_v0_plus_v1, libff::FMT(annotation_prefix, " compute_result_c1")));
+    compute_result_c1.reset(new Fp3_mul_gadget<Fp3T>(pb, *Ac0_plus_Ac1, *Bc0_plus_Bc1, *result_c1_plus_v0_plus_v1, FMT(annotation_prefix, " compute_result_c1")));
 }
 
 template<typename Fp6T>
@@ -245,15 +245,15 @@ void Fp6_mul_by_2345_gadget<Fp6T>::generate_r1cs_constraints()
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0.c1,
                                                          Fp3T::non_residue * B.c0.c2,
                                                          result.c0.c0 - Fp6T::non_residue * v1->c2),
-                                 libff::FMT(this->annotation_prefix, " v0.c0"));
+                                 FMT(this->annotation_prefix, " v0.c0"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0.c2,
                                                          Fp3T::non_residue * B.c0.c2,
                                                          result.c0.c1 - v1->c0),
-                                 libff::FMT(this->annotation_prefix, " v0.c1"));
+                                 FMT(this->annotation_prefix, " v0.c1"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(A.c0.c0,
                                                          B.c0.c2,
                                                          result.c0.c2 - v1->c1),
-                                 libff::FMT(this->annotation_prefix, " v0.c2"));
+                                 FMT(this->annotation_prefix, " v0.c2"));
     compute_result_c1->generate_r1cs_constraints();
 }
 
@@ -301,7 +301,7 @@ Fp6_sqr_gadget<Fp6T>::Fp6_sqr_gadget(protoboard<FieldT> &pb,
     gadget<FieldT>(pb, annotation_prefix), A(A), result(result)
 {
     // We can't do better than 3 Fp3_mul_gadget's for squaring, so we just use multiplication.
-    mul.reset(new Fp6_mul_gadget<Fp6T>(pb, A, A, result, libff::FMT(annotation_prefix, " mul")));
+    mul.reset(new Fp6_mul_gadget<Fp6T>(pb, A, A, result, FMT(annotation_prefix, " mul")));
 }
 
 template<typename Fp6T>
@@ -344,9 +344,9 @@ Fp6_cyclotomic_sqr_gadget<Fp6T>::Fp6_cyclotomic_sqr_gadget(protoboard<FieldT> &p
     return Fp6_2over3_model<n, mbodulus>(my_Fp3(A_a, C_a, B_b),
                                          my_Fp3(B_a, A_b, C_b))
 */
-    a.reset(new Fp2_variable<Fp2T>(pb, A.c0.c0, A.c1.c1, libff::FMT(annotation_prefix, " a")));
-    b.reset(new Fp2_variable<Fp2T>(pb, A.c1.c0, A.c0.c2, libff::FMT(annotation_prefix, " b")));
-    c.reset(new Fp2_variable<Fp2T>(pb, A.c0.c1, A.c1.c2, libff::FMT(annotation_prefix, " c")));
+    a.reset(new Fp2_variable<Fp2T>(pb, A.c0.c0, A.c1.c1, FMT(annotation_prefix, " a")));
+    b.reset(new Fp2_variable<Fp2T>(pb, A.c1.c0, A.c0.c2, FMT(annotation_prefix, " b")));
+    c.reset(new Fp2_variable<Fp2T>(pb, A.c0.c1, A.c1.c2, FMT(annotation_prefix, " c")));
 
     asq_c0.assign(pb, (result.c0.c0 + 2 * a->c0) * FieldT(3).inverse());
     asq_c1.assign(pb, (result.c1.c1 - 2 * a->c1) * FieldT(3).inverse());
@@ -357,13 +357,13 @@ Fp6_cyclotomic_sqr_gadget<Fp6T>::Fp6_cyclotomic_sqr_gadget(protoboard<FieldT> &p
     csq_c0.assign(pb, (result.c0.c2 + 2 * b->c1) * FieldT(3).inverse());
     csq_c1.assign(pb, (result.c1.c0 - 2 * b->c0) * (FieldT(3) * Fp2T::non_residue).inverse());
 
-    asq.reset(new Fp2_variable<Fp2T>(pb, asq_c0, asq_c1, libff::FMT(annotation_prefix, " asq")));
-    bsq.reset(new Fp2_variable<Fp2T>(pb, bsq_c0, bsq_c1, libff::FMT(annotation_prefix, " bsq")));
-    csq.reset(new Fp2_variable<Fp2T>(pb, csq_c0, csq_c1, libff::FMT(annotation_prefix, " csq")));
+    asq.reset(new Fp2_variable<Fp2T>(pb, asq_c0, asq_c1, FMT(annotation_prefix, " asq")));
+    bsq.reset(new Fp2_variable<Fp2T>(pb, bsq_c0, bsq_c1, FMT(annotation_prefix, " bsq")));
+    csq.reset(new Fp2_variable<Fp2T>(pb, csq_c0, csq_c1, FMT(annotation_prefix, " csq")));
 
-    compute_asq.reset(new Fp2_sqr_gadget<Fp2T>(pb, *a, *asq, libff::FMT(annotation_prefix, " compute_asq")));
-    compute_bsq.reset(new Fp2_sqr_gadget<Fp2T>(pb, *b, *bsq, libff::FMT(annotation_prefix, " compute_bsq")));
-    compute_csq.reset(new Fp2_sqr_gadget<Fp2T>(pb, *c, *csq, libff::FMT(annotation_prefix, " compute_csq")));
+    compute_asq.reset(new Fp2_sqr_gadget<Fp2T>(pb, *a, *asq, FMT(annotation_prefix, " compute_asq")));
+    compute_bsq.reset(new Fp2_sqr_gadget<Fp2T>(pb, *b, *bsq, FMT(annotation_prefix, " compute_bsq")));
+    compute_csq.reset(new Fp2_sqr_gadget<Fp2T>(pb, *c, *csq, FMT(annotation_prefix, " compute_csq")));
 }
 
 template<typename Fp6T>

--- a/src/gadgetlib1/gadgets/gadget_from_r1cs.tcc
+++ b/src/gadgetlib1/gadgets/gadget_from_r1cs.tcc
@@ -43,7 +43,7 @@ gadget_from_r1cs<FieldT>::gadget_from_r1cs(protoboard<FieldT> &pb,
                 // handle annotations, except for re-annotating constant term
                 const std::map<size_t, std::string>::const_iterator it = cs.variable_annotations.find(cs_var_idx);
 
-                std::string annotation = libff::FMT(annotation_prefix, " variable_%zu", cs_var_idx);
+                std::string annotation = FMT(annotation_prefix, " variable_%zu", cs_var_idx);
                 if (it != cs.variable_annotations.end())
                 {
                     annotation = annotation_prefix + " " + it->second;
@@ -87,7 +87,7 @@ void gadget_from_r1cs<FieldT>::generate_r1cs_constraints()
             translated_constr.c.terms.emplace_back(linear_term<FieldT>(pb_variable<FieldT>(cs_to_vars[t.index]), t.coeff));
         }
 
-        std::string annotation = libff::FMT(this->annotation_prefix, " constraint_%zu", i);
+        std::string annotation = FMT(this->annotation_prefix, " constraint_%zu", i);
 
 #ifdef DEBUG
         auto it = cs.constraint_annotations.find(i);

--- a/src/gadgetlib1/gadgets/hashes/digest_selector_gadget.tcc
+++ b/src/gadgetlib1/gadgets/hashes/digest_selector_gadget.tcc
@@ -31,7 +31,7 @@ void digest_selector_gadget<FieldT>::generate_r1cs_constraints()
           input - left = is_right(right - left)
         */
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(is_right, right.bits[i] - left.bits[i], input.bits[i] - left.bits[i]),
-                                     libff::FMT(this->annotation_prefix, " propagate_%zu", i));
+                                     FMT(this->annotation_prefix, " propagate_%zu", i));
     }
 }
 

--- a/src/gadgetlib1/gadgets/hashes/hash_io.tcc
+++ b/src/gadgetlib1/gadgets/hashes/hash_io.tcc
@@ -15,7 +15,7 @@ digest_variable<FieldT>::digest_variable(protoboard<FieldT> &pb,
                                          const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix), digest_size(digest_size)
 {
-    bits.allocate(pb, digest_size, libff::FMT(this->annotation_prefix, " bits"));
+    bits.allocate(pb, digest_size, FMT(this->annotation_prefix, " bits"));
 }
 
 template<typename FieldT>
@@ -39,7 +39,7 @@ void digest_variable<FieldT>::generate_r1cs_constraints()
 {
     for (size_t i = 0; i < digest_size; ++i)
     {
-        generate_boolean_r1cs_constraint<FieldT>(this->pb, bits[i], libff::FMT(this->annotation_prefix, " bits_%zu", i));
+        generate_boolean_r1cs_constraint<FieldT>(this->pb, bits[i], FMT(this->annotation_prefix, " bits_%zu", i));
     }
 }
 
@@ -61,7 +61,7 @@ block_variable<FieldT>::block_variable(protoboard<FieldT> &pb,
                                        const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix), block_size(block_size)
 {
-    bits.allocate(pb, block_size, libff::FMT(this->annotation_prefix, " bits"));
+    bits.allocate(pb, block_size, FMT(this->annotation_prefix, " bits"));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.tcc
+++ b/src/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.tcc
@@ -53,7 +53,7 @@ void knapsack_CRH_with_field_out_gadget<FieldT>::generate_r1cs_constraints()
                                                              pb_coeff_sum<FieldT>(input_block.bits,
                                                                                   std::vector<FieldT>(knapsack_coefficients.begin() + input_len * i,
                                                                                                       knapsack_coefficients.begin() + input_len * (i+1))),
-                                                             output[i]), libff::FMT(this->annotation_prefix, " knapsack_%zu", i));
+                                                             output[i]), FMT(this->annotation_prefix, " knapsack_%zu", i));
     }
 }
 
@@ -157,7 +157,7 @@ knapsack_CRH_with_bit_out_gadget<FieldT>::knapsack_CRH_with_bit_out_gadget(proto
                                                                               output_digest.bits.begin() + (i + 1) * FieldT::size_in_bits())));
     }
 
-    hasher.reset(new knapsack_CRH_with_field_out_gadget<FieldT>(pb, input_len, input_block, output, libff::FMT(annotation_prefix, " hasher")));
+    hasher.reset(new knapsack_CRH_with_field_out_gadget<FieldT>(pb, input_len, input_block, output, FMT(annotation_prefix, " hasher")));
 }
 
 
@@ -170,7 +170,7 @@ void knapsack_CRH_with_bit_out_gadget<FieldT>::generate_r1cs_constraints(const b
     {
         for (size_t k = 0; k < output_digest.bits.size(); ++k)
         {
-            generate_boolean_r1cs_constraint<FieldT>(this->pb, output_digest.bits[k], libff::FMT(this->annotation_prefix, " output_digest_%zu", k));
+            generate_boolean_r1cs_constraint<FieldT>(this->pb, output_digest.bits[k], FMT(this->annotation_prefix, " output_digest_%zu", k));
         }
     }
 }

--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_aux.tcc
+++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_aux.tcc
@@ -33,12 +33,12 @@ lastbits_gadget<FieldT>::lastbits_gadget(protoboard<FieldT> &pb,
     for (size_t i = result_bits.size(); i < X_bits; ++i)
     {
         pb_variable<FieldT> full_bits_overflow;
-        full_bits_overflow.allocate(pb, libff::FMT(this->annotation_prefix, " full_bits_%zu", i));
+        full_bits_overflow.allocate(pb, FMT(this->annotation_prefix, " full_bits_%zu", i));
         full_bits.emplace_back(full_bits_overflow);
     }
 
-    unpack_bits.reset(new packing_gadget<FieldT>(pb, full_bits, X, libff::FMT(this->annotation_prefix, " unpack_bits")));
-    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, libff::FMT(this->annotation_prefix, " pack_result")));
+    unpack_bits.reset(new packing_gadget<FieldT>(pb, full_bits, X, FMT(this->annotation_prefix, " unpack_bits")));
+    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, FMT(this->annotation_prefix, " pack_result")));
 }
 
 template<typename FieldT>
@@ -72,7 +72,7 @@ XOR3_gadget<FieldT>::XOR3_gadget(protoboard<FieldT> &pb,
 {
     if (!assume_C_is_zero)
     {
-        tmp.allocate(pb, libff::FMT(this->annotation_prefix, " tmp"));
+        tmp.allocate(pb, FMT(this->annotation_prefix, " tmp"));
     }
 }
 
@@ -85,12 +85,12 @@ void XOR3_gadget<FieldT>::generate_r1cs_constraints()
     */
     if (assume_C_is_zero)
     {
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(2*A, B, A + B - out), libff::FMT(this->annotation_prefix, " implicit_tmp_equals_out"));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(2*A, B, A + B - out), FMT(this->annotation_prefix, " implicit_tmp_equals_out"));
     }
     else
     {
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(2*A, B, A + B - tmp), libff::FMT(this->annotation_prefix, " tmp"));
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(2 * tmp, C, tmp + C - out), libff::FMT(this->annotation_prefix, " out"));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(2*A, B, A + B - tmp), FMT(this->annotation_prefix, " tmp"));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(2 * tmp, C, tmp + C - out), FMT(this->annotation_prefix, " out"));
     }
 }
 
@@ -123,16 +123,16 @@ small_sigma_gadget<FieldT>::small_sigma_gadget(protoboard<FieldT> &pb,
     W(W),
     result(result)
 {
-    result_bits.allocate(pb, 32, libff::FMT(this->annotation_prefix, " result_bits"));
+    result_bits.allocate(pb, 32, FMT(this->annotation_prefix, " result_bits"));
     compute_bits.resize(32);
     for (size_t i = 0; i < 32; ++i)
     {
         compute_bits[i].reset(new XOR3_gadget<FieldT>(pb, SHA256_GADGET_ROTR(W, i, rot1), SHA256_GADGET_ROTR(W, i, rot2),
                                               (i + shift < 32 ? W[i+shift] : ONE),
                                               (i + shift >= 32), result_bits[i],
-                                              libff::FMT(this->annotation_prefix, " compute_bits_%zu", i)));
+                                              FMT(this->annotation_prefix, " compute_bits_%zu", i)));
     }
-    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, libff::FMT(this->annotation_prefix, " pack_result")));
+    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, FMT(this->annotation_prefix, " pack_result")));
 }
 
 template<typename FieldT>
@@ -169,15 +169,15 @@ big_sigma_gadget<FieldT>::big_sigma_gadget(protoboard<FieldT> &pb,
     W(W),
     result(result)
 {
-    result_bits.allocate(pb, 32, libff::FMT(this->annotation_prefix, " result_bits"));
+    result_bits.allocate(pb, 32, FMT(this->annotation_prefix, " result_bits"));
     compute_bits.resize(32);
     for (size_t i = 0; i < 32; ++i)
     {
         compute_bits[i].reset(new XOR3_gadget<FieldT>(pb, SHA256_GADGET_ROTR(W, i, rot1), SHA256_GADGET_ROTR(W, i, rot2), SHA256_GADGET_ROTR(W, i, rot3), false, result_bits[i],
-                                                      libff::FMT(this->annotation_prefix, " compute_bits_%zu", i)));
+                                                      FMT(this->annotation_prefix, " compute_bits_%zu", i)));
     }
 
-    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, libff::FMT(this->annotation_prefix, " pack_result")));
+    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, FMT(this->annotation_prefix, " pack_result")));
 }
 
 template<typename FieldT>
@@ -215,8 +215,8 @@ choice_gadget<FieldT>::choice_gadget(protoboard<FieldT> &pb,
     Z(Z),
     result(result)
 {
-    result_bits.allocate(pb, 32, libff::FMT(this->annotation_prefix, " result_bits"));
-    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, libff::FMT(this->annotation_prefix, " result")));
+    result_bits.allocate(pb, 32, FMT(this->annotation_prefix, " result_bits"));
+    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, FMT(this->annotation_prefix, " result")));
 }
 
 template<typename FieldT>
@@ -228,7 +228,7 @@ void choice_gadget<FieldT>::generate_r1cs_constraints()
           result = x * y + (1-x) * z
           result - z = x * (y - z)
         */
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(X[i], Y[i] - Z[i], result_bits[i] - Z[i]), libff::FMT(this->annotation_prefix, " result_bits_%zu", i));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(X[i], Y[i] - Z[i], result_bits[i] - Z[i]), FMT(this->annotation_prefix, " result_bits_%zu", i));
     }
     pack_result->generate_r1cs_constraints(false);
 }
@@ -257,8 +257,8 @@ majority_gadget<FieldT>::majority_gadget(protoboard<FieldT> &pb,
     Z(Z),
     result(result)
 {
-    result_bits.allocate(pb, 32, libff::FMT(this->annotation_prefix, " result_bits"));
-    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, libff::FMT(this->annotation_prefix, " result")));
+    result_bits.allocate(pb, 32, FMT(this->annotation_prefix, " result_bits"));
+    pack_result.reset(new packing_gadget<FieldT>(pb, result_bits, result, FMT(this->annotation_prefix, " result")));
 }
 
 template<typename FieldT>
@@ -271,11 +271,11 @@ void majority_gadget<FieldT>::generate_r1cs_constraints()
           x, y, z, aux -- bits
           aux = x + y + z - 2*result
         */
-        generate_boolean_r1cs_constraint<FieldT>(this->pb, result_bits[i], libff::FMT(this->annotation_prefix, " result_%zu", i));
+        generate_boolean_r1cs_constraint<FieldT>(this->pb, result_bits[i], FMT(this->annotation_prefix, " result_%zu", i));
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(X[i] + Y[i] + Z[i] - 2 * result_bits[i],
                                                              1 - (X[i] + Y[i] + Z[i] -  2 * result_bits[i]),
                                                              0),
-                                     libff::FMT(this->annotation_prefix, " result_bits_%zu", i));
+                                     FMT(this->annotation_prefix, " result_bits_%zu", i));
     }
     pack_result->generate_r1cs_constraints(false);
 }

--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_components.tcc
+++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_components.tcc
@@ -66,7 +66,7 @@ sha256_message_schedule_gadget<FieldT>::sha256_message_schedule_gadget(protoboar
     for (size_t i = 0; i < 16; ++i)
     {
         W_bits[i] = pb_variable_array<FieldT>(M.rbegin() + (15-i) * 32, M.rbegin() + (16-i) * 32);
-        pack_W[i].reset(new packing_gadget<FieldT>(pb, W_bits[i], packed_W[i], libff::FMT(this->annotation_prefix, " pack_W_%zu", i)));
+        pack_W[i].reset(new packing_gadget<FieldT>(pb, W_bits[i], packed_W[i], FMT(this->annotation_prefix, " pack_W_%zu", i)));
     }
 
     /* NB: some of those will be un-allocated */
@@ -80,21 +80,21 @@ sha256_message_schedule_gadget<FieldT>::sha256_message_schedule_gadget(protoboar
     for (size_t i = 16; i < 64; ++i)
     {
         /* allocate result variables for sigma0/sigma1 invocations */
-        sigma0[i].allocate(pb, libff::FMT(this->annotation_prefix, " sigma0_%zu", i));
-        sigma1[i].allocate(pb, libff::FMT(this->annotation_prefix, " sigma1_%zu", i));
+        sigma0[i].allocate(pb, FMT(this->annotation_prefix, " sigma0_%zu", i));
+        sigma1[i].allocate(pb, FMT(this->annotation_prefix, " sigma1_%zu", i));
 
         /* compute sigma0/sigma1 */
-        compute_sigma0[i].reset(new small_sigma_gadget<FieldT>(pb, W_bits[i-15], sigma0[i], 7, 18, 3, libff::FMT(this->annotation_prefix, " compute_sigma0_%zu", i)));
-        compute_sigma1[i].reset(new small_sigma_gadget<FieldT>(pb, W_bits[i-2], sigma1[i], 17, 19, 10, libff::FMT(this->annotation_prefix, " compute_sigma1_%zu", i)));
+        compute_sigma0[i].reset(new small_sigma_gadget<FieldT>(pb, W_bits[i-15], sigma0[i], 7, 18, 3, FMT(this->annotation_prefix, " compute_sigma0_%zu", i)));
+        compute_sigma1[i].reset(new small_sigma_gadget<FieldT>(pb, W_bits[i-2], sigma1[i], 17, 19, 10, FMT(this->annotation_prefix, " compute_sigma1_%zu", i)));
 
         /* unreduced_W = sigma0(W_{i-15}) + sigma1(W_{i-2}) + W_{i-7} + W_{i-16} before modulo 2^32 */
-        unreduced_W[i].allocate(pb, libff::FMT(this->annotation_prefix, "unreduced_W_%zu", i));
+        unreduced_W[i].allocate(pb, FMT(this->annotation_prefix, "unreduced_W_%zu", i));
 
         /* allocate the bit representation of packed_W[i] */
-        W_bits[i].allocate(pb, 32, libff::FMT(this->annotation_prefix, " W_bits_%zu", i));
+        W_bits[i].allocate(pb, 32, FMT(this->annotation_prefix, " W_bits_%zu", i));
 
         /* and finally reduce this into packed and bit representations */
-        mod_reduce_W[i].reset(new lastbits_gadget<FieldT>(pb, unreduced_W[i], 32+2, packed_W[i], W_bits[i], libff::FMT(this->annotation_prefix, " mod_reduce_W_%zu", i)));
+        mod_reduce_W[i].reset(new lastbits_gadget<FieldT>(pb, unreduced_W[i], 32+2, packed_W[i], W_bits[i], FMT(this->annotation_prefix, " mod_reduce_W_%zu", i)));
     }
 }
 
@@ -114,7 +114,7 @@ void sha256_message_schedule_gadget<FieldT>::generate_r1cs_constraints()
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
                                                              sigma0[i] + sigma1[i] + packed_W[i-16] + packed_W[i-7],
                                                              unreduced_W[i]),
-            libff::FMT(this->annotation_prefix, " unreduced_W_%zu", i));
+            FMT(this->annotation_prefix, " unreduced_W_%zu", i));
 
         mod_reduce_W[i]->generate_r1cs_constraints();
     }
@@ -168,36 +168,36 @@ sha256_round_function_gadget<FieldT>::sha256_round_function_gadget(protoboard<Fi
     new_e(new_e)
 {
     /* compute sigma0 and sigma1 */
-    sigma0.allocate(pb, libff::FMT(this->annotation_prefix, " sigma0"));
-    sigma1.allocate(pb, libff::FMT(this->annotation_prefix, " sigma1"));
-    compute_sigma0.reset(new big_sigma_gadget<FieldT>(pb, a, sigma0, 2, 13, 22, libff::FMT(this->annotation_prefix, " compute_sigma0")));
-    compute_sigma1.reset(new big_sigma_gadget<FieldT>(pb, e, sigma1, 6, 11, 25, libff::FMT(this->annotation_prefix, " compute_sigma1")));
+    sigma0.allocate(pb, FMT(this->annotation_prefix, " sigma0"));
+    sigma1.allocate(pb, FMT(this->annotation_prefix, " sigma1"));
+    compute_sigma0.reset(new big_sigma_gadget<FieldT>(pb, a, sigma0, 2, 13, 22, FMT(this->annotation_prefix, " compute_sigma0")));
+    compute_sigma1.reset(new big_sigma_gadget<FieldT>(pb, e, sigma1, 6, 11, 25, FMT(this->annotation_prefix, " compute_sigma1")));
 
     /* compute choice */
-    choice.allocate(pb, libff::FMT(this->annotation_prefix, " choice"));
-    compute_choice.reset(new choice_gadget<FieldT>(pb, e, f, g, choice, libff::FMT(this->annotation_prefix, " compute_choice")));
+    choice.allocate(pb, FMT(this->annotation_prefix, " choice"));
+    compute_choice.reset(new choice_gadget<FieldT>(pb, e, f, g, choice, FMT(this->annotation_prefix, " compute_choice")));
 
     /* compute majority */
-    majority.allocate(pb, libff::FMT(this->annotation_prefix, " majority"));
-    compute_majority.reset(new majority_gadget<FieldT>(pb, a, b, c, majority, libff::FMT(this->annotation_prefix, " compute_majority")));
+    majority.allocate(pb, FMT(this->annotation_prefix, " majority"));
+    compute_majority.reset(new majority_gadget<FieldT>(pb, a, b, c, majority, FMT(this->annotation_prefix, " compute_majority")));
 
     /* pack d */
-    packed_d.allocate(pb, libff::FMT(this->annotation_prefix, " packed_d"));
-    pack_d.reset(new packing_gadget<FieldT>(pb, d, packed_d, libff::FMT(this->annotation_prefix, " pack_d")));
+    packed_d.allocate(pb, FMT(this->annotation_prefix, " packed_d"));
+    pack_d.reset(new packing_gadget<FieldT>(pb, d, packed_d, FMT(this->annotation_prefix, " pack_d")));
 
     /* pack h */
-    packed_h.allocate(pb, libff::FMT(this->annotation_prefix, " packed_h"));
-    pack_h.reset(new packing_gadget<FieldT>(pb, h, packed_h, libff::FMT(this->annotation_prefix, " pack_h")));
+    packed_h.allocate(pb, FMT(this->annotation_prefix, " packed_h"));
+    pack_h.reset(new packing_gadget<FieldT>(pb, h, packed_h, FMT(this->annotation_prefix, " pack_h")));
 
     /* compute the actual results for the round */
-    unreduced_new_a.allocate(pb, libff::FMT(this->annotation_prefix, " unreduced_new_a"));
-    unreduced_new_e.allocate(pb, libff::FMT(this->annotation_prefix, " unreduced_new_e"));
+    unreduced_new_a.allocate(pb, FMT(this->annotation_prefix, " unreduced_new_a"));
+    unreduced_new_e.allocate(pb, FMT(this->annotation_prefix, " unreduced_new_e"));
 
-    packed_new_a.allocate(pb, libff::FMT(this->annotation_prefix, " packed_new_a"));
-    packed_new_e.allocate(pb, libff::FMT(this->annotation_prefix, " packed_new_e"));
+    packed_new_a.allocate(pb, FMT(this->annotation_prefix, " packed_new_a"));
+    packed_new_e.allocate(pb, FMT(this->annotation_prefix, " packed_new_e"));
 
-    mod_reduce_new_a.reset(new lastbits_gadget<FieldT>(pb, unreduced_new_a, 32+3, packed_new_a, new_a, libff::FMT(this->annotation_prefix, " mod_reduce_new_a")));
-    mod_reduce_new_e.reset(new lastbits_gadget<FieldT>(pb, unreduced_new_e, 32+3, packed_new_e, new_e, libff::FMT(this->annotation_prefix, " mod_reduce_new_e")));
+    mod_reduce_new_a.reset(new lastbits_gadget<FieldT>(pb, unreduced_new_a, 32+3, packed_new_a, new_a, FMT(this->annotation_prefix, " mod_reduce_new_a")));
+    mod_reduce_new_e.reset(new lastbits_gadget<FieldT>(pb, unreduced_new_e, 32+3, packed_new_e, new_e, FMT(this->annotation_prefix, " mod_reduce_new_e")));
 }
 
 template<typename FieldT>
@@ -215,12 +215,12 @@ void sha256_round_function_gadget<FieldT>::generate_r1cs_constraints()
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
                                                          packed_h + sigma1 + choice + K + W + sigma0 + majority,
                                                          unreduced_new_a),
-        libff::FMT(this->annotation_prefix, " unreduced_new_a"));
+        FMT(this->annotation_prefix, " unreduced_new_a"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
                                                          packed_d + packed_h + sigma1 + choice + K + W,
                                                          unreduced_new_e),
-        libff::FMT(this->annotation_prefix, " unreduced_new_e"));
+        FMT(this->annotation_prefix, " unreduced_new_e"));
 
     mod_reduce_new_a->generate_r1cs_constraints();
     mod_reduce_new_e->generate_r1cs_constraints();

--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc
+++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc
@@ -28,8 +28,8 @@ sha256_compression_function_gadget<FieldT>::sha256_compression_function_gadget(p
     output(output)
 {
     /* message schedule and inputs for it */
-    packed_W.allocate(pb, 64, libff::FMT(this->annotation_prefix, " packed_W"));
-    message_schedule.reset(new sha256_message_schedule_gadget<FieldT>(pb, new_block, packed_W, libff::FMT(this->annotation_prefix, " message_schedule")));
+    packed_W.allocate(pb, 64, FMT(this->annotation_prefix, " packed_W"));
+    message_schedule.reset(new sha256_message_schedule_gadget<FieldT>(pb, new_block, packed_W, FMT(this->annotation_prefix, " message_schedule")));
 
     /* initalize */
     round_a.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 7*32, prev_output.rbegin() + 8*32));
@@ -52,23 +52,23 @@ sha256_compression_function_gadget<FieldT>::sha256_compression_function_gadget(p
         round_b.push_back(round_a[i]);
 
         pb_variable_array<FieldT> new_round_a_variables;
-        new_round_a_variables.allocate(pb, 32, libff::FMT(this->annotation_prefix, " new_round_a_variables_%zu", i+1));
+        new_round_a_variables.allocate(pb, 32, FMT(this->annotation_prefix, " new_round_a_variables_%zu", i+1));
         round_a.emplace_back(new_round_a_variables);
 
         pb_variable_array<FieldT> new_round_e_variables;
-        new_round_e_variables.allocate(pb, 32, libff::FMT(this->annotation_prefix, " new_round_e_variables_%zu", i+1));
+        new_round_e_variables.allocate(pb, 32, FMT(this->annotation_prefix, " new_round_e_variables_%zu", i+1));
         round_e.emplace_back(new_round_e_variables);
 
         round_functions.push_back(sha256_round_function_gadget<FieldT>(pb,
                                                                        round_a[i], round_b[i], round_c[i], round_d[i],
                                                                        round_e[i], round_f[i], round_g[i], round_h[i],
                                                                        packed_W[i], SHA256_K[i], round_a[i+1], round_e[i+1],
-                                                                       libff::FMT(this->annotation_prefix, " round_functions_%zu", i)));
+                                                                       FMT(this->annotation_prefix, " round_functions_%zu", i)));
     }
 
     /* finalize */
-    unreduced_output.allocate(pb, 8, libff::FMT(this->annotation_prefix, " unreduced_output"));
-    reduced_output.allocate(pb, 8, libff::FMT(this->annotation_prefix, " reduced_output"));
+    unreduced_output.allocate(pb, 8, FMT(this->annotation_prefix, " unreduced_output"));
+    reduced_output.allocate(pb, 8, FMT(this->annotation_prefix, " reduced_output"));
     for (size_t i = 0; i < 8; ++i)
     {
         reduce_output.push_back(lastbits_gadget<FieldT>(pb,
@@ -76,7 +76,7 @@ sha256_compression_function_gadget<FieldT>::sha256_compression_function_gadget(p
                                                         32+1,
                                                         reduced_output[i],
                                                         pb_variable_array<FieldT>(output.bits.rbegin() + (7-i) * 32, output.bits.rbegin() + (8-i) * 32),
-                                                        libff::FMT(this->annotation_prefix, " reduce_output_%zu", i)));
+                                                        FMT(this->annotation_prefix, " reduce_output_%zu", i)));
     }
 }
 
@@ -94,12 +94,12 @@ void sha256_compression_function_gadget<FieldT>::generate_r1cs_constraints()
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
                                                              round_functions[3-i].packed_d + round_functions[63-i].packed_new_a,
                                                              unreduced_output[i]),
-            libff::FMT(this->annotation_prefix, " unreduced_output_%zu", i));
+            FMT(this->annotation_prefix, " unreduced_output_%zu", i));
 
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1,
                                                              round_functions[3-i].packed_h + round_functions[63-i].packed_new_e,
                                                              unreduced_output[4+i]),
-            libff::FMT(this->annotation_prefix, " unreduced_output_%zu", 4+i));
+            FMT(this->annotation_prefix, " unreduced_output_%zu", 4+i));
     }
 
     for (size_t i = 0; i < 8; ++i)
@@ -162,7 +162,7 @@ sha256_two_to_one_hash_gadget<FieldT>::sha256_two_to_one_hash_gadget(protoboard<
     block.insert(block.end(), right.bits.begin(), right.bits.end());
 
     /* compute the hash itself */
-    f.reset(new sha256_compression_function_gadget<FieldT>(pb, SHA256_default_IV<FieldT>(pb), block, output, libff::FMT(this->annotation_prefix, " f")));
+    f.reset(new sha256_compression_function_gadget<FieldT>(pb, SHA256_default_IV<FieldT>(pb), block, output, FMT(this->annotation_prefix, " f")));
 }
 
 template<typename FieldT>
@@ -175,7 +175,7 @@ sha256_two_to_one_hash_gadget<FieldT>::sha256_two_to_one_hash_gadget(protoboard<
 {
     assert(block_length == SHA256_block_size);
     assert(input_block.bits.size() == block_length);
-    f.reset(new sha256_compression_function_gadget<FieldT>(pb, SHA256_default_IV<FieldT>(pb), input_block.bits, output, libff::FMT(this->annotation_prefix, " f")));
+    f.reset(new sha256_compression_function_gadget<FieldT>(pb, SHA256_default_IV<FieldT>(pb), input_block.bits, output, FMT(this->annotation_prefix, " f")));
 }
 
 template<typename FieldT>

--- a/src/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.tcc
+++ b/src/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.tcc
@@ -19,8 +19,8 @@ merkle_authentication_path_variable<FieldT, HashT>::merkle_authentication_path_v
 {
     for (size_t i = 0; i < tree_depth; ++i)
     {
-        left_digests.emplace_back(digest_variable<FieldT>(pb, HashT::get_digest_len(), libff::FMT(annotation_prefix, " left_digests_%zu", i)));
-        right_digests.emplace_back(digest_variable<FieldT>(pb, HashT::get_digest_len(), libff::FMT(annotation_prefix, " right_digests_%zu", i)));
+        left_digests.emplace_back(digest_variable<FieldT>(pb, HashT::get_digest_len(), FMT(annotation_prefix, " left_digests_%zu", i)));
+        right_digests.emplace_back(digest_variable<FieldT>(pb, HashT::get_digest_len(), FMT(annotation_prefix, " right_digests_%zu", i)));
     }
 }
 

--- a/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.tcc
+++ b/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.tcc
@@ -48,17 +48,17 @@ merkle_tree_check_read_gadget<FieldT, HashT>::merkle_tree_check_read_gadget(prot
 
     for (size_t i = 0; i < tree_depth-1; ++i)
     {
-        internal_output.emplace_back(digest_variable<FieldT>(pb, digest_size, libff::FMT(this->annotation_prefix, " internal_output_%zu", i)));
+        internal_output.emplace_back(digest_variable<FieldT>(pb, digest_size, FMT(this->annotation_prefix, " internal_output_%zu", i)));
     }
 
-    computed_root.reset(new digest_variable<FieldT>(pb, digest_size, libff::FMT(this->annotation_prefix, " computed_root")));
+    computed_root.reset(new digest_variable<FieldT>(pb, digest_size, FMT(this->annotation_prefix, " computed_root")));
 
     for (size_t i = 0; i < tree_depth; ++i)
     {
-        block_variable<FieldT> inp(pb, path.left_digests[i], path.right_digests[i], libff::FMT(this->annotation_prefix, " inp_%zu", i));
+        block_variable<FieldT> inp(pb, path.left_digests[i], path.right_digests[i], FMT(this->annotation_prefix, " inp_%zu", i));
         hasher_inputs.emplace_back(inp);
         hashers.emplace_back(HashT(pb, 2*digest_size, inp, (i == 0 ? *computed_root : internal_output[i-1]),
-                                   libff::FMT(this->annotation_prefix, " load_hashers_%zu", i)));
+                                   FMT(this->annotation_prefix, " load_hashers_%zu", i)));
     }
 
     for (size_t i = 0; i < tree_depth; ++i)
@@ -70,10 +70,10 @@ merkle_tree_check_read_gadget<FieldT, HashT>::merkle_tree_check_read_gadget(prot
         */
         propagators.emplace_back(digest_selector_gadget<FieldT>(pb, digest_size, i < tree_depth - 1 ? internal_output[i] : leaf,
                                                                 address_bits[tree_depth-1-i], path.left_digests[i], path.right_digests[i],
-                                                                libff::FMT(this->annotation_prefix, " digest_selector_%zu", i)));
+                                                                FMT(this->annotation_prefix, " digest_selector_%zu", i)));
     }
 
-    check_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_root->bits, root.bits, read_successful, FieldT::capacity(), libff::FMT(annotation_prefix, " check_root")));
+    check_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_root->bits, root.bits, read_successful, FieldT::capacity(), FMT(annotation_prefix, " check_root")));
 }
 
 template<typename FieldT, typename HashT>

--- a/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.tcc
+++ b/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.tcc
@@ -45,36 +45,36 @@ merkle_tree_check_update_gadget<FieldT, HashT>::merkle_tree_check_update_gadget(
 
     for (size_t i = 0; i < tree_depth-1; ++i)
     {
-        prev_internal_output.emplace_back(digest_variable<FieldT>(pb, digest_size, libff::FMT(this->annotation_prefix, " prev_internal_output_%zu", i)));
-        next_internal_output.emplace_back(digest_variable<FieldT>(pb, digest_size, libff::FMT(this->annotation_prefix, " next_internal_output_%zu", i)));
+        prev_internal_output.emplace_back(digest_variable<FieldT>(pb, digest_size, FMT(this->annotation_prefix, " prev_internal_output_%zu", i)));
+        next_internal_output.emplace_back(digest_variable<FieldT>(pb, digest_size, FMT(this->annotation_prefix, " next_internal_output_%zu", i)));
     }
 
-    computed_next_root.reset(new digest_variable<FieldT>(pb, digest_size, libff::FMT(this->annotation_prefix, " computed_root")));
+    computed_next_root.reset(new digest_variable<FieldT>(pb, digest_size, FMT(this->annotation_prefix, " computed_root")));
 
     for (size_t i = 0; i < tree_depth; ++i)
     {
-        block_variable<FieldT> prev_inp(pb, prev_path.left_digests[i], prev_path.right_digests[i], libff::FMT(this->annotation_prefix, " prev_inp_%zu", i));
+        block_variable<FieldT> prev_inp(pb, prev_path.left_digests[i], prev_path.right_digests[i], FMT(this->annotation_prefix, " prev_inp_%zu", i));
         prev_hasher_inputs.emplace_back(prev_inp);
         prev_hashers.emplace_back(HashT(pb, 2*digest_size, prev_inp, (i == 0 ? prev_root_digest : prev_internal_output[i-1]),
-                                                                  libff::FMT(this->annotation_prefix, " prev_hashers_%zu", i)));
+                                                                  FMT(this->annotation_prefix, " prev_hashers_%zu", i)));
 
-        block_variable<FieldT> next_inp(pb, next_path.left_digests[i], next_path.right_digests[i], libff::FMT(this->annotation_prefix, " next_inp_%zu", i));
+        block_variable<FieldT> next_inp(pb, next_path.left_digests[i], next_path.right_digests[i], FMT(this->annotation_prefix, " next_inp_%zu", i));
         next_hasher_inputs.emplace_back(next_inp);
         next_hashers.emplace_back(HashT(pb, 2*digest_size, next_inp, (i == 0 ? *computed_next_root : next_internal_output[i-1]),
-                                                                  libff::FMT(this->annotation_prefix, " next_hashers_%zu", i)));
+                                                                  FMT(this->annotation_prefix, " next_hashers_%zu", i)));
     }
 
     for (size_t i = 0; i < tree_depth; ++i)
     {
         prev_propagators.emplace_back(digest_selector_gadget<FieldT>(pb, digest_size, i < tree_depth -1 ? prev_internal_output[i] : prev_leaf_digest,
                                                                      address_bits[tree_depth-1-i], prev_path.left_digests[i], prev_path.right_digests[i],
-                                                                     libff::FMT(this->annotation_prefix, " prev_propagators_%zu", i)));
+                                                                     FMT(this->annotation_prefix, " prev_propagators_%zu", i)));
         next_propagators.emplace_back(digest_selector_gadget<FieldT>(pb, digest_size, i < tree_depth -1 ? next_internal_output[i] : next_leaf_digest,
                                                                      address_bits[tree_depth-1-i], next_path.left_digests[i], next_path.right_digests[i],
-                                                                     libff::FMT(this->annotation_prefix, " next_propagators_%zu", i)));
+                                                                     FMT(this->annotation_prefix, " next_propagators_%zu", i)));
     }
 
-    check_next_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_next_root->bits, next_root_digest.bits, update_successful, FieldT::capacity(), libff::FMT(annotation_prefix, " check_next_root")));
+    check_next_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_next_root->bits, next_root_digest.bits, update_successful, FieldT::capacity(), FMT(annotation_prefix, " check_next_root")));
 }
 
 template<typename FieldT, typename HashT>
@@ -106,7 +106,7 @@ void merkle_tree_check_update_gadget<FieldT, HashT>::generate_r1cs_constraints()
             this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(address_bits[tree_depth-1-i],
                                                                  prev_path.left_digests[i].bits[j] - next_path.left_digests[i].bits[j] - prev_path.right_digests[i].bits[j] + next_path.right_digests[i].bits[j],
                                                                  next_path.right_digests[i].bits[j] - prev_path.right_digests[i].bits[j]),
-                                         libff::FMT(this->annotation_prefix, " aux_check_%zu_%zu", i, j));
+                                         FMT(this->annotation_prefix, " aux_check_%zu_%zu", i, j));
         }
     }
 

--- a/src/gadgetlib1/gadgets/pairing/pairing_checks.tcc
+++ b/src/gadgetlib1/gadgets/pairing/pairing_checks.tcc
@@ -31,9 +31,9 @@ check_e_equals_e_gadget<ppT>::check_e_equals_e_gadget(protoboard<FieldT> &pb,
     rhs_G2(rhs_G2),
     result(result)
 {
-    ratio.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " ratio")));
-    compute_ratio.reset(new e_over_e_miller_loop_gadget<ppT>(pb, lhs_G1, lhs_G2, rhs_G1, rhs_G2, *ratio, libff::FMT(annotation_prefix, " compute_ratio")));
-    check_finexp.reset(new final_exp_gadget<ppT>(pb, *ratio, result, libff::FMT(annotation_prefix, " check_finexp")));
+    ratio.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " ratio")));
+    compute_ratio.reset(new e_over_e_miller_loop_gadget<ppT>(pb, lhs_G1, lhs_G2, rhs_G1, rhs_G2, *ratio, FMT(annotation_prefix, " compute_ratio")));
+    check_finexp.reset(new final_exp_gadget<ppT>(pb, *ratio, result, FMT(annotation_prefix, " check_finexp")));
 }
 
 template<typename ppT>
@@ -69,9 +69,9 @@ check_e_equals_ee_gadget<ppT>::check_e_equals_ee_gadget(protoboard<FieldT> &pb,
     rhs2_G2(rhs2_G2),
     result(result)
 {
-    ratio.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " ratio")));
-    compute_ratio.reset(new e_times_e_over_e_miller_loop_gadget<ppT>(pb, rhs1_G1, rhs1_G2, rhs2_G1, rhs2_G2, lhs_G1, lhs_G2, *ratio, libff::FMT(annotation_prefix, " compute_ratio")));
-    check_finexp.reset(new final_exp_gadget<ppT>(pb, *ratio, result, libff::FMT(annotation_prefix, " check_finexp")));
+    ratio.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " ratio")));
+    compute_ratio.reset(new e_times_e_over_e_miller_loop_gadget<ppT>(pb, rhs1_G1, rhs1_G2, rhs2_G1, rhs2_G2, lhs_G1, lhs_G2, *ratio, FMT(annotation_prefix, " compute_ratio")));
+    check_finexp.reset(new final_exp_gadget<ppT>(pb, *ratio, result, FMT(annotation_prefix, " check_finexp")));
 }
 
 template<typename ppT>

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.tcc
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.tcc
@@ -28,36 +28,36 @@ mnt4_final_exp_gadget<ppT>::mnt4_final_exp_gadget(protoboard<FieldT> &pb,
     el(el),
     result_is_one(result_is_one)
 {
-    one.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " one")));
-    el_inv.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " el_inv")));
+    one.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " one")));
+    el_inv.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " el_inv")));
     el_q_3.reset(new Fqk_variable<ppT>(el.Frobenius_map(3)));
-    el_q_3_minus_1.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " el_q_3_minus_1")));
+    el_q_3_minus_1.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " el_q_3_minus_1")));
     alpha.reset(new Fqk_variable<ppT>(el_q_3_minus_1->Frobenius_map(1)));
-    beta.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " beta")));
+    beta.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " beta")));
     beta_q.reset(new Fqk_variable<ppT>(beta->Frobenius_map(1)));
 
     el_inv_q_3.reset(new Fqk_variable<ppT>(el_inv->Frobenius_map(3)));
-    el_inv_q_3_minus_1.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " el_inv_q_3_minus_1")));
+    el_inv_q_3_minus_1.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " el_inv_q_3_minus_1")));
     inv_alpha.reset(new Fqk_variable<ppT>(el_inv_q_3_minus_1->Frobenius_map(1)));
-    inv_beta.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " inv_beta")));
-    w1.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " w1")));
-    w0.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " w0")));
-    result.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " result")));
+    inv_beta.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " inv_beta")));
+    w1.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " w1")));
+    w0.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " w0")));
+    result.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " result")));
 
-    compute_el_inv.reset(new Fqk_mul_gadget<ppT>(pb, el, *el_inv, *one, libff::FMT(annotation_prefix, " compute_el_inv")));
-    compute_el_q_3_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_q_3, *el_inv, *el_q_3_minus_1, libff::FMT(annotation_prefix, " compute_el_q_3_minus_1")));
-    compute_beta.reset(new Fqk_mul_gadget<ppT>(pb, *alpha, *el_q_3_minus_1, *beta, libff::FMT(annotation_prefix, " compute_beta")));
+    compute_el_inv.reset(new Fqk_mul_gadget<ppT>(pb, el, *el_inv, *one, FMT(annotation_prefix, " compute_el_inv")));
+    compute_el_q_3_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_q_3, *el_inv, *el_q_3_minus_1, FMT(annotation_prefix, " compute_el_q_3_minus_1")));
+    compute_beta.reset(new Fqk_mul_gadget<ppT>(pb, *alpha, *el_q_3_minus_1, *beta, FMT(annotation_prefix, " compute_beta")));
 
-    compute_el_inv_q_3_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_inv_q_3, el, *el_inv_q_3_minus_1, libff::FMT(annotation_prefix, " compute_el_inv__q_3_minus_1")));
-    compute_inv_beta.reset(new Fqk_mul_gadget<ppT>(pb, *inv_alpha, *el_inv_q_3_minus_1, *inv_beta, libff::FMT(annotation_prefix, " compute_inv_beta")));
+    compute_el_inv_q_3_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_inv_q_3, el, *el_inv_q_3_minus_1, FMT(annotation_prefix, " compute_el_inv__q_3_minus_1")));
+    compute_inv_beta.reset(new Fqk_mul_gadget<ppT>(pb, *inv_alpha, *el_inv_q_3_minus_1, *inv_beta, FMT(annotation_prefix, " compute_inv_beta")));
 
     compute_w1.reset(new exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, libff::mnt6_q_limbs>(
-        pb, *beta_q, libff::mnt6_final_exponent_last_chunk_w1, *w1, libff::FMT(annotation_prefix, " compute_w1")));
+        pb, *beta_q, libff::mnt6_final_exponent_last_chunk_w1, *w1, FMT(annotation_prefix, " compute_w1")));
 
     compute_w0.reset(new exponentiation_gadget<FqkT<ppT>, Fp6_variable, Fp6_mul_gadget, Fp6_cyclotomic_sqr_gadget, libff::mnt6_q_limbs>(
-        pb, (libff::mnt6_final_exponent_last_chunk_is_w0_neg ? *inv_beta : *beta), libff::mnt6_final_exponent_last_chunk_abs_of_w0, *w0, libff::FMT(annotation_prefix, " compute_w0")));
+        pb, (libff::mnt6_final_exponent_last_chunk_is_w0_neg ? *inv_beta : *beta), libff::mnt6_final_exponent_last_chunk_abs_of_w0, *w0, FMT(annotation_prefix, " compute_w0")));
 
-    compute_result.reset(new Fqk_mul_gadget<ppT>(pb, *w1, *w0, *result, libff::FMT(annotation_prefix, " compute_result")));
+    compute_result.reset(new Fqk_mul_gadget<ppT>(pb, *w1, *w0, *result, FMT(annotation_prefix, " compute_result")));
 }
 
 template<typename ppT>
@@ -76,7 +76,7 @@ void mnt4_final_exp_gadget<ppT>::generate_r1cs_constraints()
     compute_w1->generate_r1cs_constraints();
     compute_result->generate_r1cs_constraints();
 
-    generate_boolean_r1cs_constraint<FieldT>(this->pb, result_is_one, libff::FMT(this->annotation_prefix, " result_is_one"));
+    generate_boolean_r1cs_constraint<FieldT>(this->pb, result_is_one, FMT(this->annotation_prefix, " result_is_one"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(result_is_one, 1 - result->c0.c0, 0), " check c0.c0");
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(result_is_one, result->c0.c1, 0), " check c0.c1");
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(result_is_one, result->c0.c2, 0), " check c0.c2");
@@ -119,26 +119,26 @@ mnt6_final_exp_gadget<ppT>::mnt6_final_exp_gadget(protoboard<FieldT> &pb,
     el(el),
     result_is_one(result_is_one)
 {
-    one.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " one")));
-    el_inv.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " el_inv")));
+    one.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " one")));
+    el_inv.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " el_inv")));
     el_q_2.reset(new Fqk_variable<ppT>(el.Frobenius_map(2)));
-    el_q_2_minus_1.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " el_q_2_minus_1")));
+    el_q_2_minus_1.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " el_q_2_minus_1")));
     el_q_3_minus_q.reset(new Fqk_variable<ppT>(el_q_2_minus_1->Frobenius_map(1)));
     el_inv_q_2.reset(new Fqk_variable<ppT>(el_inv->Frobenius_map(2)));
-    el_inv_q_2_minus_1.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " el_inv_q_2_minus_1")));
-    w1.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " w1")));
-    w0.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " w0")));
-    result.reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " result")));
+    el_inv_q_2_minus_1.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " el_inv_q_2_minus_1")));
+    w1.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " w1")));
+    w0.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " w0")));
+    result.reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " result")));
 
-    compute_el_inv.reset(new Fqk_mul_gadget<ppT>(pb, el, *el_inv, *one, libff::FMT(annotation_prefix, " compute_el_inv")));
-    compute_el_q_2_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_q_2, *el_inv, *el_q_2_minus_1, libff::FMT(annotation_prefix, " compute_el_q_2_minus_1")));
-    compute_el_inv_q_2_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_inv_q_2, el, *el_inv_q_2_minus_1, libff::FMT(annotation_prefix, " compute_el_inv_q_2_minus_1")));
+    compute_el_inv.reset(new Fqk_mul_gadget<ppT>(pb, el, *el_inv, *one, FMT(annotation_prefix, " compute_el_inv")));
+    compute_el_q_2_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_q_2, *el_inv, *el_q_2_minus_1, FMT(annotation_prefix, " compute_el_q_2_minus_1")));
+    compute_el_inv_q_2_minus_1.reset(new Fqk_mul_gadget<ppT>(pb, *el_inv_q_2, el, *el_inv_q_2_minus_1, FMT(annotation_prefix, " compute_el_inv_q_2_minus_1")));
 
     compute_w1.reset(new exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, libff::mnt4_q_limbs>(
-        pb, *el_q_3_minus_q, libff::mnt4_final_exponent_last_chunk_w1, *w1, libff::FMT(annotation_prefix, " compute_w1")));
+        pb, *el_q_3_minus_q, libff::mnt4_final_exponent_last_chunk_w1, *w1, FMT(annotation_prefix, " compute_w1")));
     compute_w0.reset(new exponentiation_gadget<FqkT<ppT>, Fp4_variable, Fp4_mul_gadget, Fp4_cyclotomic_sqr_gadget, libff::mnt4_q_limbs>(
-        pb, (libff::mnt4_final_exponent_last_chunk_is_w0_neg ? *el_inv_q_2_minus_1 : *el_q_2_minus_1), libff::mnt4_final_exponent_last_chunk_abs_of_w0, *w0, libff::FMT(annotation_prefix, " compute_w0")));
-    compute_result.reset(new Fqk_mul_gadget<ppT>(pb, *w1, *w0, *result, libff::FMT(annotation_prefix, " compute_result")));
+        pb, (libff::mnt4_final_exponent_last_chunk_is_w0_neg ? *el_inv_q_2_minus_1 : *el_q_2_minus_1), libff::mnt4_final_exponent_last_chunk_abs_of_w0, *w0, FMT(annotation_prefix, " compute_w0")));
+    compute_result.reset(new Fqk_mul_gadget<ppT>(pb, *w1, *w0, *result, FMT(annotation_prefix, " compute_result")));
 }
 
 template<typename ppT>
@@ -153,7 +153,7 @@ void mnt6_final_exp_gadget<ppT>::generate_r1cs_constraints()
     compute_w0->generate_r1cs_constraints();
     compute_result->generate_r1cs_constraints();
 
-    generate_boolean_r1cs_constraint<FieldT>(this->pb, result_is_one, libff::FMT(this->annotation_prefix, " result_is_one"));
+    generate_boolean_r1cs_constraint<FieldT>(this->pb, result_is_one, FMT(this->annotation_prefix, " result_is_one"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(result_is_one, 1 - result->c0.c0, 0), " check c0.c0");
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(result_is_one, result->c0.c1, 0), " check c0.c1");
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(result_is_one, result->c1.c0, 0), " check c1.c0");

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.tcc
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.tcc
@@ -44,7 +44,7 @@ mnt_miller_loop_dbl_line_eval<ppT>::mnt_miller_loop_dbl_line_eval(protoboard<Fie
     {
         gamma_twist->evaluate();
         const FqeT gamma_twist_const = gamma_twist->get_element();
-        g_RR_at_P_c1.reset(new Fqe_variable<ppT>(Fqe_variable<ppT>(this->pb, -gamma_twist_const, prec_P.P->X, libff::FMT(annotation_prefix, " tmp")) +
+        g_RR_at_P_c1.reset(new Fqe_variable<ppT>(Fqe_variable<ppT>(this->pb, -gamma_twist_const, prec_P.P->X, FMT(annotation_prefix, " tmp")) +
                                                  *(c.gamma_X) + *(c.RY) * (-FieldT::one())));
     }
     else if (prec_P.P->X.is_constant())
@@ -55,12 +55,12 @@ mnt_miller_loop_dbl_line_eval<ppT>::mnt_miller_loop_dbl_line_eval(protoboard<Fie
     }
     else
     {
-        g_RR_at_P_c1.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_RR_at_P_c1")));
+        g_RR_at_P_c1.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " g_RR_at_P_c1")));
         compute_g_RR_at_P_c1.reset(new Fqe_mul_by_lc_gadget<ppT>(pb, *gamma_twist, prec_P.P->X,
                                                                  *(c.gamma_X) + *(c.RY) * (-FieldT::one()) + (*g_RR_at_P_c1) * (-FieldT::one()),
-                                                                 libff::FMT(annotation_prefix, " compute_g_RR_at_P_c1")));
+                                                                 FMT(annotation_prefix, " compute_g_RR_at_P_c1")));
     }
-    g_RR_at_P.reset(new Fqk_variable<ppT>(pb, *(prec_P.PY_twist_squared), *g_RR_at_P_c1, libff::FMT(annotation_prefix, " g_RR_at_P")));
+    g_RR_at_P.reset(new Fqk_variable<ppT>(pb, *(prec_P.PY_twist_squared), *g_RR_at_P_c1, FMT(annotation_prefix, " g_RR_at_P")));
 }
 
 template<typename ppT>
@@ -117,7 +117,7 @@ gadget<FieldT>(pb, annotation_prefix), invert_Q(invert_Q), prec_P(prec_P), c(c),
     {
         gamma_twist->evaluate();
         const FqeT gamma_twist_const = gamma_twist->get_element();
-        g_RQ_at_P_c1.reset(new Fqe_variable<ppT>(Fqe_variable<ppT>(this->pb, -gamma_twist_const, prec_P.P->X, libff::FMT(annotation_prefix, " tmp")) +
+        g_RQ_at_P_c1.reset(new Fqe_variable<ppT>(Fqe_variable<ppT>(this->pb, -gamma_twist_const, prec_P.P->X, FMT(annotation_prefix, " tmp")) +
                                                  *(c.gamma_X) + *(Q.Y) * (!invert_Q ? -FieldT::one() : FieldT::one())));
     }
     else if (prec_P.P->X.is_constant())
@@ -128,12 +128,12 @@ gadget<FieldT>(pb, annotation_prefix), invert_Q(invert_Q), prec_P(prec_P), c(c),
     }
     else
     {
-        g_RQ_at_P_c1.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_RQ_at_Q_c1")));
+        g_RQ_at_P_c1.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " g_RQ_at_Q_c1")));
         compute_g_RQ_at_P_c1.reset(new Fqe_mul_by_lc_gadget<ppT>(pb, *gamma_twist, prec_P.P->X,
                                                                  *(c.gamma_X) + *(Q.Y) * (!invert_Q ? -FieldT::one() : FieldT::one()) + (*g_RQ_at_P_c1) * (-FieldT::one()),
-                                                                 libff::FMT(annotation_prefix, " compute_g_RQ_at_P_c1")));
+                                                                 FMT(annotation_prefix, " compute_g_RQ_at_P_c1")));
     }
-    g_RQ_at_P.reset(new Fqk_variable<ppT>(pb, *(prec_P.PY_twist_squared), *g_RQ_at_P_c1, libff::FMT(annotation_prefix, " g_RQ_at_P")));
+    g_RQ_at_P.reset(new Fqk_variable<ppT>(pb, *(prec_P.PY_twist_squared), *g_RQ_at_P_c1, FMT(annotation_prefix, " g_RQ_at_P")));
 }
 
 template<typename ppT>
@@ -204,7 +204,7 @@ mnt_miller_loop_gadget<ppT>::mnt_miller_loop_gadget(protoboard<FieldT> &pb,
 
     for (size_t i = 0; i < f_count; ++i)
     {
-        fs[i].reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " fs_%zu", i)));
+        fs[i].reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " fs_%zu", i)));
     }
 
     dbl_sqrs.resize(dbl_count);
@@ -229,11 +229,11 @@ mnt_miller_loop_gadget<ppT>::mnt_miller_loop_gadget(protoboard<FieldT> &pb,
         doubling_steps[dbl_id].reset(new mnt_miller_loop_dbl_line_eval<ppT>(pb,
                                                                             prec_P, *prec_Q.coeffs[prec_id],
                                                                             g_RR_at_Ps[dbl_id],
-                                                                            libff::FMT(annotation_prefix, " doubling_steps_%zu", dbl_id)));
+                                                                            FMT(annotation_prefix, " doubling_steps_%zu", dbl_id)));
         ++prec_id;
-        dbl_sqrs[dbl_id].reset(new Fqk_sqr_gadget<ppT>(pb, *fs[f_id], *fs[f_id+1], libff::FMT(annotation_prefix, " dbl_sqrs_%zu", dbl_id)));
+        dbl_sqrs[dbl_id].reset(new Fqk_sqr_gadget<ppT>(pb, *fs[f_id], *fs[f_id+1], FMT(annotation_prefix, " dbl_sqrs_%zu", dbl_id)));
         ++f_id;
-        dbl_muls[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_Ps[dbl_id], (f_id + 1 == f_count ? result : *fs[f_id+1]), libff::FMT(annotation_prefix, " dbl_muls_%zu", dbl_id)));
+        dbl_muls[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_Ps[dbl_id], (f_id + 1 == f_count ? result : *fs[f_id+1]), FMT(annotation_prefix, " dbl_muls_%zu", dbl_id)));
         ++f_id;
         ++dbl_id;
 
@@ -243,9 +243,9 @@ mnt_miller_loop_gadget<ppT>::mnt_miller_loop_gadget(protoboard<FieldT> &pb,
                                                                                 NAF[i] < 0,
                                                                                 prec_P, *prec_Q.coeffs[prec_id], *prec_Q.Q,
                                                                                 g_RQ_at_Ps[add_id],
-                                                                                libff::FMT(annotation_prefix, " addition_steps_%zu", add_id)));
+                                                                                FMT(annotation_prefix, " addition_steps_%zu", add_id)));
             ++prec_id;
-            add_muls[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_Ps[add_id], (f_id + 1 == f_count ? result : *fs[f_id+1]), libff::FMT(annotation_prefix, " add_muls_%zu", add_id)));
+            add_muls[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_Ps[add_id], (f_id + 1 == f_count ? result : *fs[f_id+1]), FMT(annotation_prefix, " add_muls_%zu", add_id)));
             ++f_id;
             ++add_id;
         }
@@ -401,7 +401,7 @@ gadget<FieldT>(pb, annotation_prefix), prec_P1(prec_P1), prec_Q1(prec_Q1), prec_
 
     for (size_t i = 0; i < f_count; ++i)
     {
-        fs[i].reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " fs_%zu", i)));
+        fs[i].reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " fs_%zu", i)));
     }
 
     dbl_sqrs.resize(dbl_count);
@@ -428,18 +428,18 @@ gadget<FieldT>(pb, annotation_prefix), prec_P1(prec_P1), prec_Q1(prec_Q1), prec_
         doubling_steps1[dbl_id].reset(new mnt_miller_loop_dbl_line_eval<ppT>(pb,
                                                                              prec_P1, *prec_Q1.coeffs[prec_id],
                                                                              g_RR_at_P1s[dbl_id],
-                                                                             libff::FMT(annotation_prefix, " doubling_steps1_%zu", dbl_id)));
+                                                                             FMT(annotation_prefix, " doubling_steps1_%zu", dbl_id)));
         doubling_steps2[dbl_id].reset(new mnt_miller_loop_dbl_line_eval<ppT>(pb,
                                                                              prec_P2, *prec_Q2.coeffs[prec_id],
                                                                              g_RR_at_P2s[dbl_id],
-                                                                             libff::FMT(annotation_prefix, " doubling_steps2_%zu", dbl_id)));
+                                                                             FMT(annotation_prefix, " doubling_steps2_%zu", dbl_id)));
         ++prec_id;
 
-        dbl_sqrs[dbl_id].reset(new Fqk_sqr_gadget<ppT>(pb, *fs[f_id], *fs[f_id+1], libff::FMT(annotation_prefix, " dbl_sqrs_%zu", dbl_id)));
+        dbl_sqrs[dbl_id].reset(new Fqk_sqr_gadget<ppT>(pb, *fs[f_id], *fs[f_id+1], FMT(annotation_prefix, " dbl_sqrs_%zu", dbl_id)));
         ++f_id;
-        dbl_muls1[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_P1s[dbl_id], *fs[f_id+1], libff::FMT(annotation_prefix, " dbl_mul1s_%zu", dbl_id)));
+        dbl_muls1[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_P1s[dbl_id], *fs[f_id+1], FMT(annotation_prefix, " dbl_mul1s_%zu", dbl_id)));
         ++f_id;
-        dbl_muls2[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RR_at_P2s[dbl_id], *fs[f_id], libff::FMT(annotation_prefix, " dbl_mul2s_%zu", dbl_id)));
+        dbl_muls2[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RR_at_P2s[dbl_id], *fs[f_id], FMT(annotation_prefix, " dbl_mul2s_%zu", dbl_id)));
         ++f_id;
         ++dbl_id;
 
@@ -449,16 +449,16 @@ gadget<FieldT>(pb, annotation_prefix), prec_P1(prec_P1), prec_Q1(prec_Q1), prec_
                                                                                  NAF[i] < 0,
                                                                                  prec_P1, *prec_Q1.coeffs[prec_id], *prec_Q1.Q,
                                                                                  g_RQ_at_P1s[add_id],
-                                                                                 libff::FMT(annotation_prefix, " addition_steps1_%zu", add_id)));
+                                                                                 FMT(annotation_prefix, " addition_steps1_%zu", add_id)));
             addition_steps2[add_id].reset(new mnt_miller_loop_add_line_eval<ppT>(pb,
                                                                                  NAF[i] < 0,
                                                                                  prec_P2, *prec_Q2.coeffs[prec_id], *prec_Q2.Q,
                                                                                  g_RQ_at_P2s[add_id],
-                                                                                 libff::FMT(annotation_prefix, " addition_steps2_%zu", add_id)));
+                                                                                 FMT(annotation_prefix, " addition_steps2_%zu", add_id)));
             ++prec_id;
-            add_muls1[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_P1s[add_id], *fs[f_id+1], libff::FMT(annotation_prefix, " add_mul1s_%zu", add_id)));
+            add_muls1[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_P1s[add_id], *fs[f_id+1], FMT(annotation_prefix, " add_mul1s_%zu", add_id)));
             ++f_id;
-            add_muls2[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RQ_at_P2s[add_id], *fs[f_id], libff::FMT(annotation_prefix, " add_mul2s_%zu", add_id)));
+            add_muls2[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RQ_at_P2s[add_id], *fs[f_id], FMT(annotation_prefix, " add_mul2s_%zu", add_id)));
             ++f_id;
             ++add_id;
         }
@@ -653,7 +653,7 @@ gadget<FieldT>(pb, annotation_prefix), prec_P1(prec_P1), prec_Q1(prec_Q1), prec_
 
     for (size_t i = 0; i < f_count; ++i)
     {
-        fs[i].reset(new Fqk_variable<ppT>(pb, libff::FMT(annotation_prefix, " fs_%zu", i)));
+        fs[i].reset(new Fqk_variable<ppT>(pb, FMT(annotation_prefix, " fs_%zu", i)));
     }
 
     dbl_sqrs.resize(dbl_count);
@@ -682,24 +682,24 @@ gadget<FieldT>(pb, annotation_prefix), prec_P1(prec_P1), prec_Q1(prec_Q1), prec_
         doubling_steps1[dbl_id].reset(new mnt_miller_loop_dbl_line_eval<ppT>(pb,
                                                                              prec_P1, *prec_Q1.coeffs[prec_id],
                                                                              g_RR_at_P1s[dbl_id],
-                                                                             libff::FMT(annotation_prefix, " doubling_steps1_%zu", dbl_id)));
+                                                                             FMT(annotation_prefix, " doubling_steps1_%zu", dbl_id)));
         doubling_steps2[dbl_id].reset(new mnt_miller_loop_dbl_line_eval<ppT>(pb,
                                                                              prec_P2, *prec_Q2.coeffs[prec_id],
                                                                              g_RR_at_P2s[dbl_id],
-                                                                             libff::FMT(annotation_prefix, " doubling_steps2_%zu", dbl_id)));
+                                                                             FMT(annotation_prefix, " doubling_steps2_%zu", dbl_id)));
         doubling_steps3[dbl_id].reset(new mnt_miller_loop_dbl_line_eval<ppT>(pb,
                                                                              prec_P3, *prec_Q3.coeffs[prec_id],
                                                                              g_RR_at_P3s[dbl_id],
-                                                                             libff::FMT(annotation_prefix, " doubling_steps3_%zu", dbl_id)));
+                                                                             FMT(annotation_prefix, " doubling_steps3_%zu", dbl_id)));
         ++prec_id;
 
-        dbl_sqrs[dbl_id].reset(new Fqk_sqr_gadget<ppT>(pb, *fs[f_id], *fs[f_id+1], libff::FMT(annotation_prefix, " dbl_sqrs_%zu", dbl_id)));
+        dbl_sqrs[dbl_id].reset(new Fqk_sqr_gadget<ppT>(pb, *fs[f_id], *fs[f_id+1], FMT(annotation_prefix, " dbl_sqrs_%zu", dbl_id)));
         ++f_id;
-        dbl_muls1[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_P1s[dbl_id], *fs[f_id+1], libff::FMT(annotation_prefix, " dbl_muls1_%zu", dbl_id)));
+        dbl_muls1[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_P1s[dbl_id], *fs[f_id+1], FMT(annotation_prefix, " dbl_muls1_%zu", dbl_id)));
         ++f_id;
-        dbl_muls2[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_P2s[dbl_id], *fs[f_id+1], libff::FMT(annotation_prefix, " dbl_muls2_%zu", dbl_id)));
+        dbl_muls2[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RR_at_P2s[dbl_id], *fs[f_id+1], FMT(annotation_prefix, " dbl_muls2_%zu", dbl_id)));
         ++f_id;
-        dbl_muls3[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RR_at_P3s[dbl_id], *fs[f_id], libff::FMT(annotation_prefix, " dbl_muls3_%zu", dbl_id)));
+        dbl_muls3[dbl_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RR_at_P3s[dbl_id], *fs[f_id], FMT(annotation_prefix, " dbl_muls3_%zu", dbl_id)));
         ++f_id;
         ++dbl_id;
 
@@ -709,23 +709,23 @@ gadget<FieldT>(pb, annotation_prefix), prec_P1(prec_P1), prec_Q1(prec_Q1), prec_
                                                                                  NAF[i] < 0,
                                                                                  prec_P1, *prec_Q1.coeffs[prec_id], *prec_Q1.Q,
                                                                                  g_RQ_at_P1s[add_id],
-                                                                                 libff::FMT(annotation_prefix, " addition_steps1_%zu", add_id)));
+                                                                                 FMT(annotation_prefix, " addition_steps1_%zu", add_id)));
             addition_steps2[add_id].reset(new mnt_miller_loop_add_line_eval<ppT>(pb,
                                                                                  NAF[i] < 0,
                                                                                  prec_P2, *prec_Q2.coeffs[prec_id], *prec_Q2.Q,
                                                                                  g_RQ_at_P2s[add_id],
-                                                                                 libff::FMT(annotation_prefix, " addition_steps2_%zu", add_id)));
+                                                                                 FMT(annotation_prefix, " addition_steps2_%zu", add_id)));
             addition_steps3[add_id].reset(new mnt_miller_loop_add_line_eval<ppT>(pb,
                                                                                  NAF[i] < 0,
                                                                                  prec_P3, *prec_Q3.coeffs[prec_id], *prec_Q3.Q,
                                                                                  g_RQ_at_P3s[add_id],
-                                                                                 libff::FMT(annotation_prefix, " addition_steps3_%zu", add_id)));
+                                                                                 FMT(annotation_prefix, " addition_steps3_%zu", add_id)));
             ++prec_id;
-            add_muls1[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_P1s[add_id], *fs[f_id+1], libff::FMT(annotation_prefix, " add_muls1_%zu", add_id)));
+            add_muls1[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_P1s[add_id], *fs[f_id+1], FMT(annotation_prefix, " add_muls1_%zu", add_id)));
             ++f_id;
-            add_muls2[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_P2s[add_id], *fs[f_id+1], libff::FMT(annotation_prefix, " add_muls2_%zu", add_id)));
+            add_muls2[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, *fs[f_id], *g_RQ_at_P2s[add_id], *fs[f_id+1], FMT(annotation_prefix, " add_muls2_%zu", add_id)));
             ++f_id;
-            add_muls3[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RQ_at_P3s[add_id], *fs[f_id], libff::FMT(annotation_prefix, " add_muls3_%zu", add_id)));
+            add_muls3[add_id].reset(new Fqk_special_mul_gadget<ppT>(pb, (f_id + 1 == f_count ? result : *fs[f_id+1]), *g_RQ_at_P3s[add_id], *fs[f_id], FMT(annotation_prefix, " add_muls3_%zu", add_id)));
             ++f_id;
             ++add_id;
         }

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp
@@ -68,7 +68,7 @@ public:
         c1.assign(pb, P.Y * ((libff::mnt4_twist).squared().c1));
 
         precomp.P.reset(new G1_variable<ppT>(P));
-        precomp.PY_twist_squared.reset(new Fqe_variable<ppT>(pb, c0, c1, libff::FMT(annotation_prefix, " PY_twist_squared")));
+        precomp.PY_twist_squared.reset(new Fqe_variable<ppT>(pb, c0, c1, FMT(annotation_prefix, " PY_twist_squared")));
     }
 
     template<typename FieldT>
@@ -86,7 +86,7 @@ public:
         c2.assign(pb, P.Y * ((libff::mnt6_twist).squared().c2));
 
         precomp.P.reset(new G1_variable<ppT>(P));
-        precomp.PY_twist_squared.reset(new Fqe_variable<ppT>(pb, c0, c1, c2, libff::FMT(annotation_prefix, " PY_twist_squared")));
+        precomp.PY_twist_squared.reset(new Fqe_variable<ppT>(pb, c0, c1, c2, FMT(annotation_prefix, " PY_twist_squared")));
     }
 
     void generate_r1cs_constraints();

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.tcc
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.tcc
@@ -32,7 +32,7 @@ G1_precomputation<ppT>::G1_precomputation(protoboard<FieldT> &pb,
 {
     libff::G1<other_curve<ppT> > P_val_copy = P_val;
     P_val_copy.to_affine_coordinates();
-    P.reset(new G1_variable<ppT>(pb, P_val_copy, libff::FMT(annotation_prefix, " P")));
+    P.reset(new G1_variable<ppT>(pb, P_val_copy, FMT(annotation_prefix, " P")));
     PY_twist_squared.reset(new Fqe_variable<ppT>(pb, P_val_copy.Y() * libff::G2<other_curve<ppT> >::twist.squared(), " PY_twist_squared"));
 }
 
@@ -82,17 +82,17 @@ G2_precomputation<ppT>::G2_precomputation(protoboard<FieldT> &pb,
                                           const libff::G2<other_curve<ppT> > &Q_val,
                                           const std::string &annotation_prefix)
 {
-    Q.reset(new G2_variable<ppT>(pb, Q_val, libff::FMT(annotation_prefix, " Q")));
+    Q.reset(new G2_variable<ppT>(pb, Q_val, FMT(annotation_prefix, " Q")));
     const libff::affine_ate_G2_precomp<other_curve<ppT> > native_precomp = other_curve<ppT>::affine_ate_precompute_G2(Q_val);
 
     coeffs.resize(native_precomp.coeffs.size() + 1); // the last precomp remains for convenient programming
     for (size_t i = 0; i < native_precomp.coeffs.size(); ++i)
     {
         coeffs[i].reset(new precompute_G2_gadget_coeffs<ppT>());
-        coeffs[i]->RX.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].old_RX, libff::FMT(annotation_prefix, " RX")));
-        coeffs[i]->RY.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].old_RY, libff::FMT(annotation_prefix, " RY")));
-        coeffs[i]->gamma.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].gamma, libff::FMT(annotation_prefix, " gamma")));
-        coeffs[i]->gamma_X.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].gamma_X, libff::FMT(annotation_prefix, " gamma_X")));
+        coeffs[i]->RX.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].old_RX, FMT(annotation_prefix, " RX")));
+        coeffs[i]->RY.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].old_RY, FMT(annotation_prefix, " RY")));
+        coeffs[i]->gamma.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].gamma, FMT(annotation_prefix, " gamma")));
+        coeffs[i]->gamma_X.reset(new Fqe_variable<ppT>(pb, native_precomp.coeffs[i].gamma_X, FMT(annotation_prefix, " gamma_X")));
     }
 }
 
@@ -106,10 +106,10 @@ template<typename ppT>
 precompute_G2_gadget_coeffs<ppT>::precompute_G2_gadget_coeffs(protoboard<FieldT> &pb,
                                                               const std::string &annotation_prefix)
 {
-    RX.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " RX")));
-    RY.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " RY")));
-    gamma.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " gamma")));
-    gamma_X.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " gamma_X")));
+    RX.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " RX")));
+    RY.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " RY")));
+    gamma.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " gamma")));
+    gamma_X.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " gamma_X")));
 }
 
 template<typename ppT>
@@ -119,8 +119,8 @@ precompute_G2_gadget_coeffs<ppT>::precompute_G2_gadget_coeffs(protoboard<FieldT>
 {
     RX.reset(new Fqe_variable<ppT>(*(Q.X)));
     RY.reset(new Fqe_variable<ppT>(*(Q.Y)));
-    gamma.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " gamma")));
-    gamma_X.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " gamma_X")));
+    gamma.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " gamma")));
+    gamma_X.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " gamma_X")));
 }
 
 /*
@@ -150,20 +150,20 @@ precompute_G2_gadget_doubling_step<ppT>::precompute_G2_gadget_doubling_step(prot
     cur(cur),
     next(next)
 {
-    RXsquared.reset(new Fqe_variable<ppT>(pb, libff::FMT(annotation_prefix, " RXsquared")));
-    compute_RXsquared.reset(new Fqe_sqr_gadget<ppT>(pb, *(cur.RX), *RXsquared, libff::FMT(annotation_prefix, " compute_RXsquared")));
+    RXsquared.reset(new Fqe_variable<ppT>(pb, FMT(annotation_prefix, " RXsquared")));
+    compute_RXsquared.reset(new Fqe_sqr_gadget<ppT>(pb, *(cur.RX), *RXsquared, FMT(annotation_prefix, " compute_RXsquared")));
     three_RXsquared_plus_a.reset(new Fqe_variable<ppT>((*RXsquared) * FieldT(3) + libff::G2<other_curve<ppT> >::coeff_a));
     two_RY.reset(new Fqe_variable<ppT>(*(cur.RY) * FieldT(2)));
 
-    compute_gamma.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *two_RY, *three_RXsquared_plus_a, libff::FMT(annotation_prefix, " compute_gamma")));
-    compute_gamma_X.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *(cur.RX), *(cur.gamma_X), libff::FMT(annotation_prefix, " compute_gamma_X")));
+    compute_gamma.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *two_RY, *three_RXsquared_plus_a, FMT(annotation_prefix, " compute_gamma")));
+    compute_gamma_X.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *(cur.RX), *(cur.gamma_X), FMT(annotation_prefix, " compute_gamma_X")));
 
     next_RX_plus_two_RX.reset(new Fqe_variable<ppT>(*(next.RX) + *(cur.RX) * FieldT(2)));
-    compute_next_RX.reset(new Fqe_sqr_gadget<ppT>(pb, *(cur.gamma), *next_RX_plus_two_RX, libff::FMT(annotation_prefix, " compute_next_RX")));
+    compute_next_RX.reset(new Fqe_sqr_gadget<ppT>(pb, *(cur.gamma), *next_RX_plus_two_RX, FMT(annotation_prefix, " compute_next_RX")));
 
     RX_minus_next_RX.reset(new Fqe_variable<ppT>(*(cur.RX) + *(next.RX) * (-FieldT::one())));
     RY_plus_next_RY.reset(new Fqe_variable<ppT>(*(cur.RY) + *(next.RY)));
-    compute_next_RY.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *RX_minus_next_RX, *RY_plus_next_RY, libff::FMT(annotation_prefix, " compute_next_RY")));
+    compute_next_RY.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *RX_minus_next_RX, *RY_plus_next_RY, FMT(annotation_prefix, " compute_next_RY")));
 }
 
 template<typename ppT>
@@ -237,15 +237,15 @@ precompute_G2_gadget_addition_step<ppT>::precompute_G2_gadget_addition_step(prot
     RY_minus_QY.reset(new Fqe_variable<ppT>(*(cur.RY) + *(Q.Y) * (!invert_Q ? -FieldT::one() : FieldT::one())));
 
     RX_minus_QX.reset(new Fqe_variable<ppT>(*(cur.RX) + *(Q.X) * (-FieldT::one())));
-    compute_gamma.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *RX_minus_QX, *RY_minus_QY, libff::FMT(annotation_prefix, " compute_gamma")));
-    compute_gamma_X.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *(Q.X), *(cur.gamma_X), libff::FMT(annotation_prefix, " compute_gamma_X")));
+    compute_gamma.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *RX_minus_QX, *RY_minus_QY, FMT(annotation_prefix, " compute_gamma")));
+    compute_gamma_X.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *(Q.X), *(cur.gamma_X), FMT(annotation_prefix, " compute_gamma_X")));
 
     next_RX_plus_RX_plus_QX.reset(new Fqe_variable<ppT>(*(next.RX) + *(cur.RX) + *(Q.X)));
-    compute_next_RX.reset(new Fqe_sqr_gadget<ppT>(pb, *(cur.gamma), *next_RX_plus_RX_plus_QX, libff::FMT(annotation_prefix, " compute_next_RX")));
+    compute_next_RX.reset(new Fqe_sqr_gadget<ppT>(pb, *(cur.gamma), *next_RX_plus_RX_plus_QX, FMT(annotation_prefix, " compute_next_RX")));
 
     RX_minus_next_RX.reset(new Fqe_variable<ppT>(*(cur.RX) + *(next.RX) * (-FieldT::one())));
     RY_plus_next_RY.reset(new Fqe_variable<ppT>(*(cur.RY) + *(next.RY)));
-    compute_next_RY.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *RX_minus_next_RX, *RY_plus_next_RY, libff::FMT(annotation_prefix, " compute_next_RY")));
+    compute_next_RY.reset(new Fqe_mul_gadget<ppT>(pb, *(cur.gamma), *RX_minus_next_RX, *RY_plus_next_RY, FMT(annotation_prefix, " compute_next_RY")));
 }
 
 template<typename ppT>
@@ -328,10 +328,10 @@ precompute_G2_gadget<ppT>::precompute_G2_gadget(protoboard<FieldT> &pb,
     addition_steps.resize(add_count);
     doubling_steps.resize(dbl_count);
 
-    precomp.coeffs[0].reset(new precompute_G2_gadget_coeffs<ppT>(pb, Q, libff::FMT(annotation_prefix, " coeffs_0")));
+    precomp.coeffs[0].reset(new precompute_G2_gadget_coeffs<ppT>(pb, Q, FMT(annotation_prefix, " coeffs_0")));
     for (size_t i = 1; i < coeff_count; ++i)
     {
-        precomp.coeffs[i].reset(new precompute_G2_gadget_coeffs<ppT>(pb, libff::FMT(annotation_prefix, " coeffs_%zu", i)));
+        precomp.coeffs[i].reset(new precompute_G2_gadget_coeffs<ppT>(pb, FMT(annotation_prefix, " coeffs_%zu", i)));
     }
 
     size_t add_id = 0;
@@ -349,14 +349,14 @@ precompute_G2_gadget<ppT>::precompute_G2_gadget(protoboard<FieldT> &pb,
         }
 
         doubling_steps[dbl_id].reset(new precompute_G2_gadget_doubling_step<ppT>(pb, *(precomp.coeffs[coeff_id]), *(precomp.coeffs[coeff_id+1]),
-                                                                                 libff::FMT(annotation_prefix, " doubling_steps_%zu", dbl_id)));
+                                                                                 FMT(annotation_prefix, " doubling_steps_%zu", dbl_id)));
         ++dbl_id;
         ++coeff_id;
 
         if (NAF[i] != 0)
         {
             addition_steps[add_id].reset(new precompute_G2_gadget_addition_step<ppT>(pb, NAF[i] < 0, *(precomp.coeffs[coeff_id]), *(precomp.coeffs[coeff_id+1]), Q,
-                                                                                     libff::FMT(annotation_prefix, " addition_steps_%zu", add_id)));
+                                                                                     FMT(annotation_prefix, " addition_steps_%zu", add_id)));
             ++add_id;
             ++coeff_id;
         }

--- a/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
+++ b/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
@@ -44,7 +44,7 @@ as_waksman_routing_gadget<FieldT>::as_waksman_routing_gadget(protoboard<FieldT> 
     routed_packets[0].resize(num_packets);
     for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx)
     {
-        routed_packets[0][packet_idx].allocate(pb, num_subpackets, libff::FMT(annotation_prefix, " routed_packets_0_%zu", packet_idx));
+        routed_packets[0][packet_idx].allocate(pb, num_subpackets, FMT(annotation_prefix, " routed_packets_0_%zu", packet_idx));
     }
 
     for (size_t column_idx = 0; column_idx < num_columns; ++column_idx)
@@ -62,8 +62,8 @@ as_waksman_routing_gadget<FieldT>::as_waksman_routing_gadget(protoboard<FieldT> 
             {
                 const size_t straight_edge = neighbors[column_idx][row_idx].first;
                 const size_t cross_edge = neighbors[column_idx][row_idx].second;
-                routed_packets[column_idx+1][straight_edge].allocate(pb, num_subpackets, libff::FMT(annotation_prefix, " routed_packets_%zu_%zu", column_idx+1, straight_edge));
-                routed_packets[column_idx+1][cross_edge].allocate(pb, num_subpackets, libff::FMT(annotation_prefix, " routed_packets_%zu_%zu", column_idx+1, cross_edge));
+                routed_packets[column_idx+1][straight_edge].allocate(pb, num_subpackets, FMT(annotation_prefix, " routed_packets_%zu_%zu", column_idx+1, straight_edge));
+                routed_packets[column_idx+1][cross_edge].allocate(pb, num_subpackets, FMT(annotation_prefix, " routed_packets_%zu_%zu", column_idx+1, cross_edge));
                 ++row_idx; /* skip the next idx, as it to refers to the same packets */
             }
         }
@@ -78,13 +78,13 @@ as_waksman_routing_gadget<FieldT>::as_waksman_routing_gadget(protoboard<FieldT> 
                                         pb_variable_array<FieldT>(routing_input_bits[packet_idx].begin(), routing_input_bits[packet_idx].end()),
                                         routed_packets[0][packet_idx],
                                         FieldT::capacity(),
-                                        libff::FMT(this->annotation_prefix, " pack_inputs_%zu", packet_idx)));
+                                        FMT(this->annotation_prefix, " pack_inputs_%zu", packet_idx)));
         unpack_outputs.emplace_back(
             multipacking_gadget<FieldT>(pb,
                                         pb_variable_array<FieldT>(routing_output_bits[packet_idx].begin(), routing_output_bits[packet_idx].end()),
                                         routed_packets[num_columns][packet_idx],
                                         FieldT::capacity(),
-                                        libff::FMT(this->annotation_prefix, " unpack_outputs_%zu", packet_idx)));
+                                        FMT(this->annotation_prefix, " unpack_outputs_%zu", packet_idx)));
     }
 
     /* allocate switch bits */
@@ -98,7 +98,7 @@ as_waksman_routing_gadget<FieldT>::as_waksman_routing_gadget(protoboard<FieldT> 
             {
                 if (neighbors[column_idx][row_idx].first != neighbors[column_idx][row_idx].second)
                 {
-                    asw_switch_bits[column_idx][row_idx].allocate(pb, libff::FMT(annotation_prefix, " asw_switch_bits_%zu_%zu", column_idx, row_idx));
+                    asw_switch_bits[column_idx][row_idx].allocate(pb, FMT(annotation_prefix, " asw_switch_bits_%zu_%zu", column_idx, row_idx));
                     ++row_idx; /* next row_idx corresponds to the same switch, so skip it */
                 }
             }
@@ -141,14 +141,14 @@ void as_waksman_routing_gadget<FieldT>::generate_r1cs_constraints()
                         r1cs_constraint<FieldT>(routed_packets[column_idx][switch_input][0] - routed_packets[column_idx+1][straight_edge][0],
                                                 routed_packets[column_idx][switch_input][0] - routed_packets[column_idx+1][cross_edge][0],
                                                 0),
-                        libff::FMT(this->annotation_prefix, " easy_route_%zu_%zu", column_idx, switch_input));
+                        FMT(this->annotation_prefix, " easy_route_%zu_%zu", column_idx, switch_input));
                 }
             }
             else
             {
                 /* require switching bit to be boolean */
                 generate_boolean_r1cs_constraint<FieldT>(this->pb, asw_switch_bits[column_idx][row_idx],
-                                                         libff::FMT(this->annotation_prefix, " asw_switch_bits_%zu_%zu", column_idx, row_idx));
+                                                         FMT(this->annotation_prefix, " asw_switch_bits_%zu_%zu", column_idx, row_idx));
 
                 /* route forward according to the switch bit */
                 for (size_t subpacket_idx = 0; subpacket_idx < num_subpackets; ++subpacket_idx)
@@ -167,7 +167,7 @@ void as_waksman_routing_gadget<FieldT>::generate_r1cs_constraints()
                                 asw_switch_bits[column_idx][row_idx],
                                 routed_packets[column_idx+1][cross_edge][subpacket_idx] - routed_packets[column_idx+1][straight_edge][subpacket_idx],
                                 routed_packets[column_idx][switch_input][subpacket_idx] - routed_packets[column_idx+1][straight_edge][subpacket_idx]),
-                            libff::FMT(this->annotation_prefix, " route_forward_%zu_%zu_%zu", column_idx, switch_input, subpacket_idx));
+                            FMT(this->annotation_prefix, " route_forward_%zu_%zu_%zu", column_idx, switch_input, subpacket_idx));
                     }
                 }
             }
@@ -253,8 +253,8 @@ void test_as_waksman_routing_gadget(const size_t num_packets, const size_t packe
     std::vector<pb_variable_array<FieldT> > randbits(num_packets), outbits(num_packets);
     for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx)
     {
-        randbits[packet_idx].allocate(pb, packet_size, libff::FMT("", "randbits_%zu", packet_idx));
-        outbits[packet_idx].allocate(pb, packet_size, libff::FMT("", "outbits_%zu", packet_idx));
+        randbits[packet_idx].allocate(pb, packet_size, FMT("", "randbits_%zu", packet_idx));
+        outbits[packet_idx].allocate(pb, packet_size, FMT("", "outbits_%zu", packet_idx));
 
         for (size_t bit_idx = 0; bit_idx < packet_size; ++bit_idx)
         {

--- a/src/gadgetlib1/gadgets/routing/benes_routing_gadget.tcc
+++ b/src/gadgetlib1/gadgets/routing/benes_routing_gadget.tcc
@@ -48,7 +48,7 @@ benes_routing_gadget<FieldT>::benes_routing_gadget(protoboard<FieldT> &pb,
         routed_packets[column_idx].resize(num_packets);
         for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx)
         {
-            routed_packets[column_idx][packet_idx].allocate(pb, num_subpackets, libff::FMT(annotation_prefix, " routed_packets_%zu_%zu", column_idx, packet_idx));
+            routed_packets[column_idx][packet_idx].allocate(pb, num_subpackets, FMT(annotation_prefix, " routed_packets_%zu_%zu", column_idx, packet_idx));
         }
     }
 
@@ -62,7 +62,7 @@ benes_routing_gadget<FieldT>::benes_routing_gadget(protoboard<FieldT> &pb,
                                         pb_variable_array<FieldT>(routing_input_bits[packet_idx].begin(), routing_input_bits[packet_idx].end()),
                                         routed_packets[0][packet_idx],
                                         FieldT::capacity(),
-                                        libff::FMT(this->annotation_prefix, " pack_inputs_%zu", packet_idx)));
+                                        FMT(this->annotation_prefix, " pack_inputs_%zu", packet_idx)));
         if (packet_idx < lines_to_unpack)
         {
             unpack_outputs.emplace_back(
@@ -70,7 +70,7 @@ benes_routing_gadget<FieldT>::benes_routing_gadget(protoboard<FieldT> &pb,
                                             pb_variable_array<FieldT>(routing_output_bits[packet_idx].begin(), routing_output_bits[packet_idx].end()),
                                             routed_packets[num_columns][packet_idx],
                                             FieldT::capacity(),
-                                            libff::FMT(this->annotation_prefix, " unpack_outputs_%zu", packet_idx)));
+                                            FMT(this->annotation_prefix, " unpack_outputs_%zu", packet_idx)));
         }
     }
 
@@ -79,7 +79,7 @@ benes_routing_gadget<FieldT>::benes_routing_gadget(protoboard<FieldT> &pb,
         benes_switch_bits.resize(num_columns);
         for (size_t column_idx = 0; column_idx < num_columns; ++column_idx)
         {
-            benes_switch_bits[column_idx].allocate(pb, num_packets, libff::FMT(this->annotation_prefix, " benes_switch_bits_%zu", column_idx));
+            benes_switch_bits[column_idx].allocate(pb, num_packets, FMT(this->annotation_prefix, " benes_switch_bits_%zu", column_idx));
         }
     }
 }
@@ -101,7 +101,7 @@ void benes_routing_gadget<FieldT>::generate_r1cs_constraints()
             {
                 this->pb.add_r1cs_constraint(
                     r1cs_constraint<FieldT>(1, routed_packets[0][packet_idx][subpacket_idx], routed_packets[num_columns][packet_idx][subpacket_idx]),
-                    libff::FMT(this->annotation_prefix, " fix_line_%zu_subpacket_%zu", packet_idx, subpacket_idx));
+                    FMT(this->annotation_prefix, " fix_line_%zu_subpacket_%zu", packet_idx, subpacket_idx));
             }
         }
     }
@@ -122,13 +122,13 @@ void benes_routing_gadget<FieldT>::generate_r1cs_constraints()
                         routed_packets[column_idx][packet_idx][0] - routed_packets[column_idx+1][straight_edge][0],
                         routed_packets[column_idx][packet_idx][0] - routed_packets[column_idx+1][cross_edge][0],
                         0),
-                    libff::FMT(this->annotation_prefix, " easy_route_%zu_%zu", column_idx, packet_idx));
+                    FMT(this->annotation_prefix, " easy_route_%zu_%zu", column_idx, packet_idx));
             }
             else
             {
                 /* routing bit must be boolean */
                 generate_boolean_r1cs_constraint<FieldT>(this->pb, benes_switch_bits[column_idx][packet_idx],
-                                                         libff::FMT(this->annotation_prefix, " routing_bit_%zu_%zu", column_idx, packet_idx));
+                                                         FMT(this->annotation_prefix, " routing_bit_%zu_%zu", column_idx, packet_idx));
 
                 /* route forward according to routing bits */
                 for (size_t subpacket_idx = 0; subpacket_idx < num_subpackets; ++subpacket_idx)
@@ -142,7 +142,7 @@ void benes_routing_gadget<FieldT>::generate_r1cs_constraints()
                             benes_switch_bits[column_idx][packet_idx],
                             routed_packets[column_idx+1][cross_edge][subpacket_idx] - routed_packets[column_idx+1][straight_edge][subpacket_idx],
                             routed_packets[column_idx][packet_idx][subpacket_idx] - routed_packets[column_idx+1][straight_edge][subpacket_idx]),
-                        libff::FMT(this->annotation_prefix, " route_forward_%zu_%zu_%zu", column_idx, packet_idx, subpacket_idx));
+                        FMT(this->annotation_prefix, " route_forward_%zu_%zu_%zu", column_idx, packet_idx, subpacket_idx));
                 }
             }
         }
@@ -206,8 +206,8 @@ void test_benes_routing_gadget(const size_t num_packets, const size_t packet_siz
     std::vector<pb_variable_array<FieldT> > randbits(num_packets), outbits(num_packets);
     for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx)
     {
-        randbits[packet_idx].allocate(pb, packet_size, libff::FMT("", "randbits_%zu", packet_idx));
-        outbits[packet_idx].allocate(pb, packet_size, libff::FMT("", "outbits_%zu", packet_idx));
+        randbits[packet_idx].allocate(pb, packet_size, FMT("", "randbits_%zu", packet_idx));
+        outbits[packet_idx].allocate(pb, packet_size, FMT("", "outbits_%zu", packet_idx));
 
         for (size_t bit_idx = 0; bit_idx < packet_size; ++bit_idx)
         {

--- a/src/gadgetlib1/gadgets/routing/profiling/profile_routing_gadgets.cpp
+++ b/src/gadgetlib1/gadgets/routing/profiling/profile_routing_gadgets.cpp
@@ -26,8 +26,8 @@ void get_as_waksman_size(const size_t n, const size_t l, size_t &num_constraints
     std::vector<pb_variable_array<FieldT> > randbits(n), outbits(n);
     for (size_t y = 0; y < n; ++y)
     {
-        randbits[y].allocate(pb, l, libff::FMT("", "randbits_%zu", y));
-        outbits[y].allocate(pb, l, libff::FMT("", "outbits_%zu", y));
+        randbits[y].allocate(pb, l, FMT("", "randbits_%zu", y));
+        outbits[y].allocate(pb, l, FMT("", "outbits_%zu", y));
     }
 
     as_waksman_routing_gadget<FieldT> r(pb, n, randbits, outbits, "main_routing_gadget");
@@ -48,8 +48,8 @@ void get_benes_size(const size_t n, const size_t l, size_t &num_constraints, siz
     std::vector<pb_variable_array<FieldT> > randbits(1ul<<t), outbits(1ul<<t);
     for (size_t y = 0; y < 1ul<<t; ++y)
     {
-        randbits[y].allocate(pb, l, libff::FMT("", "randbits_%zu", y));
-        outbits[y].allocate(pb, l, libff::FMT("", "outbits_%zu", y));
+        randbits[y].allocate(pb, l, FMT("", "randbits_%zu", y));
+        outbits[y].allocate(pb, l, FMT("", "outbits_%zu", y));
     }
 
     benes_routing_gadget<FieldT> r(pb, n, randbits, outbits, n, "main_routing_gadget");

--- a/src/gadgetlib1/gadgets/set_commitment/set_commitment_gadget.tcc
+++ b/src/gadgetlib1/gadgets/set_commitment/set_commitment_gadget.tcc
@@ -22,17 +22,17 @@ set_commitment_gadget<FieldT, HashT>::set_commitment_gadget(protoboard<FieldT> &
     gadget<FieldT>(pb, annotation_prefix), tree_depth(libff::log2(max_entries)), element_bits(element_bits),
     root_digest(root_digest), proof(proof), check_successful(check_successful)
 {
-    element_block.reset(new block_variable<FieldT>(pb, { element_bits }, libff::FMT(annotation_prefix, " element_block")));
+    element_block.reset(new block_variable<FieldT>(pb, { element_bits }, FMT(annotation_prefix, " element_block")));
 
     if (tree_depth == 0)
     {
-        hash_element.reset(new HashT(pb, element_bits.size(), *element_block, root_digest, libff::FMT(annotation_prefix, " hash_element")));
+        hash_element.reset(new HashT(pb, element_bits.size(), *element_block, root_digest, FMT(annotation_prefix, " hash_element")));
     }
     else
     {
         element_digest.reset(new digest_variable<FieldT>(pb, HashT::get_digest_len(),
-                                                         libff::FMT(annotation_prefix, " element_digest")));
-        hash_element.reset(new HashT(pb, element_bits.size(), *element_block, *element_digest, libff::FMT(annotation_prefix, " hash_element")));
+                                                         FMT(annotation_prefix, " element_digest")));
+        hash_element.reset(new HashT(pb, element_bits.size(), *element_block, *element_digest, FMT(annotation_prefix, " hash_element")));
         check_membership.reset(new merkle_tree_check_read_gadget<FieldT, HashT>(pb,
                                                                                 tree_depth,
                                                                                 proof.address_bits,
@@ -40,7 +40,7 @@ set_commitment_gadget<FieldT, HashT>::set_commitment_gadget(protoboard<FieldT> &
                                                                                 root_digest,
                                                                                 *proof.merkle_path,
                                                                                 check_successful,
-                                                                                libff::FMT(annotation_prefix, " check_membership")));
+                                                                                FMT(annotation_prefix, " check_membership")));
     }
 }
 

--- a/src/gadgetlib1/gadgets/set_commitment/set_membership_proof_variable.tcc
+++ b/src/gadgetlib1/gadgets/set_commitment/set_membership_proof_variable.tcc
@@ -20,8 +20,8 @@ set_membership_proof_variable<FieldT, HashT>::set_membership_proof_variable(prot
 {
     if (tree_depth > 0)
     {
-        address_bits.allocate(pb, tree_depth, libff::FMT(annotation_prefix, " address_bits"));
-        merkle_path.reset(new merkle_authentication_path_variable<FieldT, HashT>(pb, tree_depth, libff::FMT(annotation_prefix, " merkle_path")));
+        address_bits.allocate(pb, tree_depth, FMT(annotation_prefix, " address_bits"));
+        merkle_path.reset(new merkle_authentication_path_variable<FieldT, HashT>(pb, tree_depth, FMT(annotation_prefix, " merkle_path")));
     }
 }
 
@@ -32,7 +32,7 @@ void set_membership_proof_variable<FieldT, HashT>::generate_r1cs_constraints()
     {
         for (size_t i = 0; i < tree_depth; ++i)
         {
-            generate_boolean_r1cs_constraint<FieldT>(this->pb, address_bits[i], libff::FMT(this->annotation_prefix, " address_bits"));
+            generate_boolean_r1cs_constraint<FieldT>(this->pb, address_bits[i], FMT(this->annotation_prefix, " address_bits"));
         }
         merkle_path->generate_r1cs_constraints();
     }

--- a/src/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.tcc
+++ b/src/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.tcc
@@ -26,14 +26,14 @@ r1cs_ppzksnark_proof_variable<ppT>::r1cs_ppzksnark_proof_variable(protoboard<Fie
     const size_t num_G1 = 7;
     const size_t num_G2 = 1;
 
-    g_A_g.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_A_g")));
-    g_A_h.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_A_h")));
-    g_B_g.reset(new G2_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_B_g")));
-    g_B_h.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_B_h")));
-    g_C_g.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_C_g")));
-    g_C_h.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_C_h")));
-    g_H.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_H")));
-    g_K.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " g_K")));
+    g_A_g.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " g_A_g")));
+    g_A_h.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " g_A_h")));
+    g_B_g.reset(new G2_variable<ppT>(pb, FMT(annotation_prefix, " g_B_g")));
+    g_B_h.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " g_B_h")));
+    g_C_g.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " g_C_g")));
+    g_C_h.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " g_C_h")));
+    g_H.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " g_H")));
+    g_K.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " g_K")));
 
     all_G1_vars = { g_A_g, g_A_h, g_B_h, g_C_g, g_C_h, g_H,g_K };
     all_G2_vars = { g_B_g };
@@ -42,9 +42,9 @@ r1cs_ppzksnark_proof_variable<ppT>::r1cs_ppzksnark_proof_variable(protoboard<Fie
 
     for (size_t i = 0; i < all_G1_vars.size(); ++i)
     {
-        all_G1_checkers[i].reset(new G1_checker_gadget<ppT>(pb, *all_G1_vars[i], libff::FMT(annotation_prefix, " all_G1_checkers_%zu", i)));
+        all_G1_checkers[i].reset(new G1_checker_gadget<ppT>(pb, *all_G1_vars[i], FMT(annotation_prefix, " all_G1_checkers_%zu", i)));
     }
-    G2_checker.reset(new G2_checker_gadget<ppT>(pb, *g_B_g, libff::FMT(annotation_prefix, " G2_checker")));
+    G2_checker.reset(new G2_checker_gadget<ppT>(pb, *g_B_g, FMT(annotation_prefix, " G2_checker")));
 
     assert(all_G1_vars.size() == num_G1);
     assert(all_G2_vars.size() == num_G2);
@@ -113,24 +113,24 @@ r1cs_ppzksnark_verification_key_variable<ppT>::r1cs_ppzksnark_verification_key_v
 
     assert(all_bits.size() == (G1_variable<ppT>::size_in_bits() * num_G1 + G2_variable<ppT>::size_in_bits() * num_G2));
 
-    this->alphaA_g2.reset(new G2_variable<ppT>(pb, libff::FMT(annotation_prefix, " alphaA_g2")));
-    this->alphaB_g1.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " alphaB_g1")));
-    this->alphaC_g2.reset(new G2_variable<ppT>(pb, libff::FMT(annotation_prefix, " alphaC_g2")));
-    this->gamma_g2.reset(new G2_variable<ppT>(pb, libff::FMT(annotation_prefix, " gamma_g2")));
-    this->gamma_beta_g1.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " gamma_beta_g1")));
-    this->gamma_beta_g2.reset(new G2_variable<ppT>(pb, libff::FMT(annotation_prefix, " gamma_beta_g2")));
-    this->rC_Z_g2.reset(new G2_variable<ppT>(pb, libff::FMT(annotation_prefix, " rC_Z_g2")));
+    this->alphaA_g2.reset(new G2_variable<ppT>(pb, FMT(annotation_prefix, " alphaA_g2")));
+    this->alphaB_g1.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " alphaB_g1")));
+    this->alphaC_g2.reset(new G2_variable<ppT>(pb, FMT(annotation_prefix, " alphaC_g2")));
+    this->gamma_g2.reset(new G2_variable<ppT>(pb, FMT(annotation_prefix, " gamma_g2")));
+    this->gamma_beta_g1.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " gamma_beta_g1")));
+    this->gamma_beta_g2.reset(new G2_variable<ppT>(pb, FMT(annotation_prefix, " gamma_beta_g2")));
+    this->rC_Z_g2.reset(new G2_variable<ppT>(pb, FMT(annotation_prefix, " rC_Z_g2")));
 
     all_G1_vars = { this->alphaB_g1, this->gamma_beta_g1 };
     all_G2_vars = { this->alphaA_g2, this->alphaC_g2, this->gamma_g2, this->gamma_beta_g2, this->rC_Z_g2 };
 
     this->encoded_IC_query.resize(input_size);
-    this->encoded_IC_base.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " encoded_IC_base")));
+    this->encoded_IC_base.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " encoded_IC_base")));
     this->all_G1_vars.emplace_back(this->encoded_IC_base);
 
     for (size_t i = 0; i < input_size; ++i)
     {
-        this->encoded_IC_query[i].reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " encoded_IC_query_%zu", i)));
+        this->encoded_IC_query[i].reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " encoded_IC_query_%zu", i)));
         all_G1_vars.emplace_back(this->encoded_IC_query[i]);
     }
 
@@ -148,7 +148,7 @@ r1cs_ppzksnark_verification_key_variable<ppT>::r1cs_ppzksnark_verification_key_v
     assert(all_G2_vars.size() == num_G2);
     assert(all_vars.size() == (num_G1 * G1_variable<ppT>::num_variables() + num_G2 * G2_variable<ppT>::num_variables()));
 
-    packer.reset(new multipacking_gadget<FieldT>(pb, all_bits, all_vars, FieldT::size_in_bits(), libff::FMT(annotation_prefix, " packer")));
+    packer.reset(new multipacking_gadget<FieldT>(pb, all_bits, all_vars, FieldT::size_in_bits(), FMT(annotation_prefix, " packer")));
 }
 
 template<typename ppT>
@@ -242,23 +242,23 @@ r1cs_ppzksnark_preprocessed_r1cs_ppzksnark_verification_key_variable<ppT>::r1cs_
                                                                                                                                                 const r1cs_ppzksnark_verification_key<other_curve<ppT> > &r1cs_vk,
                                                                                                                                                 const std::string &annotation_prefix)
 {
-    encoded_IC_base.reset(new G1_variable<ppT>(pb, r1cs_vk.encoded_IC_query.first, libff::FMT(annotation_prefix, " encoded_IC_base")));
+    encoded_IC_base.reset(new G1_variable<ppT>(pb, r1cs_vk.encoded_IC_query.first, FMT(annotation_prefix, " encoded_IC_base")));
     encoded_IC_query.resize(r1cs_vk.encoded_IC_query.rest.indices.size());
     for (size_t i = 0; i < r1cs_vk.encoded_IC_query.rest.indices.size(); ++i)
     {
         assert(r1cs_vk.encoded_IC_query.rest.indices[i] == i);
-        encoded_IC_query[i].reset(new G1_variable<ppT>(pb, r1cs_vk.encoded_IC_query.rest.values[i], libff::FMT(annotation_prefix, " encoded_IC_query")));
+        encoded_IC_query[i].reset(new G1_variable<ppT>(pb, r1cs_vk.encoded_IC_query.rest.values[i], FMT(annotation_prefix, " encoded_IC_query")));
     }
 
-    vk_alphaB_g1_precomp.reset(new G1_precomputation<ppT>(pb, r1cs_vk.alphaB_g1, libff::FMT(annotation_prefix, " vk_alphaB_g1_precomp")));
-    vk_gamma_beta_g1_precomp.reset(new G1_precomputation<ppT>(pb, r1cs_vk.gamma_beta_g1, libff::FMT(annotation_prefix, " vk_gamma_beta_g1_precomp")));
+    vk_alphaB_g1_precomp.reset(new G1_precomputation<ppT>(pb, r1cs_vk.alphaB_g1, FMT(annotation_prefix, " vk_alphaB_g1_precomp")));
+    vk_gamma_beta_g1_precomp.reset(new G1_precomputation<ppT>(pb, r1cs_vk.gamma_beta_g1, FMT(annotation_prefix, " vk_gamma_beta_g1_precomp")));
 
-    pp_G2_one_precomp.reset(new G2_precomputation<ppT>(pb, libff::G2<other_curve<ppT> >::one(), libff::FMT(annotation_prefix, " pp_G2_one_precomp")));
-    vk_alphaA_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.alphaA_g2, libff::FMT(annotation_prefix, " vk_alphaA_g2_precomp")));
-    vk_alphaC_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.alphaC_g2, libff::FMT(annotation_prefix, " vk_alphaC_g2_precomp")));
-    vk_gamma_beta_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.gamma_beta_g2, libff::FMT(annotation_prefix, " vk_gamma_beta_g2_precomp")));
-    vk_gamma_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.gamma_g2, libff::FMT(annotation_prefix, " vk_gamma_g2_precomp")));
-    vk_rC_Z_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.rC_Z_g2, libff::FMT(annotation_prefix, " vk_rC_Z_g2_precomp")));
+    pp_G2_one_precomp.reset(new G2_precomputation<ppT>(pb, libff::G2<other_curve<ppT> >::one(), FMT(annotation_prefix, " pp_G2_one_precomp")));
+    vk_alphaA_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.alphaA_g2, FMT(annotation_prefix, " vk_alphaA_g2_precomp")));
+    vk_alphaC_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.alphaC_g2, FMT(annotation_prefix, " vk_alphaC_g2_precomp")));
+    vk_gamma_beta_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.gamma_beta_g2, FMT(annotation_prefix, " vk_gamma_beta_g2_precomp")));
+    vk_gamma_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.gamma_g2, FMT(annotation_prefix, " vk_gamma_g2_precomp")));
+    vk_rC_Z_g2_precomp.reset(new G2_precomputation<ppT>(pb, r1cs_vk.rC_Z_g2, FMT(annotation_prefix, " vk_rC_Z_g2_precomp")));
 }
 
 template<typename ppT>
@@ -283,15 +283,15 @@ r1cs_ppzksnark_verifier_process_vk_gadget<ppT>::r1cs_ppzksnark_verifier_process_
     pvk.vk_gamma_g2_precomp.reset(new G2_precomputation<ppT>());
     pvk.vk_rC_Z_g2_precomp.reset(new G2_precomputation<ppT>());
 
-    compute_vk_alphaB_g1_precomp.reset(new precompute_G1_gadget<ppT>(pb, *vk.alphaB_g1, *pvk.vk_alphaB_g1_precomp, libff::FMT(annotation_prefix, " compute_vk_alphaB_g1_precomp")));
-    compute_vk_gamma_beta_g1_precomp.reset(new precompute_G1_gadget<ppT>(pb, *vk.gamma_beta_g1, *pvk.vk_gamma_beta_g1_precomp, libff::FMT(annotation_prefix, " compute_vk_gamma_beta_g1_precomp")));
+    compute_vk_alphaB_g1_precomp.reset(new precompute_G1_gadget<ppT>(pb, *vk.alphaB_g1, *pvk.vk_alphaB_g1_precomp, FMT(annotation_prefix, " compute_vk_alphaB_g1_precomp")));
+    compute_vk_gamma_beta_g1_precomp.reset(new precompute_G1_gadget<ppT>(pb, *vk.gamma_beta_g1, *pvk.vk_gamma_beta_g1_precomp, FMT(annotation_prefix, " compute_vk_gamma_beta_g1_precomp")));
 
-    pvk.pp_G2_one_precomp.reset(new G2_precomputation<ppT>(pb, libff::G2<other_curve<ppT> >::one(), libff::FMT(annotation_prefix, " pp_G2_one_precomp")));
-    compute_vk_alphaA_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.alphaA_g2, *pvk.vk_alphaA_g2_precomp, libff::FMT(annotation_prefix, " compute_vk_alphaA_g2_precomp")));
-    compute_vk_alphaC_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.alphaC_g2, *pvk.vk_alphaC_g2_precomp, libff::FMT(annotation_prefix, " compute_vk_alphaC_g2_precomp")));
-    compute_vk_gamma_beta_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.gamma_beta_g2, *pvk.vk_gamma_beta_g2_precomp, libff::FMT(annotation_prefix, " compute_vk_gamma_beta_g2_precomp")));
-    compute_vk_gamma_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.gamma_g2, *pvk.vk_gamma_g2_precomp, libff::FMT(annotation_prefix, " compute_vk_gamma_g2_precomp")));
-    compute_vk_rC_Z_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.rC_Z_g2, *pvk.vk_rC_Z_g2_precomp, libff::FMT(annotation_prefix, " compute_vk_rC_Z_g2_precomp")));
+    pvk.pp_G2_one_precomp.reset(new G2_precomputation<ppT>(pb, libff::G2<other_curve<ppT> >::one(), FMT(annotation_prefix, " pp_G2_one_precomp")));
+    compute_vk_alphaA_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.alphaA_g2, *pvk.vk_alphaA_g2_precomp, FMT(annotation_prefix, " compute_vk_alphaA_g2_precomp")));
+    compute_vk_alphaC_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.alphaC_g2, *pvk.vk_alphaC_g2_precomp, FMT(annotation_prefix, " compute_vk_alphaC_g2_precomp")));
+    compute_vk_gamma_beta_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.gamma_beta_g2, *pvk.vk_gamma_beta_g2_precomp, FMT(annotation_prefix, " compute_vk_gamma_beta_g2_precomp")));
+    compute_vk_gamma_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.gamma_g2, *pvk.vk_gamma_g2_precomp, FMT(annotation_prefix, " compute_vk_gamma_g2_precomp")));
+    compute_vk_rC_Z_g2_precomp.reset(new precompute_G2_gadget<ppT>(pb, *vk.rC_Z_g2, *pvk.vk_rC_Z_g2_precomp, FMT(annotation_prefix, " compute_vk_rC_Z_g2_precomp")));
 }
 
 template<typename ppT>
@@ -337,13 +337,13 @@ r1cs_ppzksnark_online_verifier_gadget<ppT>::r1cs_ppzksnark_online_verifier_gadge
     input_len(input.size())
 {
     // accumulate input and store base in acc
-    acc.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " acc")));
+    acc.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " acc")));
     std::vector<G1_variable<ppT> > IC_terms;
     for (size_t i = 0; i < pvk.encoded_IC_query.size(); ++i)
     {
         IC_terms.emplace_back(*(pvk.encoded_IC_query[i]));
     }
-    accumulate_input.reset(new G1_multiscalar_mul_gadget<ppT>(pb, *(pvk.encoded_IC_base), input, elt_size, IC_terms, *acc, libff::FMT(annotation_prefix, " accumulate_input")));
+    accumulate_input.reset(new G1_multiscalar_mul_gadget<ppT>(pb, *(pvk.encoded_IC_base), input, elt_size, IC_terms, *acc, FMT(annotation_prefix, " accumulate_input")));
 
     // allocate results for precomputation
     proof_g_A_h_precomp.reset(new G1_precomputation<ppT>());
@@ -360,43 +360,43 @@ r1cs_ppzksnark_online_verifier_gadget<ppT>::r1cs_ppzksnark_online_verifier_gadge
 
     // do the necessary precomputations
     // compute things not available in plain from proof/vk
-    proof_g_A_g_acc.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " proof_g_A_g_acc")));
-    compute_proof_g_A_g_acc.reset(new G1_add_gadget<ppT>(pb, *(proof.g_A_g), *acc , *proof_g_A_g_acc, libff::FMT(annotation_prefix, " compute_proof_g_A_g_acc")));
-    proof_g_A_g_acc_C.reset(new G1_variable<ppT>(pb, libff::FMT(annotation_prefix, " proof_g_A_g_acc_C")));
-    compute_proof_g_A_g_acc_C.reset(new G1_add_gadget<ppT>(pb, *proof_g_A_g_acc, *(proof.g_C_g) , *proof_g_A_g_acc_C, libff::FMT(annotation_prefix, " compute_proof_g_A_g_acc_C")));
+    proof_g_A_g_acc.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " proof_g_A_g_acc")));
+    compute_proof_g_A_g_acc.reset(new G1_add_gadget<ppT>(pb, *(proof.g_A_g), *acc , *proof_g_A_g_acc, FMT(annotation_prefix, " compute_proof_g_A_g_acc")));
+    proof_g_A_g_acc_C.reset(new G1_variable<ppT>(pb, FMT(annotation_prefix, " proof_g_A_g_acc_C")));
+    compute_proof_g_A_g_acc_C.reset(new G1_add_gadget<ppT>(pb, *proof_g_A_g_acc, *(proof.g_C_g) , *proof_g_A_g_acc_C, FMT(annotation_prefix, " compute_proof_g_A_g_acc_C")));
 
-    compute_proof_g_A_g_acc_precomp.reset(new precompute_G1_gadget<ppT>(pb, *proof_g_A_g_acc, *proof_g_A_g_acc_precomp, libff::FMT(annotation_prefix, " compute_proof_g_A_g_acc_precomp")));
-    compute_proof_g_A_g_acc_C_precomp.reset(new precompute_G1_gadget<ppT>(pb, *proof_g_A_g_acc_C, *proof_g_A_g_acc_C_precomp, libff::FMT(annotation_prefix, " compute_proof_g_A_g_acc_C_precomp")));
+    compute_proof_g_A_g_acc_precomp.reset(new precompute_G1_gadget<ppT>(pb, *proof_g_A_g_acc, *proof_g_A_g_acc_precomp, FMT(annotation_prefix, " compute_proof_g_A_g_acc_precomp")));
+    compute_proof_g_A_g_acc_C_precomp.reset(new precompute_G1_gadget<ppT>(pb, *proof_g_A_g_acc_C, *proof_g_A_g_acc_C_precomp, FMT(annotation_prefix, " compute_proof_g_A_g_acc_C_precomp")));
 
     // do other precomputations
-    compute_proof_g_A_h_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_A_h), *proof_g_A_h_precomp, libff::FMT(annotation_prefix, " compute_proof_g_A_h_precomp")));
-    compute_proof_g_A_g_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_A_g), *proof_g_A_g_precomp, libff::FMT(annotation_prefix, " compute_proof_g_A_g_precomp")));
-    compute_proof_g_B_h_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_B_h), *proof_g_B_h_precomp, libff::FMT(annotation_prefix, " compute_proof_g_B_h_precomp")));
-    compute_proof_g_C_h_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_C_h), *proof_g_C_h_precomp, libff::FMT(annotation_prefix, " compute_proof_g_C_h_precomp")));
-    compute_proof_g_C_g_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_C_g), *proof_g_C_g_precomp, libff::FMT(annotation_prefix, " compute_proof_g_C_g_precomp")));
-    compute_proof_g_H_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_H), *proof_g_H_precomp, libff::FMT(annotation_prefix, " compute_proof_g_H_precomp")));
-    compute_proof_g_K_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_K), *proof_g_K_precomp, libff::FMT(annotation_prefix, " compute_proof_g_K_precomp")));
-    compute_proof_g_B_g_precomp.reset(new precompute_G2_gadget<ppT>(pb, *(proof.g_B_g), *proof_g_B_g_precomp, libff::FMT(annotation_prefix, " compute_proof_g_B_g_precomp")));
+    compute_proof_g_A_h_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_A_h), *proof_g_A_h_precomp, FMT(annotation_prefix, " compute_proof_g_A_h_precomp")));
+    compute_proof_g_A_g_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_A_g), *proof_g_A_g_precomp, FMT(annotation_prefix, " compute_proof_g_A_g_precomp")));
+    compute_proof_g_B_h_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_B_h), *proof_g_B_h_precomp, FMT(annotation_prefix, " compute_proof_g_B_h_precomp")));
+    compute_proof_g_C_h_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_C_h), *proof_g_C_h_precomp, FMT(annotation_prefix, " compute_proof_g_C_h_precomp")));
+    compute_proof_g_C_g_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_C_g), *proof_g_C_g_precomp, FMT(annotation_prefix, " compute_proof_g_C_g_precomp")));
+    compute_proof_g_H_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_H), *proof_g_H_precomp, FMT(annotation_prefix, " compute_proof_g_H_precomp")));
+    compute_proof_g_K_precomp.reset(new precompute_G1_gadget<ppT>(pb, *(proof.g_K), *proof_g_K_precomp, FMT(annotation_prefix, " compute_proof_g_K_precomp")));
+    compute_proof_g_B_g_precomp.reset(new precompute_G2_gadget<ppT>(pb, *(proof.g_B_g), *proof_g_B_g_precomp, FMT(annotation_prefix, " compute_proof_g_B_g_precomp")));
 
     // check validity of A knowledge commitment
-    kc_A_valid.allocate(pb, libff::FMT(annotation_prefix, " kc_A_valid"));
-    check_kc_A_valid.reset(new check_e_equals_e_gadget<ppT>(pb, *proof_g_A_g_precomp, *(pvk.vk_alphaA_g2_precomp), *proof_g_A_h_precomp, *(pvk.pp_G2_one_precomp), kc_A_valid, libff::FMT(annotation_prefix, " check_kc_A_valid")));
+    kc_A_valid.allocate(pb, FMT(annotation_prefix, " kc_A_valid"));
+    check_kc_A_valid.reset(new check_e_equals_e_gadget<ppT>(pb, *proof_g_A_g_precomp, *(pvk.vk_alphaA_g2_precomp), *proof_g_A_h_precomp, *(pvk.pp_G2_one_precomp), kc_A_valid, FMT(annotation_prefix, " check_kc_A_valid")));
 
     // check validity of B knowledge commitment
-    kc_B_valid.allocate(pb, libff::FMT(annotation_prefix, " kc_B_valid"));
-    check_kc_B_valid.reset(new check_e_equals_e_gadget<ppT>(pb, *(pvk.vk_alphaB_g1_precomp), *proof_g_B_g_precomp, *proof_g_B_h_precomp, *(pvk.pp_G2_one_precomp), kc_B_valid, libff::FMT(annotation_prefix, " check_kc_B_valid")));
+    kc_B_valid.allocate(pb, FMT(annotation_prefix, " kc_B_valid"));
+    check_kc_B_valid.reset(new check_e_equals_e_gadget<ppT>(pb, *(pvk.vk_alphaB_g1_precomp), *proof_g_B_g_precomp, *proof_g_B_h_precomp, *(pvk.pp_G2_one_precomp), kc_B_valid, FMT(annotation_prefix, " check_kc_B_valid")));
 
     // check validity of C knowledge commitment
-    kc_C_valid.allocate(pb, libff::FMT(annotation_prefix, " kc_C_valid"));
-    check_kc_C_valid.reset(new check_e_equals_e_gadget<ppT>(pb, *proof_g_C_g_precomp, *(pvk.vk_alphaC_g2_precomp), *proof_g_C_h_precomp, *(pvk.pp_G2_one_precomp), kc_C_valid, libff::FMT(annotation_prefix, " check_kc_C_valid")));
+    kc_C_valid.allocate(pb, FMT(annotation_prefix, " kc_C_valid"));
+    check_kc_C_valid.reset(new check_e_equals_e_gadget<ppT>(pb, *proof_g_C_g_precomp, *(pvk.vk_alphaC_g2_precomp), *proof_g_C_h_precomp, *(pvk.pp_G2_one_precomp), kc_C_valid, FMT(annotation_prefix, " check_kc_C_valid")));
 
     // check QAP divisibility
-    QAP_valid.allocate(pb, libff::FMT(annotation_prefix, " QAP_valid"));
-    check_QAP_valid.reset(new check_e_equals_ee_gadget<ppT>(pb, *proof_g_A_g_acc_precomp, *proof_g_B_g_precomp, *proof_g_H_precomp, *(pvk.vk_rC_Z_g2_precomp), *proof_g_C_g_precomp, *(pvk.pp_G2_one_precomp), QAP_valid, libff::FMT(annotation_prefix, " check_QAP_valid")));
+    QAP_valid.allocate(pb, FMT(annotation_prefix, " QAP_valid"));
+    check_QAP_valid.reset(new check_e_equals_ee_gadget<ppT>(pb, *proof_g_A_g_acc_precomp, *proof_g_B_g_precomp, *proof_g_H_precomp, *(pvk.vk_rC_Z_g2_precomp), *proof_g_C_g_precomp, *(pvk.pp_G2_one_precomp), QAP_valid, FMT(annotation_prefix, " check_QAP_valid")));
 
     // check coefficients
-    CC_valid.allocate(pb, libff::FMT(annotation_prefix, " CC_valid"));
-    check_CC_valid.reset(new check_e_equals_ee_gadget<ppT>(pb, *proof_g_K_precomp, *(pvk.vk_gamma_g2_precomp), *proof_g_A_g_acc_C_precomp, *(pvk.vk_gamma_beta_g2_precomp), *(pvk.vk_gamma_beta_g1_precomp), *proof_g_B_g_precomp, CC_valid, libff::FMT(annotation_prefix, " check_CC_valid")));
+    CC_valid.allocate(pb, FMT(annotation_prefix, " CC_valid"));
+    check_CC_valid.reset(new check_e_equals_ee_gadget<ppT>(pb, *proof_g_K_precomp, *(pvk.vk_gamma_g2_precomp), *proof_g_A_g_acc_C_precomp, *(pvk.vk_gamma_beta_g2_precomp), *(pvk.vk_gamma_beta_g1_precomp), *proof_g_B_g_precomp, CC_valid, FMT(annotation_prefix, " check_CC_valid")));
 
     // final constraint
     all_test_results.emplace_back(kc_A_valid);
@@ -405,7 +405,7 @@ r1cs_ppzksnark_online_verifier_gadget<ppT>::r1cs_ppzksnark_online_verifier_gadge
     all_test_results.emplace_back(QAP_valid);
     all_test_results.emplace_back(CC_valid);
 
-    all_tests_pass.reset(new conjunction_gadget<FieldT>(pb, all_test_results, result, libff::FMT(annotation_prefix, " all_tests_pass")));
+    all_tests_pass.reset(new conjunction_gadget<FieldT>(pb, all_test_results, result, FMT(annotation_prefix, " all_tests_pass")));
 }
 
 template<typename ppT>
@@ -484,8 +484,8 @@ r1cs_ppzksnark_verifier_gadget<ppT>::r1cs_ppzksnark_verifier_gadget(protoboard<F
     gadget<FieldT>(pb, annotation_prefix)
 {
     pvk.reset(new r1cs_ppzksnark_preprocessed_r1cs_ppzksnark_verification_key_variable<ppT>());
-    compute_pvk.reset(new r1cs_ppzksnark_verifier_process_vk_gadget<ppT>(pb, vk, *pvk, libff::FMT(annotation_prefix, " compute_pvk")));
-    online_verifier.reset(new r1cs_ppzksnark_online_verifier_gadget<ppT>(pb, *pvk, input, elt_size, proof, result, libff::FMT(annotation_prefix, " online_verifier")));
+    compute_pvk.reset(new r1cs_ppzksnark_verifier_process_vk_gadget<ppT>(pb, vk, *pvk, FMT(annotation_prefix, " compute_pvk")));
+    online_verifier.reset(new r1cs_ppzksnark_online_verifier_gadget<ppT>(pb, *pvk, input, elt_size, proof, result, FMT(annotation_prefix, " online_verifier")));
 }
 
 template<typename ppT>

--- a/src/gadgetlib1/pb_variable.tcc
+++ b/src/gadgetlib1/pb_variable.tcc
@@ -30,7 +30,7 @@ void pb_variable_array<FieldT>::allocate(protoboard<FieldT> &pb, const size_t n,
 
     for (size_t i = 0; i < n; ++i)
     {
-        (*this)[i].allocate(pb, libff::FMT(annotation_prefix, "_%zu", i));
+        (*this)[i].allocate(pb, FMT(annotation_prefix, "_%zu", i));
     }
 }
 

--- a/src/gadgetlib2/infrastructure.hpp
+++ b/src/gadgetlib2/infrastructure.hpp
@@ -44,7 +44,7 @@
 /********************************************************/
 
 namespace gadgetlib2 {
-// someday, if/when MSVC supports C++0x variadic templates, change libff::FMT in release version to the
+// someday, if/when MSVC supports C++0x variadic templates, change FMT in release version to the
 // following in order to increase efficiency:
 // #define GADGETLIB2_FMT(...) ""
 ::std::string GADGETLIB2_FMT(const char* format, ...);

--- a/src/gadgetlib2/variable.cpp
+++ b/src/gadgetlib2/variable.cpp
@@ -312,9 +312,9 @@ VariableArray::VariableArray(const size_t size, const ::std::string& name) : Var
 
 VariableArray::VariableArray(const string& name) : VariableArrayContents() { libff::UNUSED(name); }
 VariableArray::VariableArray(const int size, const ::std::string& name)
-    : VariableArrayContents(size) { libff:UNUSED(name); }
+    : VariableArrayContents(size) { libff::UNUSED(name); }
 VariableArray::VariableArray(const size_t size, const ::std::string& name)
-    : VariableArrayContents(size) { libff:UNUSED(name); }
+    : VariableArrayContents(size) { libff::UNUSED(name); }
 #endif
 
 /***********************************/

--- a/src/reductions/bacs_to_r1cs/bacs_to_r1cs.tcc
+++ b/src/reductions/bacs_to_r1cs/bacs_to_r1cs.tcc
@@ -52,7 +52,7 @@ r1cs_constraint_system<FieldT> bacs_to_r1cs_instance_map(const bacs_circuit<Fiel
             result.constraints.emplace_back(r1cs_constraint<FieldT>(1, g.output, 0));
 
 #ifdef DEBUG
-            result.constraint_annotations[result.constraints.size()-1] = libff::FMT("", "output_%zu_is_circuit_output", g.output.index);
+            result.constraint_annotations[result.constraints.size()-1] = FMT("", "output_%zu_is_circuit_output", g.output.index);
 #endif
         }
     }

--- a/src/reductions/ram_to_r1cs/gadgets/memory_checker_gadget.tcc
+++ b/src/reductions/ram_to_r1cs/gadgets/memory_checker_gadget.tcc
@@ -25,19 +25,19 @@ memory_checker_gadget<ramT>::memory_checker_gadget(ram_protoboard<ramT> &pb,
     ram_gadget_base<ramT>(pb, annotation_prefix), line1(line1), line2(line2)
 {
     /* compare the two timestamps */
-    timestamps_leq.allocate(pb, libff::FMT(this->annotation_prefix, " timestamps_leq"));
-    timestamps_less.allocate(pb, libff::FMT(this->annotation_prefix, " timestamps_less"));
+    timestamps_leq.allocate(pb, FMT(this->annotation_prefix, " timestamps_leq"));
+    timestamps_less.allocate(pb, FMT(this->annotation_prefix, " timestamps_less"));
     compare_timestamps.reset(new comparison_gadget<FieldT>(pb, timestamp_size, line1.timestamp->packed, line2.timestamp->packed, timestamps_less, timestamps_leq,
-                                                           libff::FMT(this->annotation_prefix, " compare_ts")));
+                                                           FMT(this->annotation_prefix, " compare_ts")));
 
 
     /* compare the two addresses */
     const size_t address_size = pb.ap.address_size();
-    addresses_eq.allocate(pb, libff::FMT(this->annotation_prefix, " addresses_eq"));
-    addresses_leq.allocate(pb, libff::FMT(this->annotation_prefix, " addresses_leq"));
-    addresses_less.allocate(pb, libff::FMT(this->annotation_prefix, " addresses_less"));
+    addresses_eq.allocate(pb, FMT(this->annotation_prefix, " addresses_eq"));
+    addresses_leq.allocate(pb, FMT(this->annotation_prefix, " addresses_leq"));
+    addresses_less.allocate(pb, FMT(this->annotation_prefix, " addresses_less"));
     compare_addresses.reset(new comparison_gadget<FieldT>(pb, address_size, line1.address->packed, line2.address->packed, addresses_less, addresses_leq,
-                                                          libff::FMT(this->annotation_prefix, " compare_addresses")));
+                                                          FMT(this->annotation_prefix, " compare_addresses")));
 
     /*
       Add variables that will contain flags representing the following relations:
@@ -48,9 +48,9 @@ memory_checker_gadget<ramT>::memory_checker_gadget(ram_protoboard<ramT> &pb,
       More precisely, each of the above flags is "loose" (i.e., it equals 0 if
       the relation holds, but can be either 0 or 1 if the relation does not hold).
      */
-    loose_contents_after1_equals_contents_before2.allocate(pb, libff::FMT(this->annotation_prefix, " loose_contents_after1_equals_contents_before2"));
-    loose_contents_before2_equals_zero.allocate(pb, libff::FMT(this->annotation_prefix, " loose_contents_before2_equals_zero"));
-    loose_timestamp2_is_zero.allocate(pb, libff::FMT(this->annotation_prefix, " loose_timestamp2_is_zero"));
+    loose_contents_after1_equals_contents_before2.allocate(pb, FMT(this->annotation_prefix, " loose_contents_after1_equals_contents_before2"));
+    loose_contents_before2_equals_zero.allocate(pb, FMT(this->annotation_prefix, " loose_contents_before2_equals_zero"));
+    loose_timestamp2_is_zero.allocate(pb, FMT(this->annotation_prefix, " loose_timestamp2_is_zero"));
 }
 
 template<typename ramT>
@@ -61,7 +61,7 @@ void memory_checker_gadget<ramT>::generate_r1cs_constraints()
 
     /* compare the two addresses */
     compare_addresses->generate_r1cs_constraints();
-    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(addresses_leq, 1 - addresses_less, addresses_eq), libff::FMT(this->annotation_prefix, " addresses_eq"));
+    this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(addresses_leq, 1 - addresses_less, addresses_eq), FMT(this->annotation_prefix, " addresses_eq"));
 
     /*
       Add constraints for the following three flags:
@@ -71,18 +71,18 @@ void memory_checker_gadget<ramT>::generate_r1cs_constraints()
      */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(loose_contents_after1_equals_contents_before2,
                                                          line1.contents_after->packed - line2.contents_before->packed, 0),
-                                 libff::FMT(this->annotation_prefix, " loose_contents_after1_equals_contents_before2"));
-    generate_boolean_r1cs_constraint<FieldT>(this->pb, loose_contents_after1_equals_contents_before2, libff::FMT(this->annotation_prefix, " loose_contents_after1_equals_contents_before2"));
+                                 FMT(this->annotation_prefix, " loose_contents_after1_equals_contents_before2"));
+    generate_boolean_r1cs_constraint<FieldT>(this->pb, loose_contents_after1_equals_contents_before2, FMT(this->annotation_prefix, " loose_contents_after1_equals_contents_before2"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(loose_contents_before2_equals_zero,
                                                          line2.contents_before->packed, 0),
-                                 libff::FMT(this->annotation_prefix, " loose_contents_before2_equals_zero"));
-    generate_boolean_r1cs_constraint<FieldT>(this->pb, loose_contents_before2_equals_zero, libff::FMT(this->annotation_prefix, " loose_contents_before2_equals_zero"));
+                                 FMT(this->annotation_prefix, " loose_contents_before2_equals_zero"));
+    generate_boolean_r1cs_constraint<FieldT>(this->pb, loose_contents_before2_equals_zero, FMT(this->annotation_prefix, " loose_contents_before2_equals_zero"));
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(loose_timestamp2_is_zero,
                                                          line2.timestamp->packed, 0),
-                                 libff::FMT(this->annotation_prefix, " loose_timestamp2_is_zero"));
-    generate_boolean_r1cs_constraint<FieldT>(this->pb, loose_timestamp2_is_zero, libff::FMT(this->annotation_prefix, " loose_timestamp2_is_zero"));
+                                 FMT(this->annotation_prefix, " loose_timestamp2_is_zero"));
+    generate_boolean_r1cs_constraint<FieldT>(this->pb, loose_timestamp2_is_zero, FMT(this->annotation_prefix, " loose_timestamp2_is_zero"));
 
     /*
       The three cases that need to be checked are:
@@ -101,11 +101,11 @@ void memory_checker_gadget<ramT>::generate_r1cs_constraints()
       As usual, we implement "A => B" as "NOT (A AND (NOT B))".
     */
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(addresses_eq, 1 - loose_contents_after1_equals_contents_before2, 0),
-                                 libff::FMT(this->annotation_prefix, " memory_retains_contents_between_accesses"));
+                                 FMT(this->annotation_prefix, " memory_retains_contents_between_accesses"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(addresses_less, 1 - loose_contents_before2_equals_zero, 0),
-                                 libff::FMT(this->annotation_prefix, " new_address_starts_at_zero"));
+                                 FMT(this->annotation_prefix, " new_address_starts_at_zero"));
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1 - addresses_leq, 1 - loose_timestamp2_is_zero, 0),
-                                 libff::FMT(this->annotation_prefix, " only_one_cycle"));
+                                 FMT(this->annotation_prefix, " only_one_cycle"));
 }
 
 template<typename ramT>

--- a/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
+++ b/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
@@ -39,7 +39,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
     /* allocate all lines on the execution side of the routing network */
     libff::enter_block("Allocate initial state line");
     execution_lines.reserve(1 + time_bound);
-    execution_lines.emplace_back(execution_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, libff::FMT(annotation_prefix, " execution_lines_%zu", 0)));
+    execution_lines.emplace_back(execution_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, FMT(annotation_prefix, " execution_lines_%zu", 0)));
     unrouted_memory_lines.emplace_back(&execution_lines[0]);
     libff::leave_block("Allocate initial state line");
 
@@ -47,7 +47,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
     boot_lines.reserve(boot_trace_size_bound);
     for (size_t i = 0; i < boot_trace_size_bound; ++i)
     {
-        boot_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, libff::FMT(annotation_prefix, " boot_lines_%zu", i)));
+        boot_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, FMT(annotation_prefix, " boot_lines_%zu", i)));
         unrouted_memory_lines.emplace_back(&boot_lines[i]);
     }
     libff::leave_block("Allocate boot lines");
@@ -56,13 +56,13 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
     load_instruction_lines.reserve(time_bound+1); /* the last line is NOT a memory line, but here just for uniform coding (i.e. the (unusued) result of next PC) */
     for (size_t i = 0; i < time_bound; ++i)
     {
-        load_instruction_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, libff::FMT(annotation_prefix, " load_instruction_lines_%zu", i)));
+        load_instruction_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, FMT(annotation_prefix, " load_instruction_lines_%zu", i)));
         unrouted_memory_lines.emplace_back(&load_instruction_lines[i]);
 
-        execution_lines.emplace_back(execution_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, libff::FMT(annotation_prefix, " execution_lines_%zu", i+1)));
+        execution_lines.emplace_back(execution_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, FMT(annotation_prefix, " execution_lines_%zu", i+1)));
         unrouted_memory_lines.emplace_back(&execution_lines[i+1]);
     }
-    load_instruction_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, libff::FMT(annotation_prefix, " load_instruction_lines_%zu", time_bound)));
+    load_instruction_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, FMT(annotation_prefix, " load_instruction_lines_%zu", time_bound)));
     libff::leave_block("Allocate instruction fetch and execution lines");
 
     /* deal with packing of the input */
@@ -83,7 +83,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
         pb_variable_array<FieldT> packed_boot_line = pb_variable_array<FieldT>(input_it, input_it + packed_line_size);
         std::advance(input_it, packed_line_size);
 
-        unpack_boot_lines.emplace_back(multipacking_gadget<FieldT>(pb, boot_line_bits, packed_boot_line, max_chunk_size, libff::FMT(annotation_prefix, " unpack_boot_lines_%zu", i)));
+        unpack_boot_lines.emplace_back(multipacking_gadget<FieldT>(pb, boot_line_bits, packed_boot_line, max_chunk_size, FMT(annotation_prefix, " unpack_boot_lines_%zu", i)));
     }
     libff::leave_block("Pack input");
 
@@ -91,7 +91,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
     libff::enter_block("Allocate routed memory lines");
     for (size_t i = 0; i < num_memory_lines; ++i)
     {
-        routed_memory_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, libff::FMT(annotation_prefix, " routed_memory_lines_%zu", i)));
+        routed_memory_lines.emplace_back(memory_line_variable_gadget<ramT>(pb, timestamp_size, pb.ap, FMT(annotation_prefix, " routed_memory_lines_%zu", i)));
     }
     libff::leave_block("Allocate routed memory lines");
 
@@ -107,7 +107,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
     libff::leave_block("Collect inputs/outputs for the routing network");
 
     libff::enter_block("Allocate routing network");
-    routing_network.reset(new as_waksman_routing_gadget<FieldT>(pb, num_memory_lines, routing_inputs, routing_outputs, libff::FMT(this->annotation_prefix, " routing_network")));
+    routing_network.reset(new as_waksman_routing_gadget<FieldT>(pb, num_memory_lines, routing_inputs, routing_outputs, FMT(this->annotation_prefix, " routing_network")));
     libff::leave_block("Allocate routing network");
 
     /* deal with all checkers */
@@ -125,7 +125,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
                                                               execution_lines[i+1].cpu_state, // next_state
                                                               load_instruction_lines[i+1].address->bits, // next_pc_addr
                                                               execution_lines[i+1].has_accepted, // next_has_accepted
-                                                              libff::FMT(annotation_prefix, " execution_checkers_%zu", i)));
+                                                              FMT(annotation_prefix, " execution_checkers_%zu", i)));
     }
     libff::leave_block("Allocate execution checkers");
 
@@ -137,7 +137,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
                                                                  timestamp_size,
                                                                  *unrouted_memory_lines[i],
                                                                  routed_memory_lines[i],
-                                                                 libff::FMT(this->annotation_prefix, " memory_checkers_%zu", i)));
+                                                                 FMT(this->annotation_prefix, " memory_checkers_%zu", i)));
     }
     libff::leave_block("Allocate all memory checkers");
 
@@ -189,7 +189,7 @@ void ram_universal_gadget<ramT>::generate_r1cs_constraints()
     {
         this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, load_instruction_lines[i].contents_before->packed,
                                                              load_instruction_lines[i].contents_after->packed),
-                                     libff::FMT(this->annotation_prefix, " load_instruction_%zu_is_a_load", i));
+                                     FMT(this->annotation_prefix, " load_instruction_%zu_is_a_load", i));
     }
 
     /* ensure correct execution */

--- a/src/reductions/ram_to_r1cs/gadgets/trace_lines.tcc
+++ b/src/reductions/ram_to_r1cs/gadgets/trace_lines.tcc
@@ -26,10 +26,10 @@ memory_line_variable_gadget<ramT>::memory_line_variable_gadget(ram_protoboard<ra
     const size_t address_size = ap.address_size();
     const size_t value_size = ap.value_size();
 
-    timestamp.reset(new dual_variable_gadget<FieldT>(pb, timestamp_size, libff::FMT(this->annotation_prefix, " timestamp")));
-    address.reset(new dual_variable_gadget<FieldT>(pb, address_size, libff::FMT(this->annotation_prefix, " address")));
-    contents_before.reset(new dual_variable_gadget<FieldT>(pb, value_size, libff::FMT(this->annotation_prefix, " contents_before")));
-    contents_after.reset(new dual_variable_gadget<FieldT>(pb, value_size, libff::FMT(this->annotation_prefix, " contents_after")));
+    timestamp.reset(new dual_variable_gadget<FieldT>(pb, timestamp_size, FMT(this->annotation_prefix, " timestamp")));
+    address.reset(new dual_variable_gadget<FieldT>(pb, address_size, FMT(this->annotation_prefix, " address")));
+    contents_before.reset(new dual_variable_gadget<FieldT>(pb, value_size, FMT(this->annotation_prefix, " contents_before")));
+    contents_after.reset(new dual_variable_gadget<FieldT>(pb, value_size, FMT(this->annotation_prefix, " contents_after")));
 }
 
 template<typename ramT>
@@ -80,8 +80,8 @@ execution_line_variable_gadget<ramT>::execution_line_variable_gadget(ram_protobo
 {
     const size_t cpu_state_size = ap.cpu_state_size();
 
-    cpu_state.allocate(pb, cpu_state_size, libff::FMT(annotation_prefix, " cpu_state"));
-    has_accepted.allocate(pb, libff::FMT(annotation_prefix, " has_accepted"));
+    cpu_state.allocate(pb, cpu_state_size, FMT(annotation_prefix, " cpu_state"));
+    has_accepted.allocate(pb, FMT(annotation_prefix, " has_accepted"));
 }
 
 

--- a/src/reductions/tbcs_to_uscs/tbcs_to_uscs.tcc
+++ b/src/reductions/tbcs_to_uscs/tbcs_to_uscs.tcc
@@ -39,7 +39,7 @@ uscs_constraint_system<FieldT> tbcs_to_uscs_instance_map(const tbcs_circuit &cir
 
 #ifdef DEBUG
         auto it = circuit.gate_annotations.find(g.output);
-        const std::string annotation = (it != circuit.gate_annotations.end() ? it->second : libff::FMT("", "compute_wire_%zu", g.output));
+        const std::string annotation = (it != circuit.gate_annotations.end() ? it->second : FMT("", "compute_wire_%zu", g.output));
 #else
         const std::string annotation = "";
 #endif
@@ -134,7 +134,7 @@ uscs_constraint_system<FieldT> tbcs_to_uscs_instance_map(const tbcs_circuit &cir
     for (size_t i = 0; i < circuit.primary_input_size + circuit.auxiliary_input_size + circuit.gates.size(); ++i)
     {
         /* require that 2 * wire - 1 \in {-1,1}, that is wire \in {0,1} */
-        result.add_constraint(2 * variable<FieldT>(i) - 1, libff::FMT("", "wire_%zu", i));
+        result.add_constraint(2 * variable<FieldT>(i) - 1, FMT("", "wire_%zu", i));
     }
 
     for (auto &g : circuit.gates)
@@ -142,7 +142,7 @@ uscs_constraint_system<FieldT> tbcs_to_uscs_instance_map(const tbcs_circuit &cir
         if (g.is_circuit_output)
         {
             /* require that output + 1 \in {-1,1}, this together with output binary (above) enforces output = 0 */
-            result.add_constraint(variable<FieldT>(g.output) + 1, libff::FMT("", "output_%zu", g.output));
+            result.add_constraint(variable<FieldT>(g.output) + 1, FMT("", "output_%zu", g.output));
         }
     }
 

--- a/src/relations/constraint_satisfaction_problems/r1cs/r1cs.tcc
+++ b/src/relations/constraint_satisfaction_problems/r1cs/r1cs.tcc
@@ -300,7 +300,7 @@ void r1cs_constraint_system<FieldT>::report_linear_constraint_statistics() const
         if (a_is_const || b_is_const)
         {
             auto it = constraint_annotations.find(i);
-            printf("%s\n", (it == constraint_annotations.end() ? libff::FMT("", "constraint_%zu", i) : it->second).c_str());
+            printf("%s\n", (it == constraint_annotations.end() ? FMT("", "constraint_%zu", i) : it->second).c_str());
         }
     }
 #endif

--- a/src/relations/constraint_satisfaction_problems/uscs/uscs.tcc
+++ b/src/relations/constraint_satisfaction_problems/uscs/uscs.tcc
@@ -181,7 +181,7 @@ void uscs_constraint_system<FieldT>::report_linear_constraint_statistics() const
         if (a_is_const)
         {
             auto it = constraint_annotations.find(i);
-            printf("%s\n", (it == constraint_annotations.end() ? libff::FMT("", "constraint_%zu", i) : it->second).c_str());
+            printf("%s\n", (it == constraint_annotations.end() ? FMT("", "constraint_%zu", i) : it->second).c_str());
         }
     }
 #endif

--- a/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.tcc
@@ -23,7 +23,7 @@ r1cs_pcd_message_variable<FieldT>::r1cs_pcd_message_variable(protoboard<FieldT> 
                                                              const std::string &annotation_prefix) :
     gadget<FieldT>(pb, annotation_prefix)
 {
-    type.allocate(pb, libff::FMT(annotation_prefix, " type"));
+    type.allocate(pb, FMT(annotation_prefix, " type"));
     all_vars.emplace_back(type);
 
     num_vars_at_construction = pb.num_variables();

--- a/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.tcc
@@ -84,8 +84,8 @@ public:
                                const std::string &annotation_prefix) :
         r1cs_pcd_message_variable<FieldT>(pb, annotation_prefix), wordsize(wordsize)
     {
-        sum_bits.allocate(pb, wordsize, libff::FMT(annotation_prefix, " sum_bits"));
-        count_bits.allocate(pb, wordsize, libff::FMT(annotation_prefix, " count_bits"));
+        sum_bits.allocate(pb, wordsize, FMT(annotation_prefix, " sum_bits"));
+        count_bits.allocate(pb, wordsize, FMT(annotation_prefix, " count_bits"));
 
         this->update_all_vars();
     }
@@ -114,7 +114,7 @@ public:
                                   const std::string &annotation_prefix) :
         r1cs_pcd_local_data_variable<FieldT>(pb, annotation_prefix)
     {
-        summand.allocate(pb, libff::FMT(annotation_prefix, " summand"));
+        summand.allocate(pb, FMT(annotation_prefix, " summand"));
 
         this->update_all_vars();
     }
@@ -148,7 +148,7 @@ tally_cp_handler<FieldT>::tally_cp_handler(const size_t type, const size_t max_a
 
     for (size_t i = 0; i < max_arity; ++i)
     {
-        this->incoming_messages[i].reset(new tally_pcd_message_variable<FieldT>(this->pb, wordsize, libff::FMT("", "incoming_messages_%zu", i)));
+        this->incoming_messages[i].reset(new tally_pcd_message_variable<FieldT>(this->pb, wordsize, FMT("", "incoming_messages_%zu", i)));
     }
 
     this->local_data.reset(new tally_pcd_local_data_variable<FieldT>(this->pb, "local_data"));
@@ -175,8 +175,8 @@ tally_cp_handler<FieldT>::tally_cp_handler(const size_t type, const size_t max_a
 
     for (size_t i = 0; i < max_arity; ++i)
     {
-        pack_sum_in.emplace_back(packing_gadget<FieldT>(this->pb, std::dynamic_pointer_cast<tally_pcd_message_variable<FieldT> >(this->incoming_messages[i])->sum_bits, sum_in_packed[i], libff::FMT("", "pack_sum_in_%zu", i)));
-        pack_count_in.emplace_back(packing_gadget<FieldT>(this->pb, std::dynamic_pointer_cast<tally_pcd_message_variable<FieldT> >(this->incoming_messages[i])->sum_bits, count_in_packed[i], libff::FMT("", "pack_count_in_%zu", i)));
+        pack_sum_in.emplace_back(packing_gadget<FieldT>(this->pb, std::dynamic_pointer_cast<tally_pcd_message_variable<FieldT> >(this->incoming_messages[i])->sum_bits, sum_in_packed[i], FMT("", "pack_sum_in_%zu", i)));
+        pack_count_in.emplace_back(packing_gadget<FieldT>(this->pb, std::dynamic_pointer_cast<tally_pcd_message_variable<FieldT> >(this->incoming_messages[i])->sum_bits, count_in_packed[i], FMT("", "pack_count_in_%zu", i)));
     }
 
     arity_indicators.allocate(this->pb, max_arity+1, "arity_indicators");
@@ -196,14 +196,14 @@ void tally_cp_handler<FieldT>::generate_r1cs_constraints()
 
     for (size_t i = 0; i < this->max_arity; ++i)
     {
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_types[i], sum_in_packed_aux[i], sum_in_packed[i]), libff::FMT("", "initial_sum_%zu_is_zero", i));
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_types[i], count_in_packed_aux[i], count_in_packed[i]), libff::FMT("", "initial_sum_%zu_is_zero", i));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_types[i], sum_in_packed_aux[i], sum_in_packed[i]), FMT("", "initial_sum_%zu_is_zero", i));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_types[i], count_in_packed_aux[i], count_in_packed[i]), FMT("", "initial_sum_%zu_is_zero", i));
     }
 
     /* constrain arity indicator variables so that arity_indicators[arity] = 1 and arity_indicators[i] = 0 for any other i */
     for (size_t i = 0; i < this->max_arity; ++i)
     {
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(this->arity - FieldT(i), arity_indicators[i], 0), libff::FMT("", "arity_indicators_%zu", i));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(this->arity - FieldT(i), arity_indicators[i], 0), FMT("", "arity_indicators_%zu", i));
     }
 
     this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, pb_sum<FieldT>(arity_indicators), 1), "arity_indicators");
@@ -211,7 +211,7 @@ void tally_cp_handler<FieldT>::generate_r1cs_constraints()
     /* require that types of messages that are past arity (i.e. unbound wires) carry 0 */
     for (size_t i = 0; i < this->max_arity; ++i)
     {
-        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(0 + pb_sum<FieldT>(pb_variable_array<FieldT>(arity_indicators.begin(), arity_indicators.begin() + i)), incoming_types[i], 0), libff::FMT("", "unbound_types_%zu", i));
+        this->pb.add_r1cs_constraint(r1cs_constraint<FieldT>(0 + pb_sum<FieldT>(pb_variable_array<FieldT>(arity_indicators.begin(), arity_indicators.begin() + i)), incoming_types[i], 0), FMT("", "unbound_types_%zu", i));
     }
 
     /* sum_out = local_data + \sum_i type[i] * sum_in[i] */

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
@@ -57,8 +57,8 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
     incoming_message_vars.resize(compliance_predicate.max_arity);
     for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
     {
-        incoming_message_types[i].allocate(pb, libff::FMT("", "incoming_message_type_%zu", i));
-        incoming_message_payloads[i].allocate(pb, compliance_predicate.incoming_message_payload_lengths[i], libff::FMT("", "incoming_message_payloads_%zu", i));
+        incoming_message_types[i].allocate(pb, FMT("", "incoming_message_type_%zu", i));
+        incoming_message_payloads[i].allocate(pb, compliance_predicate.incoming_message_payload_lengths[i], FMT("", "incoming_message_payloads_%zu", i));
 
         incoming_message_vars[i].insert(incoming_message_vars[i].end(), incoming_message_types[i]);
         incoming_message_vars[i].insert(incoming_message_vars[i].end(), incoming_message_payloads[i].begin(), incoming_message_payloads[i].end());
@@ -91,15 +91,15 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
     {
         const size_t incoming_msg_size_in_bits = field_logsize() * (1 + compliance_predicate.incoming_message_payload_lengths[i]);
 
-        incoming_messages_bits[i].allocate(pb, incoming_msg_size_in_bits, libff::FMT("", "incoming_messages_bits_%zu", i));
-        unpack_incoming_messages.emplace_back(multipacking_gadget<FieldT>(pb, incoming_messages_bits[i], incoming_message_vars[i], field_logsize(), libff::FMT("", "unpack_incoming_messages_%zu", i)));
+        incoming_messages_bits[i].allocate(pb, incoming_msg_size_in_bits, FMT("", "incoming_messages_bits_%zu", i));
+        unpack_incoming_messages.emplace_back(multipacking_gadget<FieldT>(pb, incoming_messages_bits[i], incoming_message_vars[i], field_logsize(), FMT("", "unpack_incoming_messages_%zu", i)));
     }
 
     /* allocate digests */
     commitment_and_incoming_message_digests.resize(compliance_predicate.max_arity);
     for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
     {
-        commitment_and_incoming_message_digests[i].allocate(pb, digest_size, libff::FMT("", "commitment_and_incoming_message_digests_%zu", i));
+        commitment_and_incoming_message_digests[i].allocate(pb, digest_size, FMT("", "commitment_and_incoming_message_digests_%zu", i));
     }
 
     /* allocate commitment, verification key(s) and membership checker(s)/proof(s) */
@@ -136,18 +136,18 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
 
         for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
         {
-            translation_step_vks_bits[i].allocate(pb, translation_step_vk_size_in_bits, libff::FMT("", "translation_step_vks_bits_%zu", i));
+            translation_step_vks_bits[i].allocate(pb, translation_step_vk_size_in_bits, FMT("", "translation_step_vks_bits_%zu", i));
 
             membership_proofs.emplace_back(set_membership_proof_variable<FieldT, CRH_with_bit_out_gadget<FieldT> >(pb,
                                                                                                                    max_number_of_predicates,
-                                                                                                                   libff::FMT("", "membership_proof_%zu", i)));
+                                                                                                                   FMT("", "membership_proof_%zu", i)));
             membership_checkers.emplace_back(set_commitment_gadget<FieldT, CRH_with_bit_out_gadget<FieldT> >(pb,
                                                                                                              max_number_of_predicates,
                                                                                                              translation_step_vks_bits[i],
                                                                                                              *commitment,
                                                                                                              membership_proofs[i],
                                                                                                              membership_check_results[i],
-                                                                                                             libff::FMT("", "membership_checkers_%zu", i)));
+                                                                                                             FMT("", "membership_checkers_%zu", i)));
         }
     }
 
@@ -156,7 +156,7 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
 
     for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
     {
-        block_for_incoming_messages.emplace_back(block_variable<FieldT>(pb, { commitment->bits, incoming_messages_bits[i] }, libff::FMT("", "block_for_incoming_messages_%zu", i)));
+        block_for_incoming_messages.emplace_back(block_variable<FieldT>(pb, { commitment->bits, incoming_messages_bits[i] }, FMT("", "block_for_incoming_messages_%zu", i)));
     }
 
     /* allocate hash checkers */
@@ -165,7 +165,7 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
     for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
     {
         const size_t input_block_size = commitment_size + incoming_messages_bits[i].size();
-        hash_incoming_messages.emplace_back(CRH_with_field_out_gadget<FieldT>(pb, input_block_size, block_for_incoming_messages[i], commitment_and_incoming_message_digests[i], libff::FMT("", "hash_incoming_messages_%zu", i)));
+        hash_incoming_messages.emplace_back(CRH_with_field_out_gadget<FieldT>(pb, input_block_size, block_for_incoming_messages[i], commitment_and_incoming_message_digests[i], FMT("", "hash_incoming_messages_%zu", i)));
     }
 
     /* allocate useful zero variable */
@@ -180,7 +180,7 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
     {
         for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
         {
-            translation_step_vks.emplace_back(r1cs_ppzksnark_verification_key_variable<ppT>(pb, translation_step_vks_bits[i], mp_translation_step_pcd_circuit_maker<other_curve<ppT> >::input_size_in_elts(), libff::FMT("", "translation_step_vks_%zu", i)));
+            translation_step_vks.emplace_back(r1cs_ppzksnark_verification_key_variable<ppT>(pb, translation_step_vks_bits[i], mp_translation_step_pcd_circuit_maker<other_curve<ppT> >::input_size_in_elts(), FMT("", "translation_step_vks_%zu", i)));
         }
     }
 
@@ -189,12 +189,12 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
 
     for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
     {
-        commitment_and_incoming_messages_digest_bits[i].allocate(pb, digest_size * field_logsize(), libff::FMT("", "commitment_and_incoming_messages_digest_bits_%zu", i));
+        commitment_and_incoming_messages_digest_bits[i].allocate(pb, digest_size * field_logsize(), FMT("", "commitment_and_incoming_messages_digest_bits_%zu", i));
         unpack_commitment_and_incoming_message_digests.emplace_back(multipacking_gadget<FieldT>(pb,
                                                                                                 commitment_and_incoming_messages_digest_bits[i],
                                                                                                 commitment_and_incoming_message_digests[i],
                                                                                                 field_logsize(),
-                                                                                                libff::FMT("", "unpack_commitment_and_incoming_message_digests_%zu", i)));
+                                                                                                FMT("", "unpack_commitment_and_incoming_message_digests_%zu", i)));
 
         verifier_input.emplace_back(commitment_and_incoming_messages_digest_bits[i]);
         while (verifier_input[i].size() < padded_verifier_input_size)
@@ -202,7 +202,7 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
             verifier_input[i].emplace_back(zero);
         }
 
-        proof.emplace_back(r1cs_ppzksnark_proof_variable<ppT>(pb, libff::FMT("", "proof_%zu", i)));
+        proof.emplace_back(r1cs_ppzksnark_proof_variable<ppT>(pb, FMT("", "proof_%zu", i)));
         const r1cs_ppzksnark_verification_key_variable<ppT> &vk_to_be_used = (compliance_predicate.relies_on_same_type_inputs ? translation_step_vks[0] : translation_step_vks[i]);
         verifier.emplace_back(r1cs_ppzksnark_verifier_gadget<ppT>(pb,
                                                                   vk_to_be_used,
@@ -210,7 +210,7 @@ mp_compliance_step_pcd_circuit_maker<ppT>::mp_compliance_step_pcd_circuit_maker(
                                                                   mp_translation_step_pcd_circuit_maker<other_curve<ppT> >::field_capacity(),
                                                                   proof[i],
                                                                   verification_results[i],
-                                                                  libff::FMT("", "verifier_%zu", i)));
+                                                                  FMT("", "verifier_%zu", i)));
     }
 
     pb.set_input_sizes(input_size_in_elts());
@@ -319,7 +319,7 @@ void mp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints()
         {
             for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
             {
-                generate_boolean_r1cs_constraint<FieldT>(pb, verification_results[i], libff::FMT("", "verification_results_%zu", i));
+                generate_boolean_r1cs_constraint<FieldT>(pb, verification_results[i], FMT("", "verification_results_%zu", i));
             }
         }
 
@@ -328,7 +328,7 @@ void mp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints()
         {
             for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
             {
-                pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_message_types[i], 1 - verification_results[i], 0), libff::FMT("", "not_base_case_implies_valid_proof_%zu", i));
+                pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_message_types[i], 1 - verification_results[i], 0), FMT("", "not_base_case_implies_valid_proof_%zu", i));
             }
         }
 
@@ -338,7 +338,7 @@ void mp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints()
             {
                 for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
                 {
-                    pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_message_types[i], incoming_message_types[i] - common_type, 0), libff::FMT("", "non_base_types_equal_%zu", i));
+                    pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_message_types[i], incoming_message_types[i] - common_type, 0), FMT("", "non_base_types_equal_%zu", i));
                 }
 
                 pb.add_r1cs_constraint(r1cs_constraint<FieldT>(common_type, 1 - membership_check_results[0], 0), "valid_vk_for_the_common_type");
@@ -349,7 +349,7 @@ void mp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints()
                     pb.add_r1cs_constraint(r1cs_constraint<FieldT>((i == 0 ? common_type : common_type_check_aux[i-1]),
                                                                    common_type - FieldT(*it),
                                                                    (i == compliance_predicate.accepted_input_types.size() - 1 ? 0 * ONE : common_type_check_aux[i])),
-                                           libff::FMT("", "common_type_in_prescribed_set_%zu_must_equal_%zu", i, *it));
+                                           FMT("", "common_type_in_prescribed_set_%zu_must_equal_%zu", i, *it));
                 }
             }
         }
@@ -359,7 +359,7 @@ void mp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints()
             {
                 for (size_t i = 0; i < compliance_predicate.max_arity; ++i)
                 {
-                    pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_message_types[i], 1 - membership_check_results[i], 0), libff::FMT("", "not_base_case_implies_valid_vk_%zu", i));
+                    pb.add_r1cs_constraint(r1cs_constraint<FieldT>(incoming_message_types[i], 1 - membership_check_results[i], 0), FMT("", "not_base_case_implies_valid_vk_%zu", i));
                 }
             }
         }

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.tcc
@@ -266,7 +266,7 @@ r1cs_mp_ppzkpcd_keypair<PCD_ppT> r1cs_mp_ppzkpcd_generator(const std::vector<r1c
 
     for (size_t i = 0; i < compliance_predicates.size(); ++i)
     {
-        libff::enter_block(libff::FMT("", "Process predicate %zu (with name %zu and type %zu)", i, compliance_predicates[i].name, compliance_predicates[i].type));
+        libff::enter_block(FMT("", "Process predicate %zu (with name %zu and type %zu)", i, compliance_predicates[i].name, compliance_predicates[i].type));
         assert(compliance_predicates[i].is_well_formed());
 
         libff::enter_block("Construct compliance step PCD circuit");
@@ -308,7 +308,7 @@ r1cs_mp_ppzkpcd_keypair<PCD_ppT> r1cs_mp_ppzkpcd_generator(const std::vector<r1c
         keypair.vk.translation_step_r1cs_vks.emplace_back(mp_translation_step_keypair.vk);
         libff::leave_block("Update r1cs_mp_ppzkpcd keypair");
 
-        libff::leave_block(libff::FMT("", "Process predicate %zu (with name %zu and type %zu)", i, compliance_predicates[i].name, compliance_predicates[i].type));
+        libff::leave_block(FMT("", "Process predicate %zu (with name %zu and type %zu)", i, compliance_predicates[i].name, compliance_predicates[i].type));
     }
 
     libff::enter_block("Compute set commitment and corresponding membership proofs");

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
@@ -58,8 +58,8 @@ sp_compliance_step_pcd_circuit_maker<ppT>::sp_compliance_step_pcd_circuit_maker(
     incoming_message_vars.resize(compliance_predicate_arity);
     for (size_t i = 0; i < compliance_predicate_arity; ++i)
     {
-        incoming_message_types[i].allocate(pb, libff::FMT("", "incoming_message_type_%zu", i));
-        incoming_message_payloads[i].allocate(pb, compliance_predicate.outgoing_message_payload_length, libff::FMT("", "incoming_message_payloads_%zu", i));
+        incoming_message_types[i].allocate(pb, FMT("", "incoming_message_type_%zu", i));
+        incoming_message_payloads[i].allocate(pb, compliance_predicate.outgoing_message_payload_length, FMT("", "incoming_message_payloads_%zu", i));
 
         incoming_message_vars[i].insert(incoming_message_vars[i].end(), incoming_message_types[i]);
         incoming_message_vars[i].insert(incoming_message_vars[i].end(), incoming_message_payloads[i].begin(), incoming_message_payloads[i].end());
@@ -90,15 +90,15 @@ sp_compliance_step_pcd_circuit_maker<ppT>::sp_compliance_step_pcd_circuit_maker(
     incoming_messages_bits.resize(compliance_predicate_arity);
     for (size_t i = 0; i < compliance_predicate_arity; ++i)
     {
-        incoming_messages_bits[i].allocate(pb, msg_size_in_bits, libff::FMT("", "incoming_messages_bits_%zu", i));
-        unpack_incoming_messages.emplace_back(multipacking_gadget<FieldT>(pb, incoming_messages_bits[i], incoming_message_vars[i], field_logsize(), libff::FMT("", "unpack_incoming_messages_%zu", i)));
+        incoming_messages_bits[i].allocate(pb, msg_size_in_bits, FMT("", "incoming_messages_bits_%zu", i));
+        unpack_incoming_messages.emplace_back(multipacking_gadget<FieldT>(pb, incoming_messages_bits[i], incoming_message_vars[i], field_logsize(), FMT("", "unpack_incoming_messages_%zu", i)));
     }
 
     /* allocate digests */
     sp_translation_step_vk_and_incoming_message_payload_digests.resize(compliance_predicate_arity);
     for (size_t i = 0; i < compliance_predicate_arity; ++i)
     {
-        sp_translation_step_vk_and_incoming_message_payload_digests[i].allocate(pb, digest_size, libff::FMT("", "sp_translation_step_vk_and_incoming_message_payload_digests_%zu", i));
+        sp_translation_step_vk_and_incoming_message_payload_digests[i].allocate(pb, digest_size, FMT("", "sp_translation_step_vk_and_incoming_message_payload_digests_%zu", i));
     }
 
     /* allocate blocks */
@@ -112,7 +112,7 @@ sp_compliance_step_pcd_circuit_maker<ppT>::sp_compliance_step_pcd_circuit_maker(
     {
         blocks_for_incoming_messages.emplace_back(block_variable<FieldT>(pb, {
                     sp_translation_step_vk_bits,
-                    incoming_messages_bits[i] }, libff::FMT("", "blocks_for_incoming_messages_zu", i)));
+                    incoming_messages_bits[i] }, FMT("", "blocks_for_incoming_messages_zu", i)));
     }
 
     /* allocate hash checkers */
@@ -120,7 +120,7 @@ sp_compliance_step_pcd_circuit_maker<ppT>::sp_compliance_step_pcd_circuit_maker(
 
     for (size_t i = 0; i < compliance_predicate_arity; ++i)
     {
-        hash_incoming_messages.emplace_back(CRH_with_field_out_gadget<FieldT>(pb, block_size, blocks_for_incoming_messages[i], sp_translation_step_vk_and_incoming_message_payload_digests[i], libff::FMT("", "hash_incoming_messages_%zu", i)));
+        hash_incoming_messages.emplace_back(CRH_with_field_out_gadget<FieldT>(pb, block_size, blocks_for_incoming_messages[i], sp_translation_step_vk_and_incoming_message_payload_digests[i], FMT("", "hash_incoming_messages_%zu", i)));
     }
 
     /* allocate useful zero variable */
@@ -134,12 +134,12 @@ sp_compliance_step_pcd_circuit_maker<ppT>::sp_compliance_step_pcd_circuit_maker(
 
     for (size_t i = 0; i < compliance_predicate_arity; ++i)
     {
-        sp_translation_step_vk_and_incoming_message_payload_digest_bits[i].allocate(pb, digest_size * field_logsize(), libff::FMT("", "sp_translation_step_vk_and_incoming_message_payload_digest_bits_%zu", i));
+        sp_translation_step_vk_and_incoming_message_payload_digest_bits[i].allocate(pb, digest_size * field_logsize(), FMT("", "sp_translation_step_vk_and_incoming_message_payload_digest_bits_%zu", i));
         unpack_sp_translation_step_vk_and_incoming_message_payload_digests.emplace_back(multipacking_gadget<FieldT>(pb,
                                                                                                             sp_translation_step_vk_and_incoming_message_payload_digest_bits[i],
                                                                                                             sp_translation_step_vk_and_incoming_message_payload_digests[i],
                                                                                                             field_logsize(),
-                                                                                                            libff::FMT("", "unpack_sp_translation_step_vk_and_incoming_message_payload_digests_%zu", i)));
+                                                                                                            FMT("", "unpack_sp_translation_step_vk_and_incoming_message_payload_digests_%zu", i)));
 
         verifier_input.emplace_back(sp_translation_step_vk_and_incoming_message_payload_digest_bits[i]);
         while (verifier_input[i].size() < padded_verifier_input_size)
@@ -147,14 +147,14 @@ sp_compliance_step_pcd_circuit_maker<ppT>::sp_compliance_step_pcd_circuit_maker(
             verifier_input[i].emplace_back(zero);
         }
 
-        proof.emplace_back(r1cs_ppzksnark_proof_variable<ppT>(pb, libff::FMT("", "proof_%zu", i)));
+        proof.emplace_back(r1cs_ppzksnark_proof_variable<ppT>(pb, FMT("", "proof_%zu", i)));
         verifiers.emplace_back(r1cs_ppzksnark_verifier_gadget<ppT>(pb,
                                                     *sp_translation_step_vk,
                                                     verifier_input[i],
                                                     sp_translation_step_pcd_circuit_maker<other_curve<ppT> >::field_capacity(),
                                                     proof[i],
                                                     verification_result,
-                                                    libff::FMT("", "verifiers_%zu", i)));
+                                                    FMT("", "verifiers_%zu", i)));
     }
 
     pb.set_input_sizes(input_size_in_elts());
@@ -247,7 +247,7 @@ void sp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints()
         for (size_t i = 1; i < compliance_predicate.max_arity; ++i)
         {
             pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, incoming_message_types[0], incoming_message_types[i]),
-                                   libff::FMT("", "type_%zu_equal_to_type_0", i));
+                                   FMT("", "type_%zu_equal_to_type_0", i));
         }
 
         pb.add_r1cs_constraint(r1cs_constraint<FieldT>(1, arity, compliance_predicate_arity), "full_arity");

--- a/src/zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.tcc
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.tcc
@@ -127,7 +127,7 @@ ram_pcd_message_variable<ramT>::ram_pcd_message_variable(protoboard<FieldT> &pb,
 {
     const size_t unpacked_payload_size_in_bits = ram_pcd_message<ramT>::unpacked_payload_size_in_bits(ap);
     const size_t packed_payload_size = libff::div_ceil(unpacked_payload_size_in_bits, FieldT::capacity());
-    packed_payload.allocate(pb, packed_payload_size, libff::FMT(annotation_prefix, " packed_payload"));
+    packed_payload.allocate(pb, packed_payload_size, FMT(annotation_prefix, " packed_payload"));
 
     this->update_all_vars();
 }
@@ -137,14 +137,14 @@ void ram_pcd_message_variable<ramT>::allocate_unpacked_part()
 {
     const size_t digest_size = CRH_with_bit_out_gadget<FieldT>::get_digest_len();
 
-    timestamp.allocate(this->pb, ramT::timestamp_length, libff::FMT(this->annotation_prefix, " timestamp"));
-    root_initial.allocate(this->pb, digest_size, libff::FMT(this->annotation_prefix, " root_initial"));
-    root.allocate(this->pb, digest_size, libff::FMT(this->annotation_prefix, " root"));
-    pc_addr.allocate(this->pb, ap.address_size(), libff::FMT(this->annotation_prefix, " pc_addr"));
-    cpu_state.allocate(this->pb, ap.cpu_state_size(), libff::FMT(this->annotation_prefix, " cpu_state"));
-    pc_addr_initial.allocate(this->pb, ap.address_size(), libff::FMT(this->annotation_prefix, " pc_addr_initial"));
-    cpu_state_initial.allocate(this->pb, ap.cpu_state_size(), libff::FMT(this->annotation_prefix, " cpu_state_initial"));
-    has_accepted.allocate(this->pb, libff::FMT(this->annotation_prefix, " has_accepted"));
+    timestamp.allocate(this->pb, ramT::timestamp_length, FMT(this->annotation_prefix, " timestamp"));
+    root_initial.allocate(this->pb, digest_size, FMT(this->annotation_prefix, " root_initial"));
+    root.allocate(this->pb, digest_size, FMT(this->annotation_prefix, " root"));
+    pc_addr.allocate(this->pb, ap.address_size(), FMT(this->annotation_prefix, " pc_addr"));
+    cpu_state.allocate(this->pb, ap.cpu_state_size(), FMT(this->annotation_prefix, " cpu_state"));
+    pc_addr_initial.allocate(this->pb, ap.address_size(), FMT(this->annotation_prefix, " pc_addr_initial"));
+    cpu_state_initial.allocate(this->pb, ap.cpu_state_size(), FMT(this->annotation_prefix, " cpu_state_initial"));
+    has_accepted.allocate(this->pb, FMT(this->annotation_prefix, " has_accepted"));
 
     all_unpacked_vars.insert(all_unpacked_vars.end(), timestamp.begin(), timestamp.end());
     all_unpacked_vars.insert(all_unpacked_vars.end(), root_initial.begin(), root_initial.end());
@@ -155,7 +155,7 @@ void ram_pcd_message_variable<ramT>::allocate_unpacked_part()
     all_unpacked_vars.insert(all_unpacked_vars.end(), cpu_state_initial.begin(), cpu_state_initial.end());
     all_unpacked_vars.insert(all_unpacked_vars.end(), has_accepted);
 
-    unpack_payload.reset(new multipacking_gadget<FieldT>(this->pb, all_unpacked_vars, packed_payload, FieldT::capacity(), libff::FMT(this->annotation_prefix, " unpack_payload")));
+    unpack_payload.reset(new multipacking_gadget<FieldT>(this->pb, all_unpacked_vars, packed_payload, FieldT::capacity(), FMT(this->annotation_prefix, " unpack_payload")));
 }
 
 template<typename ramT>
@@ -225,7 +225,7 @@ ram_pcd_local_data_variable<ramT>::ram_pcd_local_data_variable(protoboard<FieldT
                                                                const std::string &annotation_prefix) :
     r1cs_pcd_local_data_variable<ram_base_field<ramT> >(pb, annotation_prefix)
 {
-    is_halt_case.allocate(pb, libff::FMT(annotation_prefix, " is_halt_case"));
+    is_halt_case.allocate(pb, FMT(annotation_prefix, " is_halt_case"));
 
     this->update_all_vars();
 }

--- a/src/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.tcc
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.tcc
@@ -155,7 +155,7 @@ ram_zksnark_proof<ram_zksnark_ppT> ram_zksnark_prover(const ram_zksnark_proving_
     bool want_halt = false;
     for (size_t step = 1; step <= time_bound; ++step)
     {
-        libff::enter_block(libff::FMT("", "Prove step %zu out of %zu", step, time_bound));
+        libff::enter_block(FMT("", "Prove step %zu out of %zu", step, time_bound));
 
         libff::enter_block("Execute witness map");
 
@@ -181,7 +181,7 @@ ram_zksnark_proof<ram_zksnark_ppT> ram_zksnark_prover(const ram_zksnark_proving_
         libff::leave_block("Execute witness map");
 
         cur_proof = r1cs_sp_ppzkpcd_prover<pcdT>(pk.pcd_pk, cp_primary_input, cp_auxiliary_input, { cur_proof });
-        libff::leave_block(libff::FMT("", "Prove step %zu out of %zu", step, time_bound));
+        libff::leave_block(FMT("", "Prove step %zu out of %zu", step, time_bound));
     }
     libff::leave_block("Execute and prove the computation");
 


### PR DESCRIPTION
This is related to [pull request #6 in libff](https://github.com/scipr-lab/libff/pull/6).

The expression ``libff::FMT(...)`` doesn't make a lot of sense, because ``FMT`` is a macro. When DEBUG is off, this is expanded into ``libff::((libff::UNUSED(__VA_ARGS__), ""))``, which is a syntax error.

This pull request removes the unnecessary ``libff:`` prefix from all calls to ``FMT`` in libsnark.