### PR TITLE
Refactor includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,8 +143,7 @@ INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIR} )
 
 # libfqfft
 find_path(LIBFQFFT_INCLUDE_DIR NAMES libfqfft)
-set(LIBFQFFT_DIRECTORY ${LIBFQFFT_INCLUDE_DIR}/libfqfft)
-include_directories(${LIBFQFFT_DIRECTORY})
+include_directories(${LIBFQFFT_INCLUDE_DIR})
 
 # libff
 find_path(LIBFF_INCLUDE_DIR NAMES libff)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ include_directories(${LIBFQFFT_DIRECTORY})
 
 # libff
 find_path(LIBFF_INCLUDE_DIR NAMES libff)
-include_directories(${LIBFF_INCLUDE_DIR}/libff)
+include_directories(${LIBFF_INCLUDE_DIR})
 find_library(LIBFF_LIBRARIES NAMES ff libff)
 
 add_definitions(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(.)
-
 set(SNARK_EXTRALIBS)
 if(${CURVE} STREQUAL "BN128")
   set(

--- a/src/common/data_structures/accumulation_vector.hpp
+++ b/src/common/data_structures/accumulation_vector.hpp
@@ -12,7 +12,7 @@
 #ifndef ACCUMULATION_VECTOR_HPP_
 #define ACCUMULATION_VECTOR_HPP_
 
-#include "common/data_structures/sparse_vector.hpp"
+#include "sparse_vector.hpp"
 
 namespace libsnark {
 
@@ -69,6 +69,6 @@ std::istream& operator>>(std::istream &in, accumulation_vector<T> &v);
 
 } // libsnark
 
-#include "common/data_structures/accumulation_vector.tcc"
+#include "accumulation_vector.tcc"
 
 #endif // ACCUMULATION_VECTOR_HPP_

--- a/src/common/data_structures/integer_permutation.cpp
+++ b/src/common/data_structures/integer_permutation.cpp
@@ -11,7 +11,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/data_structures/integer_permutation.hpp"
+#include "integer_permutation.hpp"
 
 #include <algorithm>
 #include <cassert>

--- a/src/common/data_structures/merkle_tree.hpp
+++ b/src/common/data_structures/merkle_tree.hpp
@@ -14,7 +14,7 @@
 
 #include <map>
 #include <vector>
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/common/data_structures/merkle_tree.hpp
+++ b/src/common/data_structures/merkle_tree.hpp
@@ -66,6 +66,6 @@ public:
 
 } // libsnark
 
-#include "common/data_structures/merkle_tree.tcc"
+#include "merkle_tree.tcc"
 
 #endif // MERKLE_TREE_HPP_

--- a/src/common/data_structures/merkle_tree.tcc
+++ b/src/common/data_structures/merkle_tree.tcc
@@ -16,8 +16,8 @@
 
 #include <algorithm>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/common/data_structures/set_commitment.cpp
+++ b/src/common/data_structures/set_commitment.cpp
@@ -6,7 +6,7 @@
  *****************************************************************************/
 
 #include "set_commitment.hpp"
-#include "common/serialization.hpp"
+#include <libff/common/serialization.hpp>
 
 namespace libsnark {
 

--- a/src/common/data_structures/set_commitment.cpp
+++ b/src/common/data_structures/set_commitment.cpp
@@ -5,7 +5,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/data_structures/set_commitment.hpp"
+#include "set_commitment.hpp"
 #include "common/serialization.hpp"
 
 namespace libsnark {

--- a/src/common/data_structures/set_commitment.hpp
+++ b/src/common/data_structures/set_commitment.hpp
@@ -12,7 +12,7 @@
 #ifndef SET_COMMITMENT_HPP_
 #define SET_COMMITMENT_HPP_
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "merkle_tree.hpp"
 #include "../../gadgetlib1/gadgets/hashes/hash_io.hpp" // TODO: the current structure is suboptimal
 

--- a/src/common/data_structures/set_commitment.hpp
+++ b/src/common/data_structures/set_commitment.hpp
@@ -13,8 +13,8 @@
 #define SET_COMMITMENT_HPP_
 
 #include "common/utils.hpp"
-#include "common/data_structures/merkle_tree.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp" // TODO: the current structure is suboptimal
+#include "merkle_tree.hpp"
+#include "../../gadgetlib1/gadgets/hashes/hash_io.hpp" // TODO: the current structure is suboptimal
 
 namespace libsnark {
 
@@ -55,6 +55,6 @@ public:
 /* note that set_commitment has both .cpp, for implementation of
    non-templatized code (methods of set_membership_proof) and .tcc
    (implementation of set_commitment_accumulator<HashT> */
-#include "common/data_structures/set_commitment.tcc"
+#include "set_commitment.tcc"
 
 #endif // SET_COMMITMENT_HPP_

--- a/src/common/data_structures/sparse_vector.hpp
+++ b/src/common/data_structures/sparse_vector.hpp
@@ -74,6 +74,6 @@ std::istream& operator>>(std::istream& in, sparse_vector<T> &v);
 
 } // libsnark
 
-#include "common/data_structures/sparse_vector.tcc"
+#include "sparse_vector.tcc"
 
 #endif // SPARSE_VECTOR_HPP_

--- a/src/common/data_structures/sparse_vector.tcc
+++ b/src/common/data_structures/sparse_vector.tcc
@@ -14,7 +14,7 @@
 #ifndef SPARSE_VECTOR_TCC_
 #define SPARSE_VECTOR_TCC_
 
-#include "algebra/scalar_multiplication/multiexp.hpp"
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
 
 #include <numeric>
 

--- a/src/common/default_types/bacs_ppzksnark_pp.hpp
+++ b/src/common/default_types/bacs_ppzksnark_pp.hpp
@@ -14,7 +14,7 @@
 #ifndef BACS_PPZKSNARK_PP_HPP_
 #define BACS_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 
 namespace libsnark {
 typedef libff::default_ec_pp default_bacs_ppzksnark_pp;

--- a/src/common/default_types/r1cs_gg_ppzksnark_pp.hpp
+++ b/src/common/default_types/r1cs_gg_ppzksnark_pp.hpp
@@ -13,7 +13,7 @@
 #ifndef R1CS_GG_PPZKSNARK_PP_HPP_
 #define R1CS_GG_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 
 namespace libsnark {
 typedef libff::default_ec_pp default_r1cs_gg_ppzksnark_pp;

--- a/src/common/default_types/r1cs_ppzkadsnark_pp.cpp
+++ b/src/common/default_types/r1cs_ppzkadsnark_pp.cpp
@@ -9,7 +9,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/default_types/r1cs_ppzkadsnark_pp.hpp"
+#include "r1cs_ppzkadsnark_pp.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/r1cs_ppzkadsnark_pp.hpp
+++ b/src/common/default_types/r1cs_ppzkadsnark_pp.hpp
@@ -13,9 +13,9 @@
 #ifndef R1CS_PPZKADSNARK_PP_HPP_
 #define R1CS_PPZKADSNARK_PP_HPP_
 
-#include "common/default_types/r1cs_ppzksnark_pp.hpp"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/prf/aes_ctr_prf.hpp"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/signature/ed25519_signature.hpp"
+#include "r1cs_ppzksnark_pp.hpp"
+#include "../../zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/prf/aes_ctr_prf.hpp"
+#include "../../zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/signature/ed25519_signature.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/r1cs_ppzkpcd_pp.cpp
+++ b/src/common/default_types/r1cs_ppzkpcd_pp.cpp
@@ -9,7 +9,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/default_types/r1cs_ppzkpcd_pp.hpp"
+#include "r1cs_ppzkpcd_pp.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/r1cs_ppzkpcd_pp.hpp
+++ b/src/common/default_types/r1cs_ppzkpcd_pp.hpp
@@ -14,8 +14,8 @@
 
 /*********************** Define default PCD cycle ***************************/
 
-#include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
 
 namespace libsnark {
 

--- a/src/common/default_types/r1cs_ppzksnark_pp.hpp
+++ b/src/common/default_types/r1cs_ppzksnark_pp.hpp
@@ -13,7 +13,7 @@
 #ifndef R1CS_PPZKSNARK_PP_HPP_
 #define R1CS_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 
 namespace libsnark {
 typedef libff::default_ec_pp default_r1cs_ppzksnark_pp;

--- a/src/common/default_types/ram_ppzksnark_pp.hpp
+++ b/src/common/default_types/ram_ppzksnark_pp.hpp
@@ -13,7 +13,7 @@
 #ifndef RAM_PPZKSNARK_PP_HPP_
 #define RAM_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/tinyram_ppzksnark_pp.hpp"
+#include "tinyram_ppzksnark_pp.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/ram_zksnark_pp.hpp
+++ b/src/common/default_types/ram_zksnark_pp.hpp
@@ -13,7 +13,7 @@
 #ifndef RAM_ZKSNARK_PP_HPP_
 #define RAM_ZKSNARK_PP_HPP_
 
-#include "common/default_types/tinyram_zksnark_pp.hpp"
+#include "tinyram_zksnark_pp.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/tbcs_ppzksnark_pp.hpp
+++ b/src/common/default_types/tbcs_ppzksnark_pp.hpp
@@ -14,7 +14,7 @@
 #ifndef TBCS_PPZKSNARK_PP_HPP_
 #define TBCS_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 
 namespace libsnark {
 typedef libff::default_ec_pp default_tbcs_ppzksnark_pp;

--- a/src/common/default_types/tinyram_ppzksnark_pp.cpp
+++ b/src/common/default_types/tinyram_ppzksnark_pp.cpp
@@ -9,7 +9,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/default_types/tinyram_ppzksnark_pp.hpp"
+#include "tinyram_ppzksnark_pp.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/tinyram_ppzksnark_pp.hpp
+++ b/src/common/default_types/tinyram_ppzksnark_pp.hpp
@@ -13,8 +13,8 @@
 #ifndef TINYRAM_PPZKSNARK_PP_HPP_
 #define TINYRAM_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/r1cs_ppzksnark_pp.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "r1cs_ppzksnark_pp.hpp"
+#include "../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/tinyram_zksnark_pp.cpp
+++ b/src/common/default_types/tinyram_zksnark_pp.cpp
@@ -7,7 +7,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/default_types/tinyram_zksnark_pp.hpp"
+#include "tinyram_zksnark_pp.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/tinyram_zksnark_pp.hpp
+++ b/src/common/default_types/tinyram_zksnark_pp.hpp
@@ -12,8 +12,8 @@
 #ifndef TINYRAM_PPZKSNARK_PP_HPP_
 #define TINYRAM_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/r1cs_ppzkpcd_pp.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "r1cs_ppzkpcd_pp.hpp"
+#include "../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 namespace libsnark {
 

--- a/src/common/default_types/uscs_ppzksnark_pp.hpp
+++ b/src/common/default_types/uscs_ppzksnark_pp.hpp
@@ -14,7 +14,7 @@
 #ifndef USCS_PPZKSNARK_PP_HPP_
 #define USCS_PPZKSNARK_PP_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 
 namespace libsnark {
 typedef libff::default_ec_pp default_uscs_ppzksnark_pp;

--- a/src/common/libsnark_serialization.hpp
+++ b/src/common/libsnark_serialization.hpp
@@ -12,7 +12,7 @@
 #ifndef LIBSNARK_SERIALIZATION_HPP_
 #define LIBSNARK_SERIALIZATION_HPP_
 
-#include "common/serialization.hpp"
+#include <libff/common/serialization.hpp>
 
 namespace libsnark {
     using libff::consume_newline;

--- a/src/common/routing_algorithms/as_waksman_routing_algorithm.cpp
+++ b/src/common/routing_algorithms/as_waksman_routing_algorithm.cpp
@@ -13,7 +13,7 @@
 
 #include <cassert>
 
-#include "common/routing_algorithms/as_waksman_routing_algorithm.hpp"
+#include "as_waksman_routing_algorithm.hpp"
 
 namespace libsnark {
 

--- a/src/common/routing_algorithms/as_waksman_routing_algorithm.hpp
+++ b/src/common/routing_algorithms/as_waksman_routing_algorithm.hpp
@@ -42,7 +42,7 @@
 #include <map>
 #include <vector>
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../data_structures/integer_permutation.hpp"
 
 namespace libsnark {

--- a/src/common/routing_algorithms/as_waksman_routing_algorithm.hpp
+++ b/src/common/routing_algorithms/as_waksman_routing_algorithm.hpp
@@ -43,7 +43,7 @@
 #include <vector>
 
 #include "common/utils.hpp"
-#include "common/data_structures/integer_permutation.hpp"
+#include "../data_structures/integer_permutation.hpp"
 
 namespace libsnark {
 

--- a/src/common/routing_algorithms/benes_routing_algorithm.cpp
+++ b/src/common/routing_algorithms/benes_routing_algorithm.cpp
@@ -11,7 +11,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/routing_algorithms/benes_routing_algorithm.hpp"
+#include "benes_routing_algorithm.hpp"
 #include <cassert>
 
 namespace libsnark {

--- a/src/common/routing_algorithms/benes_routing_algorithm.hpp
+++ b/src/common/routing_algorithms/benes_routing_algorithm.hpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include "../data_structures/integer_permutation.hpp"
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/common/routing_algorithms/benes_routing_algorithm.hpp
+++ b/src/common/routing_algorithms/benes_routing_algorithm.hpp
@@ -27,7 +27,7 @@
 
 #include <vector>
 
-#include "common/data_structures/integer_permutation.hpp"
+#include "../data_structures/integer_permutation.hpp"
 #include "common/utils.hpp"
 
 namespace libsnark {

--- a/src/common/routing_algorithms/profiling/profile_routing_algorithms.cpp
+++ b/src/common/routing_algorithms/profiling/profile_routing_algorithms.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../as_waksman_routing_algorithm.hpp"
 #include "../benes_routing_algorithm.hpp"
 

--- a/src/common/routing_algorithms/profiling/profile_routing_algorithms.cpp
+++ b/src/common/routing_algorithms/profiling/profile_routing_algorithms.cpp
@@ -12,8 +12,8 @@
 #include <algorithm>
 
 #include "common/profiling.hpp"
-#include "common/routing_algorithms/as_waksman_routing_algorithm.hpp"
-#include "common/routing_algorithms/benes_routing_algorithm.hpp"
+#include "../as_waksman_routing_algorithm.hpp"
+#include "../benes_routing_algorithm.hpp"
 
 using namespace libsnark;
 

--- a/src/common/routing_algorithms/tests/test_routing_algorithms.cpp
+++ b/src/common/routing_algorithms/tests/test_routing_algorithms.cpp
@@ -11,7 +11,7 @@
 
 #include <cassert>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../benes_routing_algorithm.hpp"
 #include "../as_waksman_routing_algorithm.hpp"
 

--- a/src/common/routing_algorithms/tests/test_routing_algorithms.cpp
+++ b/src/common/routing_algorithms/tests/test_routing_algorithms.cpp
@@ -12,8 +12,8 @@
 #include <cassert>
 
 #include "common/profiling.hpp"
-#include "common/routing_algorithms/benes_routing_algorithm.hpp"
-#include "common/routing_algorithms/as_waksman_routing_algorithm.hpp"
+#include "../benes_routing_algorithm.hpp"
+#include "../as_waksman_routing_algorithm.hpp"
 
 using namespace libsnark;
 

--- a/src/gadgetlib1/constraint_profiling.cpp
+++ b/src/gadgetlib1/constraint_profiling.cpp
@@ -12,7 +12,7 @@
  *****************************************************************************/
 
 #include "constraint_profiling.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/constraint_profiling.cpp
+++ b/src/gadgetlib1/constraint_profiling.cpp
@@ -11,7 +11,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "gadgetlib1/constraint_profiling.hpp"
+#include "constraint_profiling.hpp"
 #include "common/profiling.hpp"
 
 namespace libsnark {

--- a/src/gadgetlib1/examples/simple_example.hpp
+++ b/src/gadgetlib1/examples/simple_example.hpp
@@ -8,7 +8,7 @@
 #ifndef SIMPLE_EXAMPLE_HPP_
 #define SIMPLE_EXAMPLE_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {
 
@@ -18,6 +18,6 @@ r1cs_example<FieldT> gen_r1cs_example_from_protoboard(const size_t num_constrain
 
 } // libsnark
 
-#include "gadgetlib1/examples/simple_example.tcc"
+#include "simple_example.tcc"
 
 #endif // SIMPLE_EXAMPLE_HPP_

--- a/src/gadgetlib1/examples/simple_example.tcc
+++ b/src/gadgetlib1/examples/simple_example.tcc
@@ -8,7 +8,7 @@
 #ifndef SIMPLE_EXAMPLE_TCC_
 #define SIMPLE_EXAMPLE_TCC_
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "../gadgets/basic_gadgets.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadget.hpp
+++ b/src/gadgetlib1/gadget.hpp
@@ -8,7 +8,7 @@
 #ifndef GADGET_HPP_
 #define GADGET_HPP_
 
-#include "gadgetlib1/protoboard.hpp"
+#include "protoboard.hpp"
 
 namespace libsnark {
 
@@ -22,6 +22,6 @@ public:
 };
 
 } // libsnark
-#include "gadgetlib1/gadget.tcc"
+#include "gadget.tcc"
 
 #endif // GADGET_HPP_

--- a/src/gadgetlib1/gadgets/basic_gadgets.hpp
+++ b/src/gadgetlib1/gadgets/basic_gadgets.hpp
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <memory>
 
-#include "gadgetlib1/gadget.hpp"
+#include "../gadget.hpp"
 
 namespace libsnark {
 
@@ -346,6 +346,6 @@ void create_linear_combination_witness(protoboard<FieldT> &pb,
                                        const VarT &target);
 
 } // libsnark
-#include "gadgetlib1/gadgets/basic_gadgets.tcc"
+#include "basic_gadgets.tcc"
 
 #endif // BASIC_GADGETS_HPP_

--- a/src/gadgetlib1/gadgets/basic_gadgets.tcc
+++ b/src/gadgetlib1/gadgets/basic_gadgets.tcc
@@ -8,8 +8,8 @@
 #ifndef BASIC_GADGETS_TCC_
 #define BASIC_GADGETS_TCC_
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/components/bar_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/components/bar_gadget.hpp
@@ -12,8 +12,8 @@
 #ifndef BAR_GADGET_HPP_
 #define BAR_GADGET_HPP_
 
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "../../../../gadget.hpp"
+#include "../../../basic_gadgets.hpp"
 
 namespace libsnark {
 
@@ -59,6 +59,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/fooram/components/bar_gadget.tcc"
+#include "bar_gadget.tcc"
 
 #endif // BAR_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/components/fooram_protoboard.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/components/fooram_protoboard.hpp
@@ -12,8 +12,8 @@
 #ifndef FOORAM_PROTOBOARD_HPP_
 #define FOORAM_PROTOBOARD_HPP_
 
-#include "gadgetlib1/gadget.hpp"
-#include "relations/ram_computations/rams/fooram/fooram_aux.hpp"
+#include "../../../../gadget.hpp"
+#include "../../../../../relations/ram_computations/rams/fooram/fooram_aux.hpp"
 
 namespace libsnark {
 
@@ -35,6 +35,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/fooram/components/fooram_protoboard.tcc"
+#include "fooram_protoboard.tcc"
 
 #endif // FOORAM_PROTOBOARD_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/examples/test_fooram.cpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/examples/test_fooram.cpp
@@ -4,13 +4,13 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include "common/default_types/r1cs_ppzksnark_pp.hpp"
-#include "common/default_types/r1cs_ppzkpcd_pp.hpp"
+#include "../../../../../common/default_types/r1cs_ppzksnark_pp.hpp"
+#include "../../../../../common/default_types/r1cs_ppzkpcd_pp.hpp"
 #include "common/utils.hpp"
-#include "zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp"
+#include "../../../../../zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp"
+#include "../../../../../zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp"
 
-#include "relations/ram_computations/rams/fooram/fooram_params.hpp"
+#include "../../../../../relations/ram_computations/rams/fooram/fooram_params.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/examples/test_fooram.cpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/examples/test_fooram.cpp
@@ -6,7 +6,7 @@
  *****************************************************************************/
 #include "../../../../../common/default_types/r1cs_ppzksnark_pp.hpp"
 #include "../../../../../common/default_types/r1cs_ppzkpcd_pp.hpp"
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../../../../../zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp"
 #include "../../../../../zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp"
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.hpp
@@ -28,7 +28,7 @@
 #include <cstddef>
 #include <memory>
 
-#include "common/serialization.hpp"
+#include <libff/common/serialization.hpp>
 #include "../../../gadget.hpp"
 #include "../../basic_gadgets.hpp"
 #include "components/fooram_protoboard.hpp"

--- a/src/gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.hpp
@@ -29,11 +29,11 @@
 #include <memory>
 
 #include "common/serialization.hpp"
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/fooram/components/fooram_protoboard.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/fooram/components/bar_gadget.hpp"
-#include "relations/ram_computations/memory/memory_interface.hpp"
+#include "../../../gadget.hpp"
+#include "../../basic_gadgets.hpp"
+#include "components/fooram_protoboard.hpp"
+#include "components/bar_gadget.hpp"
+#include "../../../../relations/ram_computations/memory/memory_interface.hpp"
 
 namespace libsnark {
 
@@ -102,6 +102,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.tcc"
+#include "fooram_cpu_checker.tcc"
 
 #endif // FORAM_CPU_CHECKER_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.hpp
@@ -15,8 +15,8 @@
 #define ALU_ARITHMETIC_HPP_
 #include <memory>
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/tinyram_protoboard.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "tinyram_protoboard.hpp"
+#include "../../../basic_gadgets.hpp"
 
 namespace libsnark {
 
@@ -679,6 +679,6 @@ void test_ALU_shl_gadget(const size_t w);
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc"
+#include "alu_arithmetic.tcc"
 
 #endif // ALU_ARITHMETIC_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
@@ -14,6 +14,8 @@
 #ifndef ALU_ARITHMETIC_TCC_
 #define ALU_ARITHMETIC_TCC_
 
+#include <functional>
+
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
@@ -16,8 +16,8 @@
 
 #include <functional>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.hpp
@@ -14,8 +14,8 @@
 #ifndef ALU_CONTROL_FLOW_HPP_
 #define ALU_CONTROL_FLOW_HPP_
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/tinyram_protoboard.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "tinyram_protoboard.hpp"
+#include "../../../basic_gadgets.hpp"
 
 namespace libsnark {
 
@@ -97,6 +97,6 @@ void test_ALU_cnjmp_gadget();
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.tcc"
+#include "alu_control_flow.tcc"
 
 #endif // ALU_CONTROL_FLOW_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.tcc
@@ -14,7 +14,7 @@
 #ifndef ALU_CONTROL_FLOW_TCC_
 #define ALU_CONTROL_FLOW_TCC_
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_gadget.hpp
@@ -14,8 +14,8 @@
 #ifndef ALU_GADGET_HPP_
 #define ALU_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_control_flow.hpp"
+#include "alu_arithmetic.hpp"
+#include "alu_control_flow.hpp"
 
 namespace libsnark {
 
@@ -178,6 +178,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_gadget.tcc"
+#include "alu_gadget.tcc"
 
 #endif // ALU_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/argument_decoder_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/argument_decoder_gadget.hpp
@@ -61,6 +61,6 @@ void test_argument_decoder_gadget();
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/argument_decoder_gadget.tcc"
+#include "argument_decoder_gadget.tcc"
 
 #endif // ARGUMENT_DECODER_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/consistency_enforcer_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/consistency_enforcer_gadget.hpp
@@ -66,6 +66,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/consistency_enforcer_gadget.tcc"
+#include "consistency_enforcer_gadget.tcc"
 
 #endif // CONSISTENCY_ENFORCER_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/instruction_packing_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/instruction_packing_gadget.hpp
@@ -53,6 +53,6 @@ void test_instruction_packing();
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/instruction_packing_gadget.tcc"
+#include "instruction_packing_gadget.tcc"
 
 #endif // INSTRUCTION_PACKING_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/memory_masking_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/memory_masking_gadget.hpp
@@ -89,6 +89,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/memory_masking_gadget.tcc"
+#include "memory_masking_gadget.tcc"
 
 #endif // MEMORY_MASKING_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/tinyram_protoboard.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/tinyram_protoboard.hpp
@@ -12,10 +12,10 @@
 #ifndef TINYRAM_PROTOBOARD_HPP_
 #define TINYRAM_PROTOBOARD_HPP_
 
-#include "relations/ram_computations/rams/ram_params.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_aux.hpp"
-#include "gadgetlib1/protoboard.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "../../../../../relations/ram_computations/rams/ram_params.hpp"
+#include "../../../../../relations/ram_computations/rams/tinyram/tinyram_aux.hpp"
+#include "../../../../protoboard.hpp"
+#include "../../../basic_gadgets.hpp"
 
 namespace libsnark {
 
@@ -47,6 +47,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/tinyram_protoboard.tcc"
+#include "tinyram_protoboard.tcc"
 
 #endif // TINYRAM_PROTOBOARD_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/word_variable_gadget.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/components/word_variable_gadget.hpp
@@ -12,7 +12,7 @@
 #ifndef WORD_VARIABLE_GADGET_HPP_
 #define WORD_VARIABLE_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/tinyram_protoboard.hpp"
+#include "tinyram_protoboard.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.hpp
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.hpp
@@ -14,12 +14,12 @@
 #ifndef TINYRAM_CPU_CHECKER_HPP_
 #define TINYRAM_CPU_CHECKER_HPP_
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/tinyram_protoboard.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/word_variable_gadget.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_gadget.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/argument_decoder_gadget.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/consistency_enforcer_gadget.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/components/memory_masking_gadget.hpp"
+#include "components/tinyram_protoboard.hpp"
+#include "components/word_variable_gadget.hpp"
+#include "components/alu_gadget.hpp"
+#include "components/argument_decoder_gadget.hpp"
+#include "components/consistency_enforcer_gadget.hpp"
+#include "components/memory_masking_gadget.hpp"
 
 namespace libsnark {
 
@@ -96,6 +96,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc"
+#include "tinyram_cpu_checker.tcc"
 
 #endif // TINYRAM_CPU_CHECKER_HPP_

--- a/src/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
+++ b/src/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
@@ -14,7 +14,7 @@
 #ifndef TINYRAM_CPU_CHECKER_TCC_
 #define TINYRAM_CPU_CHECKER_TCC_
 
-#include "algebra/fields/field_utils.hpp"
+#include <libff/algebra/fields/field_utils.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp
+++ b/src/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp
@@ -15,8 +15,8 @@
 #ifndef WEIERSTRASS_G1_GADGET_HPP_
 #define WEIERSTRASS_G1_GADGET_HPP_
 
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
+#include "../../gadget.hpp"
+#include "../pairing/pairing_params.hpp"
 
 namespace libsnark {
 
@@ -148,6 +148,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc"
+#include "weierstrass_g1_gadget.tcc"
 
 #endif // WEIERSTRASS_G1_GADGET_TCC_

--- a/src/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp
+++ b/src/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp
@@ -15,8 +15,8 @@
 #ifndef WEIERSTRASS_G2_GADGET_HPP_
 #define WEIERSTRASS_G2_GADGET_HPP_
 
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
+#include "../../gadget.hpp"
+#include "../pairing/pairing_params.hpp"
 
 namespace libsnark {
 
@@ -79,6 +79,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/curves/weierstrass_g2_gadget.tcc"
+#include "weierstrass_g2_gadget.tcc"
 
 #endif // WEIERSTRASS_G2_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.tcc
+++ b/src/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.tcc
@@ -14,7 +14,7 @@
 #ifndef WEIERSTRASS_G2_GADGET_TCC_
 #define WEIERSTRASS_G2_GADGET_TCC_
 
-#include "algebra/scalar_multiplication/wnaf.hpp"
+#include <libff/algebra/scalar_multiplication/wnaf.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/delegated_ra_memory/memory_load_gadget.hpp
+++ b/src/gadgetlib1/gadgets/delegated_ra_memory/memory_load_gadget.hpp
@@ -13,7 +13,7 @@
 #ifndef MEMORY_LOAD_GADGET_HPP_
 #define MEMORY_LOAD_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp"
+#include "../merkle_tree/merkle_tree_check_read_gadget.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/delegated_ra_memory/memory_load_store_gadget.hpp
+++ b/src/gadgetlib1/gadgets/delegated_ra_memory/memory_load_store_gadget.hpp
@@ -15,7 +15,7 @@
 #ifndef MEMORY_LOAD_STORE_GADGET_HPP_
 #define MEMORY_LOAD_STORE_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.hpp"
+#include "../merkle_tree/merkle_tree_check_update_gadget.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/fields/exponentiation_gadget.hpp
+++ b/src/gadgetlib1/gadgets/fields/exponentiation_gadget.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 #include "algebra/fields/bigint.hpp"
 #include "algebra/scalar_multiplication/wnaf.hpp"
-#include "gadgetlib1/gadget.hpp"
+#include "../../gadget.hpp"
 
 namespace libsnark {
 
@@ -59,6 +59,6 @@ void test_exponentiation_gadget(const libff::bigint<m> &power, const std::string
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/fields/exponentiation_gadget.tcc"
+#include "exponentiation_gadget.tcc"
 
 #endif // EXPONENTIATION_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/fields/exponentiation_gadget.hpp
+++ b/src/gadgetlib1/gadgets/fields/exponentiation_gadget.hpp
@@ -14,8 +14,8 @@
 
 #include <memory>
 #include <vector>
-#include "algebra/fields/bigint.hpp"
-#include "algebra/scalar_multiplication/wnaf.hpp"
+#include <libff/algebra/fields/bigint.hpp>
+#include <libff/algebra/scalar_multiplication/wnaf.hpp>
 #include "../../gadget.hpp"
 
 namespace libsnark {

--- a/src/gadgetlib1/gadgets/fields/fp2_gadgets.hpp
+++ b/src/gadgetlib1/gadgets/fields/fp2_gadgets.hpp
@@ -15,7 +15,7 @@
 #ifndef FP2_GADGETS_HPP_
 #define FP2_GADGETS_HPP_
 
-#include "gadgetlib1/gadget.hpp"
+#include "../../gadget.hpp"
 #include <memory>
 
 namespace libsnark {
@@ -127,6 +127,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/fields/fp2_gadgets.tcc"
+#include "fp2_gadgets.tcc"
 
 #endif // FP2_GADGETS_HPP_

--- a/src/gadgetlib1/gadgets/fields/fp3_gadgets.hpp
+++ b/src/gadgetlib1/gadgets/fields/fp3_gadgets.hpp
@@ -130,6 +130,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/fields/fp3_gadgets.tcc"
+#include "fp3_gadgets.tcc"
 
 #endif // FP3_GADGETS_HPP_

--- a/src/gadgetlib1/gadgets/fields/fp4_gadgets.hpp
+++ b/src/gadgetlib1/gadgets/fields/fp4_gadgets.hpp
@@ -195,6 +195,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/fields/fp4_gadgets.tcc"
+#include "fp4_gadgets.tcc"
 
 #endif // FP4_GADGETS_HPP_

--- a/src/gadgetlib1/gadgets/fields/fp6_gadgets.hpp
+++ b/src/gadgetlib1/gadgets/fields/fp6_gadgets.hpp
@@ -15,7 +15,7 @@
 #ifndef FP6_GADGETS_HPP_
 #define FP6_GADGETS_HPP_
 
-#include "gadgetlib1/gadgets/fields/fp2_gadgets.hpp"
+#include "fp2_gadgets.hpp"
 
 namespace libsnark {
 
@@ -200,6 +200,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/fields/fp6_gadgets.tcc"
+#include "fp6_gadgets.tcc"
 
 #endif // FP6_GADGETS_HPP_

--- a/src/gadgetlib1/gadgets/gadget_from_r1cs.hpp
+++ b/src/gadgetlib1/gadgets/gadget_from_r1cs.hpp
@@ -14,7 +14,7 @@
 
 #include <map>
 
-#include "gadgetlib1/gadget.hpp"
+#include "../gadget.hpp"
 
 namespace libsnark {
 
@@ -40,6 +40,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/gadget_from_r1cs.tcc"
+#include "gadget_from_r1cs.tcc"
 
 #endif // GADGET_FROM_R1CS_HPP_

--- a/src/gadgetlib1/gadgets/hashes/crh_gadget.hpp
+++ b/src/gadgetlib1/gadgets/hashes/crh_gadget.hpp
@@ -7,7 +7,7 @@
 #ifndef CRH_GADGET_HPP_
 #define CRH_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp"
+#include "knapsack/knapsack_gadget.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/hashes/digest_selector_gadget.hpp
+++ b/src/gadgetlib1/gadgets/hashes/digest_selector_gadget.hpp
@@ -9,8 +9,8 @@
 
 #include <vector>
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
+#include "../basic_gadgets.hpp"
+#include "hash_io.hpp"
 
 namespace libsnark {
 
@@ -37,6 +37,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/hashes/digest_selector_gadget.tcc"
+#include "digest_selector_gadget.tcc"
 
 #endif // DIGEST_SELECTOR_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/hashes/hash_io.hpp
+++ b/src/gadgetlib1/gadgets/hashes/hash_io.hpp
@@ -8,7 +8,7 @@
 #define HASH_IO_HPP_
 #include <cstddef>
 #include <vector>
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "../basic_gadgets.hpp"
 
 namespace libsnark {
 
@@ -58,6 +58,6 @@ public:
 };
 
 } // libsnark
-#include "gadgetlib1/gadgets/hashes/hash_io.tcc"
+#include "hash_io.tcc"
 
 #endif // HASH_IO_HPP_

--- a/src/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp
+++ b/src/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp
@@ -43,9 +43,9 @@
 #ifndef KNAPSACK_GADGET_HPP_
 #define KNAPSACK_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
-#include "common/data_structures/merkle_tree.hpp"
+#include "../../basic_gadgets.hpp"
+#include "../hash_io.hpp"
+#include "../../../../common/data_structures/merkle_tree.hpp"
 
 namespace libsnark {
 
@@ -129,6 +129,6 @@ void test_knapsack_CRH_with_bit_out_gadget();
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.tcc"
+#include "knapsack_gadget.tcc"
 
 #endif // KNAPSACK_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.tcc
+++ b/src/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.tcc
@@ -14,8 +14,8 @@
 #ifndef KNAPSACK_GADGET_TCC_
 #define KNAPSACK_GADGET_TCC_
 
-#include "algebra/fields/field_utils.hpp"
-#include "common/rng.hpp"
+#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/common/rng.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/hashes/knapsack/tests/test_knapsack_gadget.cpp
+++ b/src/gadgetlib1/gadgets/hashes/knapsack/tests/test_knapsack_gadget.cpp
@@ -11,7 +11,7 @@
 #include "algebra/curves/edwards/edwards_pp.hpp"
 #include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
 #include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
-#include "gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp"
+#include "../knapsack_gadget.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/hashes/knapsack/tests/test_knapsack_gadget.cpp
+++ b/src/gadgetlib1/gadgets/hashes/knapsack/tests/test_knapsack_gadget.cpp
@@ -6,11 +6,11 @@
  *****************************************************************************/
 
 #ifdef CURVE_BN128
-#include "algebra/curves/bn128/bn128_pp.hpp"
+#include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif
-#include "algebra/curves/edwards/edwards_pp.hpp"
-#include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
+#include <libff/algebra/curves/edwards/edwards_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
 #include "../knapsack_gadget.hpp"
 
 namespace libsnark {

--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_aux.hpp
+++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_aux.hpp
@@ -12,7 +12,7 @@
 #ifndef SHA256_AUX_HPP_
 #define SHA256_AUX_HPP_
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "../../basic_gadgets.hpp"
 
 namespace libsnark {
 
@@ -155,6 +155,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_aux.tcc"
+#include "sha256_aux.tcc"
 
 #endif // SHA256_AUX_HPP_

--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_components.hpp
+++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_components.hpp
@@ -12,9 +12,9 @@
 #ifndef SHA256_COMPONENTS_HPP_
 #define SHA256_COMPONENTS_HPP_
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_aux.hpp"
+#include "../../basic_gadgets.hpp"
+#include "../hash_io.hpp"
+#include "sha256_aux.hpp"
 
 namespace libsnark {
 
@@ -103,6 +103,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_components.tcc"
+#include "sha256_components.tcc"
 
 #endif // SHA256_COMPONENTS_HPP_

--- a/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp
+++ b/src/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp
@@ -12,10 +12,10 @@
 #ifndef SHA256_GADGET_HPP_
 #define SHA256_GADGET_HPP_
 
-#include "common/data_structures/merkle_tree.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_components.hpp"
+#include "../../../../common/data_structures/merkle_tree.hpp"
+#include "../../basic_gadgets.hpp"
+#include "../hash_io.hpp"
+#include "sha256_components.hpp"
 
 namespace libsnark {
 
@@ -93,6 +93,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc"
+#include "sha256_gadget.tcc"
 
 #endif // SHA256_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/hashes/sha256/tests/test_sha256_gadget.cpp
+++ b/src/gadgetlib1/gadgets/hashes/sha256/tests/test_sha256_gadget.cpp
@@ -8,7 +8,7 @@
 #include "common/default_types/ec_pp.hpp"
 #include "common/utils.hpp"
 #include "common/profiling.hpp"
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp"
+#include "../sha256_gadget.hpp"
 
 using namespace libsnark;
 

--- a/src/gadgetlib1/gadgets/hashes/sha256/tests/test_sha256_gadget.cpp
+++ b/src/gadgetlib1/gadgets/hashes/sha256/tests/test_sha256_gadget.cpp
@@ -5,9 +5,9 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/default_types/ec_pp.hpp"
-#include "common/utils.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
+#include <libff/common/utils.hpp>
+#include <libff/common/profiling.hpp>
 #include "../sha256_gadget.hpp"
 
 using namespace libsnark;

--- a/src/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.hpp
+++ b/src/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.hpp
@@ -8,9 +8,9 @@
 #ifndef MERKLE_AUTHENTICATION_PATH_VARIABLE_HPP_
 #define MERKLE_AUTHENTICATION_PATH_VARIABLE_HPP_
 
-#include "common/data_structures/merkle_tree.hpp"
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
+#include "../../../common/data_structures/merkle_tree.hpp"
+#include "../../gadget.hpp"
+#include "../hashes/hash_io.hpp"
 
 namespace libsnark {
 
@@ -33,6 +33,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.tcc"
+#include "merkle_authentication_path_variable.tcc"
 
 #endif // MERKLE_AUTHENTICATION_PATH_VARIABLE_HPP

--- a/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp
+++ b/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp
@@ -16,12 +16,12 @@
 #ifndef MERKLE_TREE_CHECK_READ_GADGET_HPP_
 #define MERKLE_TREE_CHECK_READ_GADGET_HPP_
 
-#include "common/data_structures/merkle_tree.hpp"
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/crh_gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
-#include "gadgetlib1/gadgets/hashes/digest_selector_gadget.hpp"
-#include "gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.hpp"
+#include "../../../common/data_structures/merkle_tree.hpp"
+#include "../../gadget.hpp"
+#include "../hashes/crh_gadget.hpp"
+#include "../hashes/hash_io.hpp"
+#include "../hashes/digest_selector_gadget.hpp"
+#include "merkle_authentication_path_variable.hpp"
 
 namespace libsnark {
 
@@ -69,6 +69,6 @@ void test_merkle_tree_check_read_gadget();
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.tcc"
+#include "merkle_tree_check_read_gadget.tcc"
 
 #endif // MERKLE_TREE_CHECK_READ_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.hpp
+++ b/src/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.hpp
@@ -17,12 +17,12 @@
 #ifndef MERKLE_TREE_CHECK_UPDATE_GADGET_HPP_
 #define MERKLE_TREE_CHECK_UPDATE_GADGET_HPP_
 
-#include "common/data_structures/merkle_tree.hpp"
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/crh_gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
-#include "gadgetlib1/gadgets/hashes/digest_selector_gadget.hpp"
-#include "gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.hpp"
+#include "../../../common/data_structures/merkle_tree.hpp"
+#include "../../gadget.hpp"
+#include "../hashes/crh_gadget.hpp"
+#include "../hashes/hash_io.hpp"
+#include "../hashes/digest_selector_gadget.hpp"
+#include "merkle_authentication_path_variable.hpp"
 
 namespace libsnark {
 
@@ -86,6 +86,6 @@ void test_merkle_tree_check_update_gadget();
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.tcc"
+#include "merkle_tree_check_update_gadget.tcc"
 
 #endif // MERKLE_TREE_CHECK_UPDATE_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/merkle_tree/tests/test_merkle_tree_gadgets.cpp
+++ b/src/gadgetlib1/gadgets/merkle_tree/tests/test_merkle_tree_gadgets.cpp
@@ -11,9 +11,9 @@
 #include "algebra/curves/edwards/edwards_pp.hpp"
 #include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
 #include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
-#include "gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp"
-#include "gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp"
+#include "../merkle_tree_check_read_gadget.hpp"
+#include "../merkle_tree_check_update_gadget.hpp"
+#include "../../hashes/sha256/sha256_gadget.hpp"
 
 using namespace libsnark;
 

--- a/src/gadgetlib1/gadgets/merkle_tree/tests/test_merkle_tree_gadgets.cpp
+++ b/src/gadgetlib1/gadgets/merkle_tree/tests/test_merkle_tree_gadgets.cpp
@@ -6,11 +6,11 @@
  *****************************************************************************/
 
 #ifdef CURVE_BN128
-#include "algebra/curves/bn128/bn128_pp.hpp"
+#include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif
-#include "algebra/curves/edwards/edwards_pp.hpp"
-#include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
+#include <libff/algebra/curves/edwards/edwards_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
 #include "../merkle_tree_check_read_gadget.hpp"
 #include "../merkle_tree_check_update_gadget.hpp"
 #include "../../hashes/sha256/sha256_gadget.hpp"

--- a/src/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
+++ b/src/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
@@ -18,11 +18,11 @@
 
 #include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
 #include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
-#include "gadgetlib1/gadgets/fields/fp2_gadgets.hpp"
-#include "gadgetlib1/gadgets/fields/fp4_gadgets.hpp"
-#include "gadgetlib1/gadgets/fields/fp3_gadgets.hpp"
-#include "gadgetlib1/gadgets/fields/fp6_gadgets.hpp"
+#include "pairing_params.hpp"
+#include "../fields/fp2_gadgets.hpp"
+#include "../fields/fp4_gadgets.hpp"
+#include "../fields/fp3_gadgets.hpp"
+#include "../fields/fp6_gadgets.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
+++ b/src/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp
@@ -16,8 +16,8 @@
 #ifndef MNT_PAIRING_PARAMS_HPP_
 #define MNT_PAIRING_PARAMS_HPP_
 
-#include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
 #include "pairing_params.hpp"
 #include "../fields/fp2_gadgets.hpp"
 #include "../fields/fp4_gadgets.hpp"

--- a/src/gadgetlib1/gadgets/pairing/pairing_checks.hpp
+++ b/src/gadgetlib1/gadgets/pairing/pairing_checks.hpp
@@ -17,9 +17,9 @@
 #define PAIRING_CHECKS_HPP_
 
 #include <memory>
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
-#include "gadgetlib1/gadgets/pairing/weierstrass_miller_loop.hpp"
-#include "gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.hpp"
+#include "pairing_params.hpp"
+#include "weierstrass_miller_loop.hpp"
+#include "weierstrass_final_exponentiation.hpp"
 
 namespace libsnark {
 
@@ -89,6 +89,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/pairing/pairing_checks.tcc"
+#include "pairing_checks.tcc"
 
 #endif // PAIRING_CHECKS_HPP_

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.hpp
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.hpp
@@ -16,8 +16,8 @@
 #define WEIERSTRASS_FINAL_EXPONENTIATION_HPP_
 
 #include <memory>
-#include "gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp"
-#include "gadgetlib1/gadgets/fields/exponentiation_gadget.hpp"
+#include "mnt_pairing_params.hpp"
+#include "../fields/exponentiation_gadget.hpp"
 
 namespace libsnark {
 
@@ -105,6 +105,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.tcc"
+#include "weierstrass_final_exponentiation.tcc"
 
 #endif // WEIERSTRASS_FINAL_EXPONENTIATION_HPP_

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.tcc
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_final_exponentiation.tcc
@@ -14,8 +14,8 @@
 #ifndef WEIERSTRASS_FINAL_EXPONENTIATION_TCC_
 #define WEIERSTRASS_FINAL_EXPONENTIATION_TCC_
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp"
+#include "../basic_gadgets.hpp"
+#include "mnt_pairing_params.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.hpp
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.hpp
@@ -15,8 +15,8 @@
 #define WEIERSTRASS_MILLER_LOOP_HPP_
 
 #include <memory>
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
-#include "gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp"
+#include "pairing_params.hpp"
+#include "weierstrass_precomputation.hpp"
 
 namespace libsnark {
 
@@ -251,6 +251,6 @@ void test_mnt_e_times_e_over_e_miller_loop(const std::string &annotation);
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/pairing/weierstrass_miller_loop.tcc"
+#include "weierstrass_miller_loop.tcc"
 
 #endif // WEIERSTRASS_MILLER_LOOP_HPP_

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.tcc
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.tcc
@@ -14,7 +14,7 @@
 #ifndef WEIERSTRASS_MILLER_LOOP_TCC_
 #define WEIERSTRASS_MILLER_LOOP_TCC_
 
-#include "algebra/scalar_multiplication/wnaf.hpp"
+#include <libff/algebra/scalar_multiplication/wnaf.hpp>
 #include "../../constraint_profiling.hpp"
 #include "../basic_gadgets.hpp"
 

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.tcc
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_miller_loop.tcc
@@ -15,8 +15,8 @@
 #define WEIERSTRASS_MILLER_LOOP_TCC_
 
 #include "algebra/scalar_multiplication/wnaf.hpp"
-#include "gadgetlib1/constraint_profiling.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "../../constraint_profiling.hpp"
+#include "../basic_gadgets.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.hpp
@@ -15,9 +15,9 @@
 #define WEIERSTRASS_PRECOMPUTATION_HPP_
 
 #include <memory>
-#include "gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp"
-#include "gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp"
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
+#include "../curves/weierstrass_g1_gadget.hpp"
+#include "../curves/weierstrass_g2_gadget.hpp"
+#include "pairing_params.hpp"
 
 namespace libsnark {
 
@@ -275,6 +275,6 @@ void test_G2_variable_precomp(const std::string &annotation);
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/pairing/weierstrass_precomputation.tcc"
+#include "weierstrass_precomputation.tcc"
 
 #endif // WEIERSTRASS_PRECOMPUTATION_HPP_

--- a/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.tcc
+++ b/src/gadgetlib1/gadgets/pairing/weierstrass_precomputation.tcc
@@ -15,7 +15,7 @@
 #define WEIERSTRASS_PRECOMPUTATION_TCC_
 
 #include <type_traits>
-#include "gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp"
+#include "mnt_pairing_params.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.hpp
+++ b/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.hpp
@@ -15,10 +15,10 @@
 #ifndef AS_WAKSMAN_ROUTING_GADGET_HPP_
 #define AS_WAKSMAN_ROUTING_GADGET_HPP_
 
-#include "gadgetlib1/protoboard.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "common/data_structures/integer_permutation.hpp"
-#include "common/routing_algorithms/as_waksman_routing_algorithm.hpp"
+#include "../../protoboard.hpp"
+#include "../basic_gadgets.hpp"
+#include "../../../common/data_structures/integer_permutation.hpp"
+#include "../../../common/routing_algorithms/as_waksman_routing_algorithm.hpp"
 
 namespace libsnark {
 
@@ -77,6 +77,6 @@ void test_as_waksman_routing_gadget(const size_t num_packets, const size_t packe
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc"
+#include "as_waksman_routing_gadget.tcc"
 
 #endif // AS_WAKSMAN_ROUTING_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
+++ b/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
@@ -17,7 +17,7 @@
 #include <algorithm>
 
 #include "../../../common/routing_algorithms/as_waksman_routing_algorithm.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
+++ b/src/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 
-#include "common/routing_algorithms/as_waksman_routing_algorithm.hpp"
+#include "../../../common/routing_algorithms/as_waksman_routing_algorithm.hpp"
 #include "common/profiling.hpp"
 
 namespace libsnark {

--- a/src/gadgetlib1/gadgets/routing/benes_routing_gadget.hpp
+++ b/src/gadgetlib1/gadgets/routing/benes_routing_gadget.hpp
@@ -15,10 +15,10 @@
 #ifndef BENES_ROUTING_GADGET_HPP_
 #define BENES_ROUTING_GADGET_HPP_
 
-#include "common/data_structures/integer_permutation.hpp"
-#include "common/routing_algorithms/benes_routing_algorithm.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/protoboard.hpp"
+#include "../../../common/data_structures/integer_permutation.hpp"
+#include "../../../common/routing_algorithms/benes_routing_algorithm.hpp"
+#include "../basic_gadgets.hpp"
+#include "../../protoboard.hpp"
 
 namespace libsnark {
 
@@ -76,6 +76,6 @@ void test_benes_routing_gadget(const size_t num_packets, const size_t packet_siz
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/routing/benes_routing_gadget.tcc"
+#include "benes_routing_gadget.tcc"
 
 #endif // BENES_ROUTING_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/routing/benes_routing_gadget.tcc
+++ b/src/gadgetlib1/gadgets/routing/benes_routing_gadget.tcc
@@ -14,7 +14,7 @@
 #ifndef BENES_ROUTING_GADGET_TCC_
 #define BENES_ROUTING_GADGET_TCC_
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 #include <algorithm>
 

--- a/src/gadgetlib1/gadgets/routing/profiling/profile_routing_gadgets.cpp
+++ b/src/gadgetlib1/gadgets/routing/profiling/profile_routing_gadgets.cpp
@@ -13,8 +13,8 @@
 
 #include "common/default_types/ec_pp.hpp"
 #include "common/profiling.hpp"
-#include "gadgetlib1/gadgets/routing/benes_routing_gadget.hpp"
-#include "gadgetlib1/gadgets/routing/as_waksman_routing_gadget.hpp"
+#include "../benes_routing_gadget.hpp"
+#include "../as_waksman_routing_gadget.hpp"
 
 using namespace libsnark;
 

--- a/src/gadgetlib1/gadgets/routing/profiling/profile_routing_gadgets.cpp
+++ b/src/gadgetlib1/gadgets/routing/profiling/profile_routing_gadgets.cpp
@@ -11,8 +11,8 @@
 
 #include <algorithm>
 
-#include "common/default_types/ec_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
+#include <libff/common/profiling.hpp>
 #include "../benes_routing_gadget.hpp"
 #include "../as_waksman_routing_gadget.hpp"
 

--- a/src/gadgetlib1/gadgets/set_commitment/set_commitment_gadget.hpp
+++ b/src/gadgetlib1/gadgets/set_commitment/set_commitment_gadget.hpp
@@ -7,11 +7,11 @@
 #ifndef SET_COMMITMENT_GADGET_HPP_
 #define SET_COMMITMENT_GADGET_HPP_
 
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
-#include "gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp"
-#include "gadgetlib1/gadgets/set_commitment/set_membership_proof_variable.hpp"
+#include "../../gadget.hpp"
+#include "../basic_gadgets.hpp"
+#include "../hashes/hash_io.hpp"
+#include "../merkle_tree/merkle_tree_check_read_gadget.hpp"
+#include "set_membership_proof_variable.hpp"
 
 namespace libsnark {
 
@@ -52,6 +52,6 @@ void test_set_commitment_gadget();
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/set_commitment/set_commitment_gadget.tcc"
+#include "set_commitment_gadget.tcc"
 
 #endif // SET_COMMITMENT_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/set_commitment/set_commitment_gadget.tcc
+++ b/src/gadgetlib1/gadgets/set_commitment/set_commitment_gadget.tcc
@@ -7,7 +7,7 @@
 #ifndef SET_COMMITMENT_GADGET_TCC_
 #define SET_COMMITMENT_GADGET_TCC_
 
-#include "common/data_structures/set_commitment.hpp"
+#include "../../../common/data_structures/set_commitment.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/set_commitment/set_membership_proof_variable.hpp
+++ b/src/gadgetlib1/gadgets/set_commitment/set_membership_proof_variable.hpp
@@ -8,10 +8,10 @@
 #ifndef SET_MEMBERSHIP_PROOF_VARIABLE_HPP_
 #define SET_MEMBERSHIP_PROOF_VARIABLE_HPP_
 
-#include "common/data_structures/set_commitment.hpp"
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/hash_io.hpp"
-#include "gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.hpp"
+#include "../../../common/data_structures/set_commitment.hpp"
+#include "../../gadget.hpp"
+#include "../hashes/hash_io.hpp"
+#include "../merkle_tree/merkle_authentication_path_variable.hpp"
 
 namespace libsnark {
 
@@ -38,6 +38,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/set_commitment/set_membership_proof_variable.tcc"
+#include "set_membership_proof_variable.tcc"
 
 #endif // SET_MEMBERSHIP_PROOF_VARIABLE_HPP

--- a/src/gadgetlib1/gadgets/set_commitment/tests/test_set_commitment_gadget.cpp
+++ b/src/gadgetlib1/gadgets/set_commitment/tests/test_set_commitment_gadget.cpp
@@ -11,8 +11,8 @@
 #include "algebra/curves/edwards/edwards_pp.hpp"
 #include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
 #include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
-#include "gadgetlib1/gadgets/set_commitment/set_commitment_gadget.hpp"
-#include "gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp"
+#include "../set_commitment_gadget.hpp"
+#include "../../hashes/sha256/sha256_gadget.hpp"
 
 using namespace libsnark;
 

--- a/src/gadgetlib1/gadgets/set_commitment/tests/test_set_commitment_gadget.cpp
+++ b/src/gadgetlib1/gadgets/set_commitment/tests/test_set_commitment_gadget.cpp
@@ -6,11 +6,11 @@
  *****************************************************************************/
 
 #ifdef CURVE_BN128
-#include "algebra/curves/bn128/bn128_pp.hpp"
+#include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif
-#include "algebra/curves/edwards/edwards_pp.hpp"
-#include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
+#include <libff/algebra/curves/edwards/edwards_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
 #include "../set_commitment_gadget.hpp"
 #include "../../hashes/sha256/sha256_gadget.hpp"
 

--- a/src/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp
+++ b/src/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp
@@ -18,12 +18,12 @@
 #ifndef R1CS_PPZKSNARK_VERIFIER_GADGET_HPP_
 #define R1CS_PPZKSNARK_VERIFIER_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp"
-#include "gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp"
-#include "gadgetlib1/gadgets/pairing/pairing_checks.hpp"
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include "../basic_gadgets.hpp"
+#include "../curves/weierstrass_g1_gadget.hpp"
+#include "../curves/weierstrass_g2_gadget.hpp"
+#include "../pairing/pairing_checks.hpp"
+#include "../pairing/pairing_params.hpp"
+#include "../../../zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
 
 namespace libsnark {
 
@@ -245,6 +245,6 @@ public:
 
 } // libsnark
 
-#include "gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.tcc"
+#include "r1cs_ppzksnark_verifier_gadget.tcc"
 
 #endif // R1CS_PPZKSNARK_VERIFIER_GADGET_HPP_

--- a/src/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.tcc
+++ b/src/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.tcc
@@ -14,7 +14,7 @@
 #ifndef R1CS_PPZKSNARK_VERIFIER_GADGET_TCC_
 #define R1CS_PPZKSNARK_VERIFIER_GADGET_TCC_
 
-#include "gadgetlib1/constraint_profiling.hpp"
+#include "../../constraint_profiling.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/src/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -4,9 +4,9 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
-#include "algebra/fields/field_utils.hpp"
+#include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/fields/field_utils.hpp>
 #include "../../fields/fp2_gadgets.hpp"
 #include "../../fields/fp3_gadgets.hpp"
 #include "../../fields/fp4_gadgets.hpp"

--- a/src/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/src/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -7,13 +7,13 @@
 #include "algebra/curves/mnt/mnt4/mnt4_pp.hpp"
 #include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
 #include "algebra/fields/field_utils.hpp"
-#include "gadgetlib1/gadgets/fields/fp2_gadgets.hpp"
-#include "gadgetlib1/gadgets/fields/fp3_gadgets.hpp"
-#include "gadgetlib1/gadgets/fields/fp4_gadgets.hpp"
-#include "gadgetlib1/gadgets/fields/fp6_gadgets.hpp"
-#include "gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include "../../fields/fp2_gadgets.hpp"
+#include "../../fields/fp3_gadgets.hpp"
+#include "../../fields/fp4_gadgets.hpp"
+#include "../../fields/fp6_gadgets.hpp"
+#include "../r1cs_ppzksnark_verifier_gadget.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../../../zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/gadgetlib1/pb_variable.hpp
+++ b/src/gadgetlib1/pb_variable.hpp
@@ -11,7 +11,7 @@
 #include <cstddef>
 #include <string>
 #include <vector>
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../relations/variable.hpp"
 
 namespace libsnark {

--- a/src/gadgetlib1/pb_variable.hpp
+++ b/src/gadgetlib1/pb_variable.hpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 #include "common/utils.hpp"
-#include "relations/variable.hpp"
+#include "../relations/variable.hpp"
 
 namespace libsnark {
 
@@ -139,6 +139,6 @@ template<typename FieldT>
 linear_combination<FieldT> pb_coeff_sum(const pb_linear_combination_array<FieldT> &v, const std::vector<FieldT> &coeffs);
 
 } // libsnark
-#include "gadgetlib1/pb_variable.tcc"
+#include "pb_variable.tcc"
 
 #endif // PB_VARIABLE_HPP_

--- a/src/gadgetlib1/pb_variable.tcc
+++ b/src/gadgetlib1/pb_variable.tcc
@@ -8,7 +8,7 @@
 #ifndef PB_VARIABLE_TCC_
 #define PB_VARIABLE_TCC_
 #include <cassert>
-#include "gadgetlib1/protoboard.hpp"
+#include "protoboard.hpp"
 #include "common/utils.hpp"
 
 namespace libsnark {

--- a/src/gadgetlib1/pb_variable.tcc
+++ b/src/gadgetlib1/pb_variable.tcc
@@ -9,7 +9,7 @@
 #define PB_VARIABLE_TCC_
 #include <cassert>
 #include "protoboard.hpp"
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/protoboard.hpp
+++ b/src/gadgetlib1/protoboard.hpp
@@ -13,8 +13,8 @@
 #include <cstdio>
 #include <string>
 #include <vector>
-#include "gadgetlib1/pb_variable.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "pb_variable.hpp"
+#include "../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 #include "common/utils.hpp"
 
 namespace libsnark {
@@ -71,5 +71,5 @@ private:
 };
 
 } // libsnark
-#include "gadgetlib1/protoboard.tcc"
+#include "protoboard.tcc"
 #endif // PROTOBOARD_HPP_

--- a/src/gadgetlib1/protoboard.hpp
+++ b/src/gadgetlib1/protoboard.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 #include "pb_variable.hpp"
 #include "../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/protoboard.tcc
+++ b/src/gadgetlib1/protoboard.tcc
@@ -10,7 +10,7 @@
 
 #include <cstdio>
 #include <cstdarg>
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/gadgetlib1/tests/gadgetlib1_test.cpp
+++ b/src/gadgetlib1/tests/gadgetlib1_test.cpp
@@ -8,8 +8,8 @@
  *****************************************************************************/
 
 #include <gtest/gtest.h>
-#include "gadgetlib1/examples/simple_example.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
+#include "../examples/simple_example.hpp"
+#include "../../zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
 
 namespace {
 

--- a/src/gadgetlib2/examples/simple_example.cpp
+++ b/src/gadgetlib2/examples/simple_example.cpp
@@ -5,11 +5,11 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "gadgetlib2/examples/simple_example.hpp"
+#include "simple_example.hpp"
 
-#include "gadgetlib2/adapters.hpp"
-#include "gadgetlib2/gadget.hpp"
-#include "gadgetlib2/integration.hpp"
+#include "../adapters.hpp"
+#include "../gadget.hpp"
+#include "../integration.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib2/examples/simple_example.hpp
+++ b/src/gadgetlib2/examples/simple_example.hpp
@@ -9,7 +9,7 @@
 #define SIMPLE_EXAMPLE_HPP_
 
 #include "common/default_types/ec_pp.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib2/examples/simple_example.hpp
+++ b/src/gadgetlib2/examples/simple_example.hpp
@@ -8,7 +8,7 @@
 #ifndef SIMPLE_EXAMPLE_HPP_
 #define SIMPLE_EXAMPLE_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 #include "../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {

--- a/src/gadgetlib2/examples/tutorial.cpp
+++ b/src/gadgetlib2/examples/tutorial.cpp
@@ -10,10 +10,10 @@ This file is meant to be read top-down as a tutorial for gadget writing.
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "gadgetlib2/examples/simple_example.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "simple_example.hpp"
+#include "../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 #include "third_party/gtest/googletest/include/gtest/gtest.h"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
+#include "../../zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
 #include <gadgetlib2/gadget.hpp>
 
 namespace gadgetExamples {

--- a/src/gadgetlib2/infrastructure.hpp
+++ b/src/gadgetlib2/infrastructure.hpp
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <cmath>
 #include <cstdarg>
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 #ifndef  __infrastructure_HPP
 #define  __infrastructure_HPP

--- a/src/gadgetlib2/integration.cpp
+++ b/src/gadgetlib2/integration.cpp
@@ -5,8 +5,8 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "gadgetlib2/adapters.hpp"
-#include "gadgetlib2/integration.hpp"
+#include "adapters.hpp"
+#include "integration.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib2/integration.hpp
+++ b/src/gadgetlib2/integration.hpp
@@ -8,7 +8,7 @@
 #ifndef INTEGRATION_HPP_
 #define INTEGRATION_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 #include "../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 #include "protoboard.hpp"
 

--- a/src/gadgetlib2/integration.hpp
+++ b/src/gadgetlib2/integration.hpp
@@ -9,8 +9,8 @@
 #define INTEGRATION_HPP_
 
 #include "common/default_types/ec_pp.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
-#include "gadgetlib2/protoboard.hpp"
+#include "../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "protoboard.hpp"
 
 namespace libsnark {
 

--- a/src/gadgetlib2/pp.hpp
+++ b/src/gadgetlib2/pp.hpp
@@ -10,7 +10,7 @@
 #ifndef LIBSNARK_GADGETLIB2_INCLUDE_GADGETLIB2_PP_HPP_
 #define LIBSNARK_GADGETLIB2_INCLUDE_GADGETLIB2_PP_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 
 #include <memory>
 #include <vector>

--- a/src/gadgetlib2/tests/integration_UTEST.cpp
+++ b/src/gadgetlib2/tests/integration_UTEST.cpp
@@ -11,11 +11,11 @@
 #include <gadgetlib2/protoboard.hpp>
 #include <gadgetlib2/gadget.hpp>
 
-#include "common/default_types/r1cs_ppzksnark_pp.hpp"
-#include "gadgetlib2/examples/simple_example.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../common/default_types/r1cs_ppzksnark_pp.hpp"
+#include "../examples/simple_example.hpp"
+#include "../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 #include "third_party/gtest/googletest/include/gtest/gtest.h"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
+#include "../../zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
 
 using namespace gadgetlib2;
 

--- a/src/knowledge_commitment/kc_multiexp.hpp
+++ b/src/knowledge_commitment/kc_multiexp.hpp
@@ -17,7 +17,7 @@
   Will probably go away in more general exp refactoring.
 */
 
-#include "knowledge_commitment/knowledge_commitment.hpp"
+#include "knowledge_commitment.hpp"
 
 namespace libsnark {
 
@@ -50,6 +50,6 @@ knowledge_commitment_vector<T1, T2> kc_batch_exp(const size_t scalar_size,
 
 } // libsnark
 
-#include "knowledge_commitment/kc_multiexp.tcc"
+#include "kc_multiexp.tcc"
 
 #endif // KC_MULTIEXP_HPP_

--- a/src/knowledge_commitment/knowledge_commitment.hpp
+++ b/src/knowledge_commitment/knowledge_commitment.hpp
@@ -15,7 +15,7 @@
 #define KNOWLEDGE_COMMITMENT_HPP_
 
 #include "algebra/fields/fp.hpp"
-#include "common/data_structures/sparse_vector.hpp"
+#include "../common/data_structures/sparse_vector.hpp"
 
 namespace libsnark {
 
@@ -79,6 +79,6 @@ using knowledge_commitment_vector = sparse_vector<knowledge_commitment<T1, T2> >
 
 } // libsnark
 
-#include "knowledge_commitment/knowledge_commitment.tcc"
+#include "knowledge_commitment.tcc"
 
 #endif // KNOWLEDGE_COMMITMENT_HPP_

--- a/src/knowledge_commitment/knowledge_commitment.hpp
+++ b/src/knowledge_commitment/knowledge_commitment.hpp
@@ -14,7 +14,7 @@
 #ifndef KNOWLEDGE_COMMITMENT_HPP_
 #define KNOWLEDGE_COMMITMENT_HPP_
 
-#include "algebra/fields/fp.hpp"
+#include <libff/algebra/fields/fp.hpp>
 #include "../common/data_structures/sparse_vector.hpp"
 
 namespace libsnark {

--- a/src/reductions/bacs_to_r1cs/bacs_to_r1cs.hpp
+++ b/src/reductions/bacs_to_r1cs/bacs_to_r1cs.hpp
@@ -18,8 +18,8 @@
 #ifndef BACS_TO_R1CS_HPP_
 #define BACS_TO_R1CS_HPP_
 
-#include "relations/circuit_satisfaction_problems/bacs/bacs.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../relations/circuit_satisfaction_problems/bacs/bacs.hpp"
+#include "../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 
 namespace libsnark {
 
@@ -39,6 +39,6 @@ r1cs_variable_assignment<FieldT> bacs_to_r1cs_witness_map(const bacs_circuit<Fie
 
 } // libsnark
 
-#include "reductions/bacs_to_r1cs/bacs_to_r1cs.tcc"
+#include "bacs_to_r1cs.tcc"
 
 #endif // BACS_TO_R1CS_HPP_

--- a/src/reductions/bacs_to_r1cs/bacs_to_r1cs.tcc
+++ b/src/reductions/bacs_to_r1cs/bacs_to_r1cs.tcc
@@ -14,8 +14,8 @@ See bacs_to_r1cs.hpp .
 #ifndef BACS_TO_R1CS_TCC_
 #define BACS_TO_R1CS_TCC_
 
-#include "relations/circuit_satisfaction_problems/bacs/bacs.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../relations/circuit_satisfaction_problems/bacs/bacs.hpp"
+#include "../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 
 namespace libsnark {
 

--- a/src/reductions/r1cs_to_qap/r1cs_to_qap.hpp
+++ b/src/reductions/r1cs_to_qap/r1cs_to_qap.hpp
@@ -32,8 +32,8 @@
 #ifndef R1CS_TO_QAP_HPP_
 #define R1CS_TO_QAP_HPP_
 
-#include "relations/arithmetic_programs/qap/qap.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../relations/arithmetic_programs/qap/qap.hpp"
+#include "../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 
 namespace libsnark {
 
@@ -65,6 +65,6 @@ qap_witness<FieldT> r1cs_to_qap_witness_map(const r1cs_constraint_system<FieldT>
 
 } // libsnark
 
-#include "reductions/r1cs_to_qap/r1cs_to_qap.tcc"
+#include "r1cs_to_qap.tcc"
 
 #endif // R1CS_TO_QAP_HPP_

--- a/src/reductions/r1cs_to_qap/r1cs_to_qap.tcc
+++ b/src/reductions/r1cs_to_qap/r1cs_to_qap.tcc
@@ -16,7 +16,7 @@
 
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
-#include "evaluation_domain/evaluation_domain.hpp"
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 
 namespace libsnark {
 

--- a/src/reductions/r1cs_to_qap/r1cs_to_qap.tcc
+++ b/src/reductions/r1cs_to_qap/r1cs_to_qap.tcc
@@ -14,8 +14,8 @@
 #ifndef R1CS_TO_QAP_TCC_
 #define R1CS_TO_QAP_TCC_
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "evaluation_domain/evaluation_domain.hpp"
 
 namespace libsnark {

--- a/src/reductions/ram_to_r1cs/examples/demo_arithmetization.cpp
+++ b/src/reductions/ram_to_r1cs/examples/demo_arithmetization.cpp
@@ -13,11 +13,11 @@
 #include <boost/program_options.hpp>
 #endif
 
-#include "common/default_types/tinyram_ppzksnark_pp.hpp"
+#include "../../../common/default_types/tinyram_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "reductions/ram_to_r1cs/ram_to_r1cs.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"
+#include "../ram_to_r1cs.hpp"
+#include "../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../../../zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"
 
 #ifndef MINDEPS
 namespace po = boost::program_options;

--- a/src/reductions/ram_to_r1cs/examples/demo_arithmetization.cpp
+++ b/src/reductions/ram_to_r1cs/examples/demo_arithmetization.cpp
@@ -14,7 +14,7 @@
 #endif
 
 #include "../../../common/default_types/tinyram_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../ram_to_r1cs.hpp"
 #include "../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 #include "../../../zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"

--- a/src/reductions/ram_to_r1cs/gadgets/memory_checker_gadget.hpp
+++ b/src/reductions/ram_to_r1cs/gadgets/memory_checker_gadget.hpp
@@ -13,7 +13,7 @@
 #ifndef MEMORY_CHECKER_GADGET_HPP_
 #define MEMORY_CHECKER_GADGET_HPP_
 
-#include "reductions/ram_to_r1cs/gadgets/trace_lines.hpp"
+#include "trace_lines.hpp"
 
 namespace libsnark {
 
@@ -53,6 +53,6 @@ public:
 
 } // libsnark
 
-#include "reductions/ram_to_r1cs/gadgets/memory_checker_gadget.tcc"
+#include "memory_checker_gadget.tcc"
 
 #endif // MEMORY_CHECKER_GADGET_HPP_

--- a/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.hpp
+++ b/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.hpp
@@ -42,10 +42,10 @@
 #ifndef RAM_UNIVERSAL_GADGET_HPP_
 #define RAM_UNIVERSAL_GADGET_HPP_
 
-#include "gadgetlib1/gadgets/routing/as_waksman_routing_gadget.hpp"
-#include "reductions/ram_to_r1cs/gadgets/memory_checker_gadget.hpp"
-#include "reductions/ram_to_r1cs/gadgets/trace_lines.hpp"
-#include "relations/ram_computations/rams/ram_params.hpp"
+#include "../../../gadgetlib1/gadgets/routing/as_waksman_routing_gadget.hpp"
+#include "memory_checker_gadget.hpp"
+#include "trace_lines.hpp"
+#include "../../../relations/ram_computations/rams/ram_params.hpp"
 
 namespace libsnark {
 
@@ -133,6 +133,6 @@ public:
 
 } // libsnark
 
-#include "reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc"
+#include "ram_universal_gadget.tcc"
 
 #endif // RAM_UNIVERSAL_GADGET_HPP_

--- a/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
+++ b/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
@@ -15,9 +15,9 @@
 #define RAM_UNIVERSAL_GADGET_TCC_
 
 #include "../../../common/data_structures/integer_permutation.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
-#include "algebra/fields/field_utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libff/algebra/fields/field_utils.hpp>
 #include "../../../relations/ram_computations/memory/ra_memory.hpp"
 
 namespace libsnark {

--- a/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
+++ b/src/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
@@ -14,11 +14,11 @@
 #ifndef RAM_UNIVERSAL_GADGET_TCC_
 #define RAM_UNIVERSAL_GADGET_TCC_
 
-#include "common/data_structures/integer_permutation.hpp"
+#include "../../../common/data_structures/integer_permutation.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
 #include "algebra/fields/field_utils.hpp"
-#include "relations/ram_computations/memory/ra_memory.hpp"
+#include "../../../relations/ram_computations/memory/ra_memory.hpp"
 
 namespace libsnark {
 

--- a/src/reductions/ram_to_r1cs/gadgets/trace_lines.hpp
+++ b/src/reductions/ram_to_r1cs/gadgets/trace_lines.hpp
@@ -13,7 +13,7 @@
 #define TRACE_LINES_HPP_
 
 #include <memory>
-#include "relations/ram_computations/rams/ram_params.hpp"
+#include "../../../relations/ram_computations/rams/ram_params.hpp"
 
 namespace libsnark {
 
@@ -74,6 +74,6 @@ public:
 
 } // libsnark
 
-#include "reductions/ram_to_r1cs/gadgets/trace_lines.tcc"
+#include "trace_lines.tcc"
 
 #endif // TRACE_LINES_HPP_

--- a/src/reductions/ram_to_r1cs/ram_to_r1cs.hpp
+++ b/src/reductions/ram_to_r1cs/ram_to_r1cs.hpp
@@ -16,7 +16,7 @@
 #ifndef RAM_TO_R1CS_HPP_
 #define RAM_TO_R1CS_HPP_
 
-#include "reductions/ram_to_r1cs/gadgets/ram_universal_gadget.hpp"
+#include "gadgets/ram_universal_gadget.hpp"
 
 namespace libsnark {
 
@@ -54,6 +54,6 @@ public:
 
 } // libsnark
 
-#include "reductions/ram_to_r1cs/ram_to_r1cs.tcc"
+#include "ram_to_r1cs.tcc"
 
 #endif // RAM_TO_R1CS_HPP_

--- a/src/reductions/tbcs_to_uscs/tbcs_to_uscs.hpp
+++ b/src/reductions/tbcs_to_uscs/tbcs_to_uscs.hpp
@@ -29,8 +29,8 @@
 #ifndef TBCS_TO_USCS_HPP_
 #define TBCS_TO_USCS_HPP_
 
-#include "relations/constraint_satisfaction_problems/uscs/uscs.hpp"
-#include "relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
+#include "../../relations/constraint_satisfaction_problems/uscs/uscs.hpp"
+#include "../../relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
 
 namespace libsnark {
 
@@ -50,6 +50,6 @@ uscs_variable_assignment<FieldT> tbcs_to_uscs_witness_map(const tbcs_circuit &ci
 
 } // libsnark
 
-#include "reductions/tbcs_to_uscs/tbcs_to_uscs.tcc"
+#include "tbcs_to_uscs.tcc"
 
 #endif // TBCS_TO_USCS_HPP_

--- a/src/reductions/tbcs_to_uscs/tbcs_to_uscs.tcc
+++ b/src/reductions/tbcs_to_uscs/tbcs_to_uscs.tcc
@@ -14,7 +14,7 @@ See tbcs_to_uscs.hpp .
 #ifndef TBCS_TO_USCS_TCC_
 #define TBCS_TO_USCS_TCC_
 
-#include "algebra/fields/field_utils.hpp"
+#include <libff/algebra/fields/field_utils.hpp>
 
 namespace libsnark {
 

--- a/src/reductions/uscs_to_ssp/uscs_to_ssp.hpp
+++ b/src/reductions/uscs_to_ssp/uscs_to_ssp.hpp
@@ -32,8 +32,8 @@
 #ifndef USCS_TO_SSP_HPP_
 #define USCS_TO_SSP_HPP_
 
-#include "relations/arithmetic_programs/ssp/ssp.hpp"
-#include "relations/constraint_satisfaction_problems/uscs/uscs.hpp"
+#include "../../relations/arithmetic_programs/ssp/ssp.hpp"
+#include "../../relations/constraint_satisfaction_problems/uscs/uscs.hpp"
 
 namespace libsnark {
 
@@ -63,6 +63,6 @@ ssp_witness<FieldT> uscs_to_ssp_witness_map(const uscs_constraint_system<FieldT>
 
 } // libsnark
 
-#include "reductions/uscs_to_ssp/uscs_to_ssp.tcc"
+#include "uscs_to_ssp.tcc"
 
 #endif // USCS_TO_SSP_HPP_

--- a/src/reductions/uscs_to_ssp/uscs_to_ssp.tcc
+++ b/src/reductions/uscs_to_ssp/uscs_to_ssp.tcc
@@ -14,8 +14,8 @@
 #ifndef USCS_TO_SSP_TCC_
 #define USCS_TO_SSP_TCC_
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "evaluation_domain/evaluation_domain.hpp"
 
 namespace libsnark {

--- a/src/reductions/uscs_to_ssp/uscs_to_ssp.tcc
+++ b/src/reductions/uscs_to_ssp/uscs_to_ssp.tcc
@@ -16,7 +16,7 @@
 
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
-#include "evaluation_domain/evaluation_domain.hpp"
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 
 namespace libsnark {
 

--- a/src/relations/arithmetic_programs/qap/qap.hpp
+++ b/src/relations/arithmetic_programs/qap/qap.hpp
@@ -22,7 +22,7 @@
 #ifndef QAP_HPP_
 #define QAP_HPP_
 
-#include "evaluation_domain/evaluation_domain.hpp"
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 
 namespace libsnark {
 

--- a/src/relations/arithmetic_programs/qap/qap.hpp
+++ b/src/relations/arithmetic_programs/qap/qap.hpp
@@ -188,6 +188,6 @@ public:
 
 } // libsnark
 
-#include "relations/arithmetic_programs/qap/qap.tcc"
+#include "qap.tcc"
 
 #endif // QAP_HPP_

--- a/src/relations/arithmetic_programs/qap/qap.tcc
+++ b/src/relations/arithmetic_programs/qap/qap.tcc
@@ -16,7 +16,7 @@ See qap.hpp .
 
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
-#include "evaluation_domain/evaluation_domain.hpp"
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 #include <libff/algebra/scalar_multiplication/multiexp.hpp>
 
 namespace libsnark {

--- a/src/relations/arithmetic_programs/qap/qap.tcc
+++ b/src/relations/arithmetic_programs/qap/qap.tcc
@@ -14,10 +14,10 @@ See qap.hpp .
 #ifndef QAP_TCC_
 #define QAP_TCC_
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "evaluation_domain/evaluation_domain.hpp"
-#include "algebra/scalar_multiplication/multiexp.hpp"
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
 
 namespace libsnark {
 

--- a/src/relations/arithmetic_programs/qap/tests/test_qap.cpp
+++ b/src/relations/arithmetic_programs/qap/tests/test_qap.cpp
@@ -10,10 +10,10 @@
 #include <cstring>
 #include <vector>
 
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
-#include "algebra/fields/field_utils.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
 #include "../../../constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 

--- a/src/relations/arithmetic_programs/qap/tests/test_qap.cpp
+++ b/src/relations/arithmetic_programs/qap/tests/test_qap.cpp
@@ -14,8 +14,8 @@
 #include "algebra/fields/field_utils.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "reductions/r1cs_to_qap/r1cs_to_qap.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
+#include "../../../constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 using namespace libsnark;
 

--- a/src/relations/arithmetic_programs/ssp/ssp.hpp
+++ b/src/relations/arithmetic_programs/ssp/ssp.hpp
@@ -173,6 +173,6 @@ public:
 
 } // libsnark
 
-#include "relations/arithmetic_programs/ssp/ssp.tcc"
+#include "ssp.tcc"
 
 #endif // SSP_HPP_

--- a/src/relations/arithmetic_programs/ssp/ssp.hpp
+++ b/src/relations/arithmetic_programs/ssp/ssp.hpp
@@ -22,7 +22,7 @@
 #ifndef SSP_HPP_
 #define SSP_HPP_
 
-#include "evaluation_domain/evaluation_domain.hpp"
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 
 namespace libsnark {
 

--- a/src/relations/arithmetic_programs/ssp/ssp.tcc
+++ b/src/relations/arithmetic_programs/ssp/ssp.tcc
@@ -16,7 +16,7 @@
 
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
-#include "evaluation_domain/evaluation_domain.hpp"
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 #include <libff/algebra/scalar_multiplication/multiexp.hpp>
 
 namespace libsnark {

--- a/src/relations/arithmetic_programs/ssp/ssp.tcc
+++ b/src/relations/arithmetic_programs/ssp/ssp.tcc
@@ -14,10 +14,10 @@
 #ifndef SSP_TCC_
 #define SSP_TCC_
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "evaluation_domain/evaluation_domain.hpp"
-#include "algebra/scalar_multiplication/multiexp.hpp"
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
 
 namespace libsnark {
 

--- a/src/relations/arithmetic_programs/ssp/tests/test_ssp.cpp
+++ b/src/relations/arithmetic_programs/ssp/tests/test_ssp.cpp
@@ -10,10 +10,10 @@
 #include <cstring>
 #include <vector>
 
-#include "algebra/curves/mnt/mnt6/mnt6_pp.hpp"
-#include "algebra/fields/field_utils.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../reductions/uscs_to_ssp/uscs_to_ssp.hpp"
 #include "../../../constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
 

--- a/src/relations/arithmetic_programs/ssp/tests/test_ssp.cpp
+++ b/src/relations/arithmetic_programs/ssp/tests/test_ssp.cpp
@@ -14,8 +14,8 @@
 #include "algebra/fields/field_utils.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "reductions/uscs_to_ssp/uscs_to_ssp.hpp"
-#include "relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
+#include "../../../../reductions/uscs_to_ssp/uscs_to_ssp.hpp"
+#include "../../../constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
 
 using namespace libsnark;
 

--- a/src/relations/circuit_satisfaction_problems/bacs/bacs.hpp
+++ b/src/relations/circuit_satisfaction_problems/bacs/bacs.hpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include "relations/variable.hpp"
+#include "../../variable.hpp"
 
 namespace libsnark {
 
@@ -150,6 +150,6 @@ public:
 
 } // libsnark
 
-#include "relations/circuit_satisfaction_problems/bacs/bacs.tcc"
+#include "bacs.tcc"
 
 #endif // BACS_HPP_

--- a/src/relations/circuit_satisfaction_problems/bacs/bacs.tcc
+++ b/src/relations/circuit_satisfaction_problems/bacs/bacs.tcc
@@ -20,8 +20,8 @@
 #define BACS_TCC_
 
 #include <algorithm>
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp
+++ b/src/relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp
@@ -13,7 +13,7 @@
 #ifndef BACS_EXAMPLES_HPP_
 #define BACS_EXAMPLES_HPP_
 
-#include "relations/circuit_satisfaction_problems/bacs/bacs.hpp"
+#include "../bacs.hpp"
 
 namespace libsnark {
 
@@ -66,6 +66,6 @@ bacs_example<FieldT> generate_bacs_example(const size_t primary_input_size,
 
 } // libsnark
 
-#include "relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.tcc"
+#include "bacs_examples.tcc"
 
 #endif // BACS_EXAMPLES_HPP_

--- a/src/relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.tcc
+++ b/src/relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.tcc
@@ -17,7 +17,7 @@
 
 #include <cassert>
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.cpp
+++ b/src/relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.cpp
@@ -12,7 +12,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
+#include "tbcs_examples.hpp"
 
 #include <cassert>
 

--- a/src/relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.cpp
+++ b/src/relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.cpp
@@ -16,7 +16,7 @@
 
 #include <cassert>
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp
+++ b/src/relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp
@@ -13,7 +13,7 @@
 #ifndef TBCS_EXAMPLES_HPP_
 #define TBCS_EXAMPLES_HPP_
 
-#include "relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
+#include "../tbcs.hpp"
 
 namespace libsnark {
 

--- a/src/relations/circuit_satisfaction_problems/tbcs/tbcs.cpp
+++ b/src/relations/circuit_satisfaction_problems/tbcs/tbcs.cpp
@@ -17,7 +17,7 @@
 #include "tbcs.hpp"
 
 #include <algorithm>
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/circuit_satisfaction_problems/tbcs/tbcs.cpp
+++ b/src/relations/circuit_satisfaction_problems/tbcs/tbcs.cpp
@@ -14,7 +14,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
+#include "tbcs.hpp"
 
 #include <algorithm>
 #include "common/utils.hpp"

--- a/src/relations/circuit_satisfaction_problems/tbcs/tbcs.hpp
+++ b/src/relations/circuit_satisfaction_problems/tbcs/tbcs.hpp
@@ -18,7 +18,7 @@
 #define TBCS_HPP_
 
 #include "common/profiling.hpp"
-#include "relations/variable.hpp"
+#include "../../variable.hpp"
 
 namespace libsnark {
 

--- a/src/relations/circuit_satisfaction_problems/tbcs/tbcs.hpp
+++ b/src/relations/circuit_satisfaction_problems/tbcs/tbcs.hpp
@@ -17,7 +17,7 @@
 #ifndef TBCS_HPP_
 #define TBCS_HPP_
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../variable.hpp"
 
 namespace libsnark {

--- a/src/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp
+++ b/src/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp
@@ -13,7 +13,7 @@
 #ifndef R1CS_EXAMPLES_HPP_
 #define R1CS_EXAMPLES_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../r1cs.hpp"
 
 namespace libsnark {
 
@@ -68,6 +68,6 @@ r1cs_example<FieldT> generate_r1cs_example_with_binary_input(const size_t num_co
 
 } // libsnark
 
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.tcc"
+#include "r1cs_examples.tcc"
 
 #endif // R1CS_EXAMPLES_HPP_

--- a/src/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.tcc
+++ b/src/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.tcc
@@ -17,7 +17,7 @@
 
 #include <cassert>
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/constraint_satisfaction_problems/r1cs/r1cs.hpp
+++ b/src/relations/constraint_satisfaction_problems/r1cs/r1cs.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include "relations/variable.hpp"
+#include "../../variable.hpp"
 
 namespace libsnark {
 
@@ -148,6 +148,6 @@ public:
 
 } // libsnark
 
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.tcc"
+#include "r1cs.tcc"
 
 #endif // R1CS_HPP_

--- a/src/relations/constraint_satisfaction_problems/r1cs/r1cs.tcc
+++ b/src/relations/constraint_satisfaction_problems/r1cs/r1cs.tcc
@@ -20,9 +20,9 @@
 #include <algorithm>
 #include <cassert>
 #include <set>
-#include "common/utils.hpp"
-#include "common/profiling.hpp"
-#include "algebra/fields/bigint.hpp"
+#include <libff/common/utils.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/algebra/fields/bigint.hpp>
 
 namespace libsnark {
 

--- a/src/relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp
+++ b/src/relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp
@@ -12,7 +12,7 @@
 #ifndef USCS_EXAMPLES_HPP_
 #define USCS_EXAMPLES_HPP_
 
-#include "relations/constraint_satisfaction_problems/uscs/uscs.hpp"
+#include "../uscs.hpp"
 
 namespace libsnark {
 
@@ -67,6 +67,6 @@ uscs_example<FieldT> generate_uscs_example_with_binary_input(const size_t num_co
 
 } // libsnark
 
-#include "relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.tcc"
+#include "uscs_examples.tcc"
 
 #endif // USCS_EXAMPLES_HPP_

--- a/src/relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.tcc
+++ b/src/relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.tcc
@@ -17,7 +17,7 @@
 
 #include <cassert>
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/constraint_satisfaction_problems/uscs/uscs.hpp
+++ b/src/relations/constraint_satisfaction_problems/uscs/uscs.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include "relations/variable.hpp"
+#include "../../variable.hpp"
 
 namespace libsnark {
 
@@ -119,6 +119,6 @@ public:
 
 } // libsnark
 
-#include "relations/constraint_satisfaction_problems/uscs/uscs.tcc"
+#include "uscs.tcc"
 
 #endif // USCS_HPP_

--- a/src/relations/constraint_satisfaction_problems/uscs/uscs.tcc
+++ b/src/relations/constraint_satisfaction_problems/uscs/uscs.tcc
@@ -20,9 +20,9 @@
 #include <algorithm>
 #include <cassert>
 #include <set>
-#include "common/utils.hpp"
-#include "common/profiling.hpp"
-#include "algebra/fields/bigint.hpp"
+#include <libff/common/utils.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/algebra/fields/bigint.hpp>
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/memory/delegated_ra_memory.hpp
+++ b/src/relations/ram_computations/memory/delegated_ra_memory.hpp
@@ -16,8 +16,8 @@
 #include <memory>
 #include <vector>
 
-#include "common/data_structures/merkle_tree.hpp"
-#include "relations/ram_computations/memory/memory_interface.hpp"
+#include "../../../common/data_structures/merkle_tree.hpp"
+#include "memory_interface.hpp"
 
 namespace libsnark {
 
@@ -45,6 +45,6 @@ public:
 
 } // libsnark
 
-#include "relations/ram_computations/memory/delegated_ra_memory.tcc"
+#include "delegated_ra_memory.tcc"
 
 #endif // DELEGATED_RA_MEMORY_HPP_

--- a/src/relations/ram_computations/memory/delegated_ra_memory.tcc
+++ b/src/relations/ram_computations/memory/delegated_ra_memory.tcc
@@ -16,8 +16,8 @@
 
 #include <algorithm>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/memory/examples/memory_contents_examples.cpp
+++ b/src/relations/ram_computations/memory/examples/memory_contents_examples.cpp
@@ -11,7 +11,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "relations/ram_computations/memory/examples/memory_contents_examples.hpp"
+#include "memory_contents_examples.hpp"
 
 #include <cstdlib>
 #include <map>

--- a/src/relations/ram_computations/memory/examples/memory_contents_examples.hpp
+++ b/src/relations/ram_computations/memory/examples/memory_contents_examples.hpp
@@ -12,7 +12,7 @@
 #ifndef MEMORY_CONTENTS_EXAMPLES_HPP_
 #define MEMORY_CONTENTS_EXAMPLES_HPP_
 
-#include "relations/ram_computations/memory/memory_interface.hpp"
+#include "../memory_interface.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/memory/memory_store_trace.cpp
+++ b/src/relations/ram_computations/memory/memory_store_trace.cpp
@@ -11,7 +11,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "relations/ram_computations/memory/memory_store_trace.hpp"
+#include "memory_store_trace.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/memory/memory_store_trace.hpp
+++ b/src/relations/ram_computations/memory/memory_store_trace.hpp
@@ -12,7 +12,7 @@
 #ifndef MEMORY_STORE_TRACE_HPP_
 #define MEMORY_STORE_TRACE_HPP_
 
-#include "relations/ram_computations/memory/memory_interface.hpp"
+#include "memory_interface.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/memory/ra_memory.cpp
+++ b/src/relations/ram_computations/memory/ra_memory.cpp
@@ -13,7 +13,7 @@
 
 #include <cassert>
 
-#include "relations/ram_computations/memory/ra_memory.hpp"
+#include "ra_memory.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/memory/ra_memory.hpp
+++ b/src/relations/ram_computations/memory/ra_memory.hpp
@@ -12,7 +12,7 @@
 #ifndef RA_MEMORY_HPP_
 #define RA_MEMORY_HPP_
 
-#include "relations/ram_computations/memory/memory_interface.hpp"
+#include "memory_interface.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/examples/ram_examples.hpp
+++ b/src/relations/ram_computations/rams/examples/ram_examples.hpp
@@ -13,7 +13,7 @@
 #ifndef RAM_EXAMPLES_HPP_
 #define RAM_EXAMPLES_HPP_
 
-#include "relations/ram_computations/rams/ram_params.hpp"
+#include "../ram_params.hpp"
 
 namespace libsnark {
 
@@ -40,6 +40,6 @@ ram_example<ramT> gen_ram_example_complex(const ram_architecture_params<ramT> &a
 
 } // libsnark
 
-#include "relations/ram_computations/rams/examples/ram_examples.tcc"
+#include "ram_examples.tcc"
 
 #endif // RAM_EXAMPLES_HPP_

--- a/src/relations/ram_computations/rams/examples/ram_examples.tcc
+++ b/src/relations/ram_computations/rams/examples/ram_examples.tcc
@@ -15,7 +15,7 @@
 #ifndef RAM_EXAMPLES_TCC_
 #define RAM_EXAMPLES_TCC_
 
-#include "relations/ram_computations/rams/tinyram/tinyram_aux.hpp"
+#include "../tinyram/tinyram_aux.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/fooram/fooram_aux.cpp
+++ b/src/relations/ram_computations/rams/fooram/fooram_aux.cpp
@@ -13,7 +13,7 @@
 
 #include "fooram_aux.hpp"
 
-#include "common/serialization.hpp"
+#include <libff/common/serialization.hpp>
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/fooram/fooram_aux.cpp
+++ b/src/relations/ram_computations/rams/fooram/fooram_aux.cpp
@@ -11,7 +11,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "relations/ram_computations/rams/fooram/fooram_aux.hpp"
+#include "fooram_aux.hpp"
 
 #include "common/serialization.hpp"
 

--- a/src/relations/ram_computations/rams/fooram/fooram_aux.hpp
+++ b/src/relations/ram_computations/rams/fooram/fooram_aux.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 #include "common/utils.hpp"
-#include "relations/ram_computations/memory/memory_interface.hpp"
+#include "../../memory/memory_interface.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/fooram/fooram_aux.hpp
+++ b/src/relations/ram_computations/rams/fooram/fooram_aux.hpp
@@ -15,7 +15,7 @@
 #include <iostream>
 #include <vector>
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../../memory/memory_interface.hpp"
 
 namespace libsnark {

--- a/src/relations/ram_computations/rams/fooram/fooram_params.hpp
+++ b/src/relations/ram_computations/rams/fooram/fooram_params.hpp
@@ -12,9 +12,9 @@
 #ifndef FOORAM_PARAMS_HPP_
 #define FOORAM_PARAMS_HPP_
 
-#include "gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.hpp"
-#include "relations/ram_computations/rams/fooram/fooram_aux.hpp"
-#include "relations/ram_computations/rams/ram_params.hpp"
+#include "../../../../gadgetlib1/gadgets/cpu_checkers/fooram/fooram_cpu_checker.hpp"
+#include "fooram_aux.hpp"
+#include "../ram_params.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/ram_params.hpp
+++ b/src/relations/ram_computations/rams/ram_params.hpp
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-#include "relations/ram_computations/memory/memory_store_trace.hpp"
+#include "../memory/memory_store_trace.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/tinyram/tinyram_aux.cpp
+++ b/src/relations/ram_computations/rams/tinyram/tinyram_aux.cpp
@@ -16,7 +16,7 @@
 #include <string>
 
 #include "common/profiling.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_aux.hpp"
+#include "tinyram_aux.hpp"
 #include "common/utils.hpp"
 
 namespace libsnark {

--- a/src/relations/ram_computations/rams/tinyram/tinyram_aux.cpp
+++ b/src/relations/ram_computations/rams/tinyram/tinyram_aux.cpp
@@ -15,9 +15,9 @@
 #include <fstream>
 #include <string>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "tinyram_aux.hpp"
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/tinyram/tinyram_aux.hpp
+++ b/src/relations/ram_computations/rams/tinyram/tinyram_aux.hpp
@@ -16,7 +16,7 @@
 #include <iostream>
 #include <map>
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../../../constraint_satisfaction_problems/r1cs/r1cs.hpp"
 #include "../../memory/memory_interface.hpp"
 #include "../ram_params.hpp"

--- a/src/relations/ram_computations/rams/tinyram/tinyram_aux.hpp
+++ b/src/relations/ram_computations/rams/tinyram/tinyram_aux.hpp
@@ -17,9 +17,9 @@
 #include <map>
 
 #include "common/utils.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
-#include "relations/ram_computations/memory/memory_interface.hpp"
-#include "relations/ram_computations/rams/ram_params.hpp"
+#include "../../../constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../memory/memory_interface.hpp"
+#include "../ram_params.hpp"
 
 namespace libsnark {
 

--- a/src/relations/ram_computations/rams/tinyram/tinyram_params.hpp
+++ b/src/relations/ram_computations/rams/tinyram/tinyram_params.hpp
@@ -12,9 +12,9 @@
 #ifndef TINYRAM_PARAMS_HPP_
 #define TINYRAM_PARAMS_HPP_
 
-#include "relations/ram_computations/rams/ram_params.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_aux.hpp"
-#include "gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.hpp"
+#include "../ram_params.hpp"
+#include "tinyram_aux.hpp"
+#include "../../../../gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.hpp"
 
 namespace libsnark {
 

--- a/src/relations/variable.hpp
+++ b/src/relations/variable.hpp
@@ -208,6 +208,6 @@ linear_combination<FieldT> operator-(const FieldT &field_coeff, const linear_com
 
 } // libsnark
 
-#include "relations/variable.tcc"
+#include "variable.tcc"
 
 #endif // VARIABLE_HPP_

--- a/src/relations/variable.tcc
+++ b/src/relations/variable.tcc
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <cassert>
 
-#include "algebra/fields/bigint.hpp"
+#include <libff/algebra/fields/bigint.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp
@@ -17,7 +17,7 @@
 #ifndef COMPLIANCE_PREDICATE_HPP_
 #define COMPLIANCE_PREDICATE_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 
 namespace libsnark {
 
@@ -155,6 +155,6 @@ public:
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.tcc"
+#include "compliance_predicate.tcc"
 
 #endif // COMPLIANCE_PREDICATE_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.tcc
@@ -14,7 +14,7 @@
 #ifndef COMPLIANCE_PREDICATE_TCC_
 #define COMPLIANCE_PREDICATE_TCC_
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.tcc
@@ -15,7 +15,7 @@
 #define COMPLIANCE_PREDICATE_TCC_
 
 #include "common/utils.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp"
+#include "../r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.hpp
@@ -15,8 +15,8 @@
 #ifndef CP_HANDLER_HPP_
 #define CP_HANDLER_HPP_
 
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
-#include "gadgetlib1/protoboard.hpp"
+#include "compliance_predicate.hpp"
+#include "../../../../gadgetlib1/protoboard.hpp"
 
 namespace libsnark {
 
@@ -109,6 +109,6 @@ public:
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.tcc"
+#include "cp_handler.tcc"
 
 #endif // CP_HANDLER_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.hpp
@@ -21,9 +21,9 @@
 #ifndef TALLY_CP_HPP_
 #define TALLY_CP_HPP_
 
-#include "gadgetlib1/gadgets/basic_gadgets.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.hpp"
+#include "../../../../../gadgetlib1/gadgets/basic_gadgets.hpp"
+#include "../compliance_predicate.hpp"
+#include "../cp_handler.hpp"
 
 namespace libsnark {
 
@@ -105,6 +105,6 @@ public:
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.tcc"
+#include "tally_cp.tcc"
 
 #endif // TALLY_CP_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/ppzkpcd_compliance_predicate.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/ppzkpcd_compliance_predicate.hpp
@@ -13,7 +13,7 @@
 #define PPZKPCD_COMPLIANCE_PREDICATE_HPP_
 
 #include "algebra/curves/public_params.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
+#include "compliance_predicate/compliance_predicate.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/ppzkpcd_compliance_predicate.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/ppzkpcd_compliance_predicate.hpp
@@ -12,7 +12,7 @@
 #ifndef PPZKPCD_COMPLIANCE_PREDICATE_HPP_
 #define PPZKPCD_COMPLIANCE_PREDICATE_HPP_
 
-#include "algebra/curves/public_params.hpp"
+#include <libff/algebra/curves/public_params.hpp>
 #include "compliance_predicate/compliance_predicate.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.hpp
@@ -34,6 +34,6 @@ bool run_r1cs_mp_ppzkpcd_tally_example(const size_t wordsize,
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.tcc"
+#include "run_r1cs_mp_ppzkpcd.tcc"
 
 #endif // RUN_R1CS_MP_PPZKPCD_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.tcc
@@ -15,9 +15,9 @@
 #ifndef RUN_R1CS_MP_PPZKPCD_TCC_
 #define RUN_R1CS_MP_PPZKPCD_TCC_
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.hpp"
+#include "../r1cs_mp_ppzkpcd.hpp"
 
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.hpp"
+#include "../../compliance_predicate/examples/tally_cp.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.hpp
@@ -25,12 +25,12 @@
 #ifndef MP_PCD_CIRCUITS_HPP_
 #define MP_PCD_CIRCUITS_HPP_
 
-#include "gadgetlib1/gadget.hpp"
-#include "gadgetlib1/gadgets/gadget_from_r1cs.hpp"
-#include "gadgetlib1/gadgets/hashes/crh_gadget.hpp"
-#include "gadgetlib1/gadgets/set_commitment/set_commitment_gadget.hpp"
-#include "gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.hpp"
+#include "../../../../gadgetlib1/gadget.hpp"
+#include "../../../../gadgetlib1/gadgets/gadget_from_r1cs.hpp"
+#include "../../../../gadgetlib1/gadgets/hashes/crh_gadget.hpp"
+#include "../../../../gadgetlib1/gadgets/set_commitment/set_commitment_gadget.hpp"
+#include "../../../../gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp"
+#include "../compliance_predicate/cp_handler.hpp"
 
 namespace libsnark {
 
@@ -178,6 +178,6 @@ r1cs_primary_input<libff::Fr<ppT> > get_mp_translation_step_pcd_circuit_input(co
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc"
+#include "mp_pcd_circuits.tcc"
 
 #endif // MP_PCD_CIRCUITS_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
@@ -17,7 +17,7 @@
 
 #include <algorithm>
 #include "common/utils.hpp"
-#include "gadgetlib1/constraint_profiling.hpp"
+#include "../../../../gadgetlib1/constraint_profiling.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
@@ -16,7 +16,7 @@
 #define MP_PCD_CIRCUITS_TCC_
 
 #include <algorithm>
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../../../../gadgetlib1/constraint_profiling.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/profiling/profile_r1cs_mp_ppzkpcd.cpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/profiling/profile_r1cs_mp_ppzkpcd.cpp
@@ -4,9 +4,9 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include "common/default_types/r1cs_ppzkpcd_pp.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.hpp"
+#include "../../../../../common/default_types/r1cs_ppzkpcd_pp.hpp"
+#include "../r1cs_mp_ppzkpcd.hpp"
+#include "../examples/run_r1cs_mp_ppzkpcd.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.hpp
@@ -41,10 +41,10 @@
 #include <memory>
 #include <vector>
 
-#include "common/data_structures/set_commitment.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/ppzkpcd_compliance_predicate.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd_params.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include "../../../../common/data_structures/set_commitment.hpp"
+#include "../ppzkpcd_compliance_predicate.hpp"
+#include "r1cs_mp_ppzkpcd_params.hpp"
+#include "../../../ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
 
 namespace libsnark {
 
@@ -323,6 +323,6 @@ bool r1cs_mp_ppzkpcd_online_verifier(const r1cs_mp_ppzkpcd_processed_verificatio
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.tcc"
+#include "r1cs_mp_ppzkpcd.tcc"
 
 #endif // R1CS_MP_PPZKPCD_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.tcc
@@ -18,8 +18,8 @@
 #include <cassert>
 #include <iostream>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../common/libsnark_serialization.hpp"
 #include "mp_pcd_circuits.hpp"
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.tcc
@@ -20,8 +20,8 @@
 
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "common/libsnark_serialization.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.hpp"
+#include "../../../../common/libsnark_serialization.hpp"
+#include "mp_pcd_circuits.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd_params.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd_params.hpp
@@ -12,7 +12,7 @@
 #ifndef R1CS_MP_PPZKPCD_PARAMS_HPP_
 #define R1CS_MP_PPZKPCD_PARAMS_HPP_
 
-#include "algebra/curves/public_params.hpp"
+#include <libff/algebra/curves/public_params.hpp>
 #include "../compliance_predicate/compliance_predicate.hpp"
 #include "../r1cs_pcd_params.hpp"
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd_params.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd_params.hpp
@@ -13,8 +13,8 @@
 #define R1CS_MP_PPZKPCD_PARAMS_HPP_
 
 #include "algebra/curves/public_params.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.hpp"
+#include "../compliance_predicate/compliance_predicate.hpp"
+#include "../r1cs_pcd_params.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/tests/test_r1cs_mp_ppzkpcd.cpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/tests/test_r1cs_mp_ppzkpcd.cpp
@@ -4,8 +4,8 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include "common/default_types/r1cs_ppzkpcd_pp.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.hpp"
+#include "../../../../../common/default_types/r1cs_ppzkpcd_pp.hpp"
+#include "../examples/run_r1cs_mp_ppzkpcd.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.hpp
@@ -8,7 +8,7 @@
 #define R1CS_PCD_PARAMS_HPP_
 
 #include <memory>
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
+#include "compliance_predicate/compliance_predicate.hpp"
 
 namespace libsnark {
 
@@ -38,6 +38,6 @@ public:
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.tcc"
+#include "r1cs_pcd_params.tcc"
 
 #endif // R1CS_PCD_PARAMS_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.hpp
@@ -30,6 +30,6 @@ bool run_r1cs_sp_ppzkpcd_tally_example(const size_t wordsize,
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.tcc"
+#include "run_r1cs_sp_ppzkpcd.tcc"
 
 #endif // RUN_R1CS_SP_PPZKPCD_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.tcc
@@ -15,9 +15,9 @@
 #ifndef RUN_R1CS_SP_PPZKPCD_TCC_
 #define RUN_R1CS_SP_PPZKPCD_TCC_
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.hpp"
+#include "../r1cs_sp_ppzkpcd.hpp"
 
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.hpp"
+#include "../../compliance_predicate/examples/tally_cp.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/profiling/profile_r1cs_sp_ppzkpcd.cpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/profiling/profile_r1cs_sp_ppzkpcd.cpp
@@ -4,9 +4,9 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include "common/default_types/r1cs_ppzkpcd_pp.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.hpp"
+#include "../../../../../common/default_types/r1cs_ppzkpcd_pp.hpp"
+#include "../r1cs_sp_ppzkpcd.hpp"
+#include "../examples/run_r1cs_sp_ppzkpcd.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.hpp
@@ -42,8 +42,8 @@
 
 #include <memory>
 
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp"
+#include "../../../ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include "r1cs_sp_ppzkpcd_params.hpp"
 
 namespace libsnark {
 
@@ -303,6 +303,6 @@ bool r1cs_sp_ppzkpcd_online_verifier(const r1cs_sp_ppzkpcd_processed_verificatio
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.tcc"
+#include "r1cs_sp_ppzkpcd.tcc"
 
 #endif // R1CS_SP_PPZKPCD_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.tcc
@@ -18,8 +18,8 @@
 #include <cassert>
 #include <iostream>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "sp_pcd_circuits.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.tcc
@@ -20,7 +20,7 @@
 
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.hpp"
+#include "sp_pcd_circuits.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp
@@ -13,8 +13,8 @@
 #define R1CS_SP_PPZKPCD_PARAMS_HPP_
 
 #include "algebra/curves/public_params.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.hpp"
+#include "../compliance_predicate/compliance_predicate.hpp"
+#include "../r1cs_pcd_params.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd_params.hpp
@@ -12,7 +12,7 @@
 #ifndef R1CS_SP_PPZKPCD_PARAMS_HPP_
 #define R1CS_SP_PPZKPCD_PARAMS_HPP_
 
-#include "algebra/curves/public_params.hpp"
+#include <libff/algebra/curves/public_params.hpp>
 #include "../compliance_predicate/compliance_predicate.hpp"
 #include "../r1cs_pcd_params.hpp"
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.hpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.hpp
@@ -26,12 +26,12 @@
 #ifndef SP_PCD_CIRCUITS_HPP_
 #define SP_PCD_CIRCUITS_HPP_
 
-#include "gadgetlib1/protoboard.hpp"
-#include "gadgetlib1/gadgets/gadget_from_r1cs.hpp"
-#include "gadgetlib1/gadgets/hashes/crh_gadget.hpp"
-#include "gadgetlib1/gadgets/pairing/pairing_params.hpp"
-#include "gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.hpp"
+#include "../../../../gadgetlib1/protoboard.hpp"
+#include "../../../../gadgetlib1/gadgets/gadget_from_r1cs.hpp"
+#include "../../../../gadgetlib1/gadgets/hashes/crh_gadget.hpp"
+#include "../../../../gadgetlib1/gadgets/pairing/pairing_params.hpp"
+#include "../../../../gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.hpp"
+#include "../compliance_predicate/cp_handler.hpp"
 
 namespace libsnark {
 
@@ -169,6 +169,6 @@ r1cs_primary_input<libff::Fr<ppT> > get_sp_translation_step_pcd_circuit_input(co
 
 } // libsnark
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc"
+#include "sp_pcd_circuits.tcc"
 
 #endif // SP_PCD_CIRCUITS_HPP_

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
@@ -15,7 +15,7 @@
 #ifndef SP_PCD_CIRCUITS_TCC_
 #define SP_PCD_CIRCUITS_TCC_
 
-#include "common/utils.hpp"
+#include <libff/common/utils.hpp>
 #include "../../../../gadgetlib1/constraint_profiling.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
@@ -16,7 +16,7 @@
 #define SP_PCD_CIRCUITS_TCC_
 
 #include "common/utils.hpp"
-#include "gadgetlib1/constraint_profiling.hpp"
+#include "../../../../gadgetlib1/constraint_profiling.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/tests/test_r1cs_sp_ppzkpcd.cpp
+++ b/src/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/tests/test_r1cs_sp_ppzkpcd.cpp
@@ -4,8 +4,8 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include "common/default_types/r1cs_ppzkpcd_pp.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.hpp"
+#include "../../../../../common/default_types/r1cs_ppzkpcd_pp.hpp"
+#include "../examples/run_r1cs_sp_ppzkpcd.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/demo_r1cs_ppzkadsnark.cpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/demo_r1cs_ppzkadsnark.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "../../../../common/default_types/r1cs_ppzkadsnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "run_r1cs_ppzkadsnark.hpp"
 
 using namespace libsnark;

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/demo_r1cs_ppzkadsnark.cpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/demo_r1cs_ppzkadsnark.cpp
@@ -10,9 +10,9 @@
 #include <cstring>
 #include <vector>
 
-#include "common/default_types/r1cs_ppzkadsnark_pp.hpp"
+#include "../../../../common/default_types/r1cs_ppzkadsnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.hpp"
+#include "run_r1cs_ppzkadsnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/prf/aes_ctr_prf.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/prf/aes_ctr_prf.hpp
@@ -12,7 +12,7 @@
 #ifndef AESCTRPRF_HPP_
 #define AESCTRPRF_HPP_
 
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_prf.hpp"
+#include "../../r1cs_ppzkadsnark_prf.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/prf/aes_ctr_prf.tcc
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/prf/aes_ctr_prf.tcc
@@ -10,7 +10,7 @@
  *****************************************************************************/
 
 #include "gmp.h"
-#include "common/default_types/r1cs_ppzkadsnark_pp.hpp"
+#include "../../../../../common/default_types/r1cs_ppzkadsnark_pp.hpp"
 #include "third_party/libsnark-supercop/include/crypto_core_aes128encrypt.h"
 #include "third_party/libsnark-supercop/include/randombytes.h"
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.hpp
@@ -13,7 +13,7 @@
 #ifndef RUN_R1CS_PPZKADSNARK_HPP_
 #define RUN_R1CS_PPZKADSNARK_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {
 
@@ -30,6 +30,6 @@ bool run_r1cs_ppzkadsnark(const r1cs_example<libff::Fr<snark_pp<ppT>> > &example
 
 } // libsnark
 
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.tcc"
+#include "run_r1cs_ppzkadsnark.tcc"
 
 #endif // RUN_R1CS_PPZKADSNARK_HPP_

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.tcc
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.tcc
@@ -15,9 +15,9 @@
 #ifndef RUN_R1CS_PPZKADSNARK_TCC_
 #define RUN_R1CS_PPZKADSNARK_TCC_
 
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/prf/aes_ctr_prf.tcc"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/signature/ed25519_signature.tcc"
+#include "../r1cs_ppzkadsnark.hpp"
+#include "prf/aes_ctr_prf.tcc"
+#include "signature/ed25519_signature.tcc"
 
 #include <sstream>
 #include <type_traits>

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.tcc
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/run_r1cs_ppzkadsnark.tcc
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <type_traits>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/signature/ed25519_signature.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/signature/ed25519_signature.hpp
@@ -18,7 +18,7 @@
 #ifndef ED25519SIG_HPP_
 #define ED25519SIG_HPP_
 
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_signature.hpp"
+#include "../../r1cs_ppzkadsnark_signature.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/signature/ed25519_signature.tcc
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/examples/signature/ed25519_signature.tcc
@@ -15,7 +15,7 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 
-#include "common/default_types/r1cs_ppzkadsnark_pp.hpp"
+#include "../../../../../common/default_types/r1cs_ppzkadsnark_pp.hpp"
 #include "third_party/libsnark-supercop/include/crypto_sign.h"
 
 namespace libsnark {

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp
@@ -46,12 +46,12 @@ IEEE Symposium on Security and Privacy 2015,
 #include <memory>
 
 #include "algebra/curves/public_params.hpp"
-#include "common/data_structures/accumulation_vector.hpp"
-#include "knowledge_commitment/knowledge_commitment.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params.hpp"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_signature.hpp"
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_prf.hpp"
+#include "../../../common/data_structures/accumulation_vector.hpp"
+#include "../../../knowledge_commitment/knowledge_commitment.hpp"
+#include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "r1cs_ppzkadsnark_params.hpp"
+#include "r1cs_ppzkadsnark_signature.hpp"
+#include "r1cs_ppzkadsnark_prf.hpp"
 
 namespace libsnark {
 
@@ -669,6 +669,6 @@ bool r1cs_ppzkadsnark_online_verifier(const r1cs_ppzkadsnark_processed_verificat
 
 } // libsnark
 
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc"
+#include "r1cs_ppzkadsnark.tcc"
 
 #endif // R1CS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp
@@ -45,7 +45,7 @@ IEEE Symposium on Security and Privacy 2015,
 
 #include <memory>
 
-#include "algebra/curves/public_params.hpp"
+#include <libff/algebra/curves/public_params.hpp>
 #include "../../../common/data_structures/accumulation_vector.hpp"
 #include "../../../knowledge_commitment/knowledge_commitment.hpp"
 #include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
@@ -23,8 +23,8 @@ See r1cs_ppzkadsnark.hpp .
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
 #include "algebra/scalar_multiplication/multiexp.hpp"
-#include "knowledge_commitment/kc_multiexp.hpp"
-#include "reductions/r1cs_to_qap/r1cs_to_qap.hpp"
+#include "../../../knowledge_commitment/kc_multiexp.hpp"
+#include "../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
@@ -20,9 +20,9 @@ See r1cs_ppzkadsnark.hpp .
 #include <iostream>
 #include <sstream>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
-#include "algebra/scalar_multiplication/multiexp.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
 #include "../../../knowledge_commitment/kc_multiexp.hpp"
 #include "../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params.hpp
@@ -12,7 +12,7 @@
 #ifndef R1CS_PPZKADSNARK_PARAMS_HPP_
 #define R1CS_PPZKADSNARK_PARAMS_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_prf.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_prf.hpp
@@ -12,7 +12,7 @@
 #ifndef PRF_HPP_
 #define PRF_HPP_
 
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params.hpp"
+#include "r1cs_ppzkadsnark_params.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_signature.hpp
+++ b/src/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_signature.hpp
@@ -18,7 +18,7 @@
 #ifndef SIGNATURE_HPP_
 #define SIGNATURE_HPP_
 
-#include "zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params.hpp"
+#include "r1cs_ppzkadsnark_params.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark.hpp
@@ -34,9 +34,9 @@
 #ifndef BACS_PPZKSNARK_HPP_
 #define BACS_PPZKSNARK_HPP_
 
-#include "relations/circuit_satisfaction_problems/bacs/bacs.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
-#include "zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark_params.hpp"
+#include "../../../relations/circuit_satisfaction_problems/bacs/bacs.hpp"
+#include "../r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include "bacs_ppzksnark_params.hpp"
 
 namespace libsnark {
 
@@ -253,6 +253,6 @@ bool bacs_ppzksnark_online_verifier_strong_IC(const bacs_ppzksnark_processed_ver
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark.tcc"
+#include "bacs_ppzksnark.tcc"
 
 #endif // BACS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark.tcc
@@ -14,7 +14,7 @@
 #ifndef BACS_PPZKSNARK_TCC_
 #define BACS_PPZKSNARK_TCC_
 
-#include "reductions/bacs_to_r1cs/bacs_to_r1cs.hpp"
+#include "../../../reductions/bacs_to_r1cs/bacs_to_r1cs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark_params.hpp
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark_params.hpp
@@ -12,7 +12,7 @@
 #ifndef BACS_PPZKSNARK_PARAMS_HPP_
 #define BACS_PPZKSNARK_PARAMS_HPP_
 
-#include "relations/circuit_satisfaction_problems/bacs/bacs.hpp"
+#include "../../../relations/circuit_satisfaction_problems/bacs/bacs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.hpp
@@ -13,7 +13,7 @@
 #ifndef RUN_BACS_PPZKSNARK_HPP_
 #define RUN_BACS_PPZKSNARK_HPP_
 
-#include "relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
+#include "../../../../relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
 
 namespace libsnark {
 
@@ -30,6 +30,6 @@ bool run_bacs_ppzksnark(const bacs_example<libff::Fr<ppT> > &example,
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.tcc"
+#include "run_bacs_ppzksnark.tcc"
 
 #endif // RUN_BACS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.tcc
@@ -19,7 +19,7 @@
 
 #include <sstream>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.tcc
@@ -15,7 +15,7 @@
 #ifndef RUN_BACS_PPZKSNARK_TCC_
 #define RUN_BACS_PPZKSNARK_TCC_
 
-#include "zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark.hpp"
+#include "../bacs_ppzksnark.hpp"
 
 #include <sstream>
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/profiling/profile_bacs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/profiling/profile_bacs_ppzksnark.cpp
@@ -20,7 +20,7 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/bacs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../../../relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
 #include "../examples/run_bacs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/profiling/profile_bacs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/profiling/profile_bacs_ppzksnark.cpp
@@ -19,10 +19,10 @@
 
 #include <cstdio>
 
-#include "common/default_types/bacs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/bacs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.hpp"
+#include "../../../../relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
+#include "../examples/run_bacs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/tests/test_bacs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/tests/test_bacs_ppzksnark.cpp
@@ -11,10 +11,10 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/bacs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/bacs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/bacs_ppzksnark/examples/run_bacs_ppzksnark.hpp"
+#include "../../../../relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
+#include "../examples/run_bacs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/tests/test_bacs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/bacs_ppzksnark/tests/test_bacs_ppzksnark.cpp
@@ -12,7 +12,7 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/bacs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../../../relations/circuit_satisfaction_problems/bacs/examples/bacs_examples.hpp"
 #include "../examples/run_bacs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.hpp
@@ -13,7 +13,7 @@
 #ifndef RUN_R1CS_GG_PPZKSNARK_HPP_
 #define RUN_R1CS_GG_PPZKSNARK_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {
 
@@ -30,6 +30,6 @@ bool run_r1cs_gg_ppzksnark(const r1cs_example<libff::Fr<ppT> > &example,
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.tcc"
+#include "run_r1cs_gg_ppzksnark.tcc"
 
 #endif // RUN_R1CS_GG_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.tcc
@@ -15,7 +15,7 @@
 #ifndef RUN_R1CS_GG_PPZKSNARK_TCC_
 #define RUN_R1CS_GG_PPZKSNARK_TCC_
 
-#include "zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp"
+#include "../r1cs_gg_ppzksnark.hpp"
 
 #include <sstream>
 #include <type_traits>

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.tcc
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <type_traits>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/profiling/profile_r1cs_gg_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/profiling/profile_r1cs_gg_ppzksnark.cpp
@@ -25,11 +25,11 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/r1cs_gg_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/r1cs_gg_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../examples/run_r1cs_gg_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/profiling/profile_r1cs_gg_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/profiling/profile_r1cs_gg_ppzksnark.cpp
@@ -26,8 +26,8 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/r1cs_gg_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 #include "../examples/run_r1cs_gg_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -43,7 +43,7 @@ References:
 
 #include <memory>
 
-#include "algebra/curves/public_params.hpp"
+#include <libff/algebra/curves/public_params.hpp>
 #include "../../../common/data_structures/accumulation_vector.hpp"
 #include "../../../knowledge_commitment/knowledge_commitment.hpp"
 #include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -44,10 +44,10 @@ References:
 #include <memory>
 
 #include "algebra/curves/public_params.hpp"
-#include "common/data_structures/accumulation_vector.hpp"
-#include "knowledge_commitment/knowledge_commitment.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark_params.hpp"
+#include "../../../common/data_structures/accumulation_vector.hpp"
+#include "../../../knowledge_commitment/knowledge_commitment.hpp"
+#include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "r1cs_gg_ppzksnark_params.hpp"
 
 namespace libsnark {
 
@@ -452,6 +452,6 @@ bool r1cs_gg_ppzksnark_affine_verifier_weak_IC(const r1cs_gg_ppzksnark_verificat
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc"
+#include "r1cs_gg_ppzksnark.tcc"
 
 #endif // R1CS_GG_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -20,9 +20,9 @@ See r1cs_gg_ppzksnark.hpp .
 #include <iostream>
 #include <sstream>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
-#include "algebra/scalar_multiplication/multiexp.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
 #include "../../../knowledge_commitment/kc_multiexp.hpp"
 #include "../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -23,8 +23,8 @@ See r1cs_gg_ppzksnark.hpp .
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
 #include "algebra/scalar_multiplication/multiexp.hpp"
-#include "knowledge_commitment/kc_multiexp.hpp"
-#include "reductions/r1cs_to_qap/r1cs_to_qap.hpp"
+#include "../../../knowledge_commitment/kc_multiexp.hpp"
+#include "../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark_params.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark_params.hpp
@@ -12,7 +12,7 @@
 #ifndef R1CS_GG_PPZKSNARK_PARAMS_HPP_
 #define R1CS_GG_PPZKSNARK_PARAMS_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/tests/test_r1cs_gg_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/tests/test_r1cs_gg_ppzksnark.cpp
@@ -11,11 +11,11 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/r1cs_gg_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/r1cs_gg_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/examples/run_r1cs_gg_ppzksnark.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../examples/run_r1cs_gg_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/tests/test_r1cs_gg_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/tests/test_r1cs_gg_ppzksnark.cpp
@@ -12,8 +12,8 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/r1cs_gg_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 #include "../examples/run_r1cs_gg_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp
@@ -13,7 +13,7 @@
 #ifndef RUN_R1CS_PPZKSNARK_HPP_
 #define RUN_R1CS_PPZKSNARK_HPP_
 
-#include "common/default_types/ec_pp.hpp"
+#include <libff/common/default_types/ec_pp.hpp>
 #include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp
@@ -14,7 +14,7 @@
 #define RUN_R1CS_PPZKSNARK_HPP_
 
 #include "common/default_types/ec_pp.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 
 namespace libsnark {
 
@@ -31,6 +31,6 @@ bool run_r1cs_ppzksnark(const r1cs_example<libff::Fr<ppT> > &example,
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.tcc"
+#include "run_r1cs_ppzksnark.tcc"
 
 #endif // RUN_R1CS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.tcc
@@ -15,7 +15,7 @@
 #ifndef RUN_R1CS_PPZKSNARK_TCC_
 #define RUN_R1CS_PPZKSNARK_TCC_
 
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include "../r1cs_ppzksnark.hpp"
 
 #include <sstream>
 #include <type_traits>

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.tcc
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <type_traits>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/profiling/profile_r1cs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/profiling/profile_r1cs_ppzksnark.cpp
@@ -25,11 +25,11 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/r1cs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/r1cs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../examples/run_r1cs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/profiling/profile_r1cs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/profiling/profile_r1cs_ppzksnark.cpp
@@ -26,8 +26,8 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/r1cs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 #include "../examples/run_r1cs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
@@ -49,10 +49,10 @@
 #include <memory>
 
 #include "algebra/curves/public_params.hpp"
-#include "common/data_structures/accumulation_vector.hpp"
-#include "knowledge_commitment/knowledge_commitment.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark_params.hpp"
+#include "../../../common/data_structures/accumulation_vector.hpp"
+#include "../../../knowledge_commitment/knowledge_commitment.hpp"
+#include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "r1cs_ppzksnark_params.hpp"
 
 namespace libsnark {
 
@@ -465,6 +465,6 @@ bool r1cs_ppzksnark_affine_verifier_weak_IC(const r1cs_ppzksnark_verification_ke
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc"
+#include "r1cs_ppzksnark.tcc"
 
 #endif // R1CS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
@@ -48,7 +48,7 @@
 
 #include <memory>
 
-#include "algebra/curves/public_params.hpp"
+#include <libff/algebra/curves/public_params.hpp>
 #include "../../../common/data_structures/accumulation_vector.hpp"
 #include "../../../knowledge_commitment/knowledge_commitment.hpp"
 #include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -20,9 +20,9 @@ See r1cs_ppzksnark.hpp .
 #include <iostream>
 #include <sstream>
 
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
-#include "algebra/scalar_multiplication/multiexp.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
 #include "../../../knowledge_commitment/kc_multiexp.hpp"
 #include "../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -23,8 +23,8 @@ See r1cs_ppzksnark.hpp .
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
 #include "algebra/scalar_multiplication/multiexp.hpp"
-#include "knowledge_commitment/kc_multiexp.hpp"
-#include "reductions/r1cs_to_qap/r1cs_to_qap.hpp"
+#include "../../../knowledge_commitment/kc_multiexp.hpp"
+#include "../../../reductions/r1cs_to_qap/r1cs_to_qap.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark_params.hpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark_params.hpp
@@ -12,7 +12,7 @@
 #ifndef R1CS_PPZKSNARK_PARAMS_HPP_
 #define R1CS_PPZKSNARK_PARAMS_HPP_
 
-#include "relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
+#include "../../../relations/constraint_satisfaction_problems/r1cs/r1cs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/tests/test_r1cs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/tests/test_r1cs_ppzksnark.cpp
@@ -12,8 +12,8 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/r1cs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
 #include "../examples/run_r1cs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/tests/test_r1cs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/r1cs_ppzksnark/tests/test_r1cs_ppzksnark.cpp
@@ -11,11 +11,11 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/r1cs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/r1cs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp"
+#include "../examples/run_r1cs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark.cpp
@@ -14,7 +14,7 @@
 #endif
 
 #include "../../../../common/default_types/tinyram_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../../../reductions/ram_to_r1cs/ram_to_r1cs.hpp"
 #include "../ram_ppzksnark.hpp"
 #include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark.cpp
@@ -13,11 +13,11 @@
 #include <boost/program_options.hpp>
 #endif
 
-#include "common/default_types/tinyram_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/tinyram_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "reductions/ram_to_r1cs/ram_to_r1cs.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../../../../reductions/ram_to_r1cs/ram_to_r1cs.hpp"
+#include "../ram_ppzksnark.hpp"
+#include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 #ifndef MINDEPS
 namespace po = boost::program_options;

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark_generator.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark_generator.cpp
@@ -10,9 +10,9 @@
 #include <boost/program_options.hpp>
 #endif
 
-#include "common/default_types/ram_ppzksnark_pp.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../../../../common/default_types/ram_ppzksnark_pp.hpp"
+#include "../ram_ppzksnark.hpp"
+#include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 #ifndef MINDEPS
 namespace po = boost::program_options;

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark_prover.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark_prover.cpp
@@ -10,9 +10,9 @@
 #include <boost/program_options.hpp>
 #endif
 
-#include "common/default_types/tinyram_ppzksnark_pp.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../../../../common/default_types/tinyram_ppzksnark_pp.hpp"
+#include "../ram_ppzksnark.hpp"
+#include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 #ifndef MINDEPS
 namespace po = boost::program_options;

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark_verifier.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/demo_ram_ppzksnark_verifier.cpp
@@ -10,9 +10,9 @@
 #include <boost/program_options.hpp>
 #endif
 
-#include "common/default_types/tinyram_ppzksnark_pp.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../../../../common/default_types/tinyram_ppzksnark_pp.hpp"
+#include "../ram_ppzksnark.hpp"
+#include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 #ifndef MINDEPS
 namespace po = boost::program_options;

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp
@@ -13,8 +13,8 @@
 #ifndef RUN_RAM_PPZKSNARK_HPP_
 #define RUN_RAM_PPZKSNARK_HPP_
 
-#include "relations/ram_computations/rams/examples/ram_examples.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark_params.hpp"
+#include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
+#include "../ram_ppzksnark_params.hpp"
 
 namespace libsnark {
 
@@ -31,6 +31,6 @@ bool run_ram_ppzksnark(const ram_example<ram_ppzksnark_machine_pp<ram_ppzksnark_
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.tcc"
+#include "run_ram_ppzksnark.tcc"
 
 #endif // RUN_RAM_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.tcc
@@ -19,7 +19,7 @@
 
 #include <sstream>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.tcc
@@ -15,7 +15,7 @@
 #ifndef RUN_RAM_PPZKSNARK_TCC_
 #define RUN_RAM_PPZKSNARK_TCC_
 
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp"
+#include "../ram_ppzksnark.hpp"
 
 #include <sstream>
 

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/profiling/profile_ram_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/profiling/profile_ram_ppzksnark.cpp
@@ -11,11 +11,11 @@
 #include <sstream>
 #include <string>
 
-#include "common/default_types/ram_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/ram_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "relations/ram_computations/rams/examples/ram_examples.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
+#include "../examples/run_ram_ppzksnark.hpp"
+#include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/profiling/profile_ram_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/profiling/profile_ram_ppzksnark.cpp
@@ -12,7 +12,7 @@
 #include <string>
 
 #include "../../../../common/default_types/ram_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
 #include "../examples/run_ram_ppzksnark.hpp"
 #include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp
@@ -48,9 +48,9 @@
 
 #include <memory>
 
-#include "reductions/ram_to_r1cs/ram_to_r1cs.hpp"
-#include "zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark_params.hpp"
+#include "../../../reductions/ram_to_r1cs/ram_to_r1cs.hpp"
+#include "../r1cs_ppzksnark/r1cs_ppzksnark.hpp"
+#include "ram_ppzksnark_params.hpp"
 
 namespace libsnark {
 
@@ -222,6 +222,6 @@ bool ram_ppzksnark_verifier(const ram_ppzksnark_verification_key<ram_ppzksnark_p
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.tcc"
+#include "ram_ppzksnark.tcc"
 
 #endif // RAM_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.tcc
@@ -14,7 +14,7 @@
 #ifndef RAM_PPZKSNARK_TCC_
 #define RAM_PPZKSNARK_TCC_
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../../reductions/ram_to_r1cs/ram_to_r1cs.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.tcc
@@ -15,7 +15,7 @@
 #define RAM_PPZKSNARK_TCC_
 
 #include "common/profiling.hpp"
-#include "reductions/ram_to_r1cs/ram_to_r1cs.hpp"
+#include "../../../reductions/ram_to_r1cs/ram_to_r1cs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/tests/test_ram_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/tests/test_ram_ppzksnark.cpp
@@ -10,10 +10,10 @@
 #include <sstream>
 #include <string>
 
-#include "common/default_types/ram_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/ram_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "relations/ram_computations/rams/examples/ram_examples.hpp"
-#include "zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp"
+#include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
+#include "../examples/run_ram_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/ram_ppzksnark/tests/test_ram_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/ram_ppzksnark/tests/test_ram_ppzksnark.cpp
@@ -11,7 +11,7 @@
 #include <string>
 
 #include "../../../../common/default_types/ram_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
 #include "../examples/run_ram_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.hpp
@@ -13,7 +13,7 @@
 #ifndef RUN_TBCS_PPZKSNARK_HPP_
 #define RUN_TBCS_PPZKSNARK_HPP_
 
-#include "relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
+#include "../../../../relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
 
 namespace libsnark {
 
@@ -30,6 +30,6 @@ bool run_tbcs_ppzksnark(const tbcs_example &example,
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.tcc"
+#include "run_tbcs_ppzksnark.tcc"
 
 #endif // RUN_TBCS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.tcc
@@ -19,7 +19,7 @@
 
 #include <sstream>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.tcc
@@ -15,7 +15,7 @@
 #ifndef RUN_TBCS_PPZKSNARK_TCC_
 #define RUN_TBCS_PPZKSNARK_TCC_
 
-#include "zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.hpp"
+#include "../tbcs_ppzksnark.hpp"
 
 #include <sstream>
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/profiling/profile_tbcs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/profiling/profile_tbcs_ppzksnark.cpp
@@ -17,11 +17,11 @@
 
 #include <cstdio>
 
-#include "common/default_types/tbcs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/tbcs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.hpp"
+#include "../../../../relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
+#include "../examples/run_tbcs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/profiling/profile_tbcs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/profiling/profile_tbcs_ppzksnark.cpp
@@ -18,8 +18,8 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/tbcs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
 #include "../examples/run_tbcs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.hpp
@@ -34,9 +34,9 @@
 #ifndef TBCS_PPZKSNARK_HPP_
 #define TBCS_PPZKSNARK_HPP_
 
-#include "relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
-#include "zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.hpp"
-#include "zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark_params.hpp"
+#include "../../../relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
+#include "../uscs_ppzksnark/uscs_ppzksnark.hpp"
+#include "tbcs_ppzksnark_params.hpp"
 
 namespace libsnark {
 
@@ -255,6 +255,6 @@ bool tbcs_ppzksnark_online_verifier_strong_IC(const tbcs_ppzksnark_processed_ver
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.tcc"
+#include "tbcs_ppzksnark.tcc"
 
 #endif // TBCS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.tcc
@@ -14,7 +14,7 @@
 #ifndef TBCS_PPZKSNARK_TCC_
 #define TBCS_PPZKSNARK_TCC_
 
-#include "reductions/tbcs_to_uscs/tbcs_to_uscs.hpp"
+#include "../../../reductions/tbcs_to_uscs/tbcs_to_uscs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark_params.hpp
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark_params.hpp
@@ -12,7 +12,7 @@
 #ifndef TBCS_PPZKSNARK_PARAMS_HPP_
 #define TBCS_PPZKSNARK_PARAMS_HPP_
 
-#include "relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
+#include "../../../relations/circuit_satisfaction_problems/tbcs/tbcs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tests/test_tbcs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tests/test_tbcs_ppzksnark.cpp
@@ -12,7 +12,7 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/tbcs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 #include "../../../../relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
 #include "../examples/run_tbcs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tests/test_tbcs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tests/test_tbcs_ppzksnark.cpp
@@ -11,10 +11,10 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/tbcs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/tbcs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
-#include "relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.hpp"
+#include "../../../../relations/circuit_satisfaction_problems/tbcs/examples/tbcs_examples.hpp"
+#include "../examples/run_tbcs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.hpp
@@ -13,7 +13,7 @@
 #ifndef RUN_USCS_PPZKSNARK_HPP_
 #define RUN_USCS_PPZKSNARK_HPP_
 
-#include "relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
 
 namespace libsnark {
 
@@ -30,6 +30,6 @@ bool run_uscs_ppzksnark(const uscs_example<libff::Fr<ppT> > &example,
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.tcc"
+#include "run_uscs_ppzksnark.tcc"
 
 #endif // RUN_USCS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.tcc
@@ -19,7 +19,7 @@
 
 #include <sstream>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.tcc
@@ -15,7 +15,7 @@
 #ifndef RUN_USCS_PPZKSNARK_TCC_
 #define RUN_USCS_PPZKSNARK_TCC_
 
-#include "zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.hpp"
+#include "../uscs_ppzksnark.hpp"
 
 #include <sstream>
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/profiling/profile_uscs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/profiling/profile_uscs_ppzksnark.cpp
@@ -27,8 +27,8 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/uscs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
 #include "../examples/run_uscs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/profiling/profile_uscs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/profiling/profile_uscs_ppzksnark.cpp
@@ -26,11 +26,11 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/uscs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/uscs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
+#include "../examples/run_uscs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/tests/test_uscs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/tests/test_uscs_ppzksnark.cpp
@@ -12,8 +12,8 @@
 #include <cstdio>
 
 #include "../../../../common/default_types/uscs_ppzksnark_pp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
 #include "../../../../relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
 #include "../examples/run_uscs_ppzksnark.hpp"
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/tests/test_uscs_ppzksnark.cpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/tests/test_uscs_ppzksnark.cpp
@@ -11,11 +11,11 @@
 #include <cassert>
 #include <cstdio>
 
-#include "common/default_types/uscs_ppzksnark_pp.hpp"
+#include "../../../../common/default_types/uscs_ppzksnark_pp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
-#include "relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
-#include "zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.hpp"
+#include "../../../../relations/constraint_satisfaction_problems/uscs/examples/uscs_examples.hpp"
+#include "../examples/run_uscs_ppzksnark.hpp"
 
 using namespace libsnark;
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.hpp
@@ -49,10 +49,10 @@
 #include <memory>
 
 #include "algebra/curves/public_params.hpp"
-#include "common/data_structures/accumulation_vector.hpp"
-#include "knowledge_commitment/knowledge_commitment.hpp"
-#include "relations/constraint_satisfaction_problems/uscs/uscs.hpp"
-#include "zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark_params.hpp"
+#include "../../../common/data_structures/accumulation_vector.hpp"
+#include "../../../knowledge_commitment/knowledge_commitment.hpp"
+#include "../../../relations/constraint_satisfaction_problems/uscs/uscs.hpp"
+#include "uscs_ppzksnark_params.hpp"
 
 namespace libsnark {
 
@@ -423,6 +423,6 @@ bool uscs_ppzksnark_online_verifier_strong_IC(const uscs_ppzksnark_processed_ver
 
 } // libsnark
 
-#include "zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc"
+#include "uscs_ppzksnark.tcc"
 
 #endif // USCS_PPZKSNARK_HPP_

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.hpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.hpp
@@ -48,7 +48,7 @@
 
 #include <memory>
 
-#include "algebra/curves/public_params.hpp"
+#include <libff/algebra/curves/public_params.hpp>
 #include "../../../common/data_structures/accumulation_vector.hpp"
 #include "../../../knowledge_commitment/knowledge_commitment.hpp"
 #include "../../../relations/constraint_satisfaction_problems/uscs/uscs.hpp"

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
@@ -19,9 +19,9 @@
 #include <sstream>
 
 #include "../../../reductions/uscs_to_ssp/uscs_to_ssp.hpp"
-#include "common/profiling.hpp"
-#include "common/utils.hpp"
-#include "algebra/scalar_multiplication/multiexp.hpp"
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
 #include "../../../relations/arithmetic_programs/ssp/ssp.hpp"
 
 namespace libsnark {

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
@@ -18,11 +18,11 @@
 #include <iostream>
 #include <sstream>
 
-#include "reductions/uscs_to_ssp/uscs_to_ssp.hpp"
+#include "../../../reductions/uscs_to_ssp/uscs_to_ssp.hpp"
 #include "common/profiling.hpp"
 #include "common/utils.hpp"
 #include "algebra/scalar_multiplication/multiexp.hpp"
-#include "relations/arithmetic_programs/ssp/ssp.hpp"
+#include "../../../relations/arithmetic_programs/ssp/ssp.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark_params.hpp
+++ b/src/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark_params.hpp
@@ -12,7 +12,7 @@
 #ifndef USCS_PPZKSNARK_PARAMS_HPP_
 #define USCS_PPZKSNARK_PARAMS_HPP_
 
-#include "relations/constraint_satisfaction_problems/uscs/uscs.hpp"
+#include "../../../relations/constraint_satisfaction_problems/uscs/uscs.hpp"
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp
@@ -13,8 +13,8 @@
 #ifndef RUN_RAM_ZKSNARK_HPP_
 #define RUN_RAM_ZKSNARK_HPP_
 
-#include "relations/ram_computations/rams/examples/ram_examples.hpp"
-#include "zk_proof_systems/zksnark/ram_zksnark/ram_zksnark_params.hpp"
+#include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
+#include "../ram_zksnark_params.hpp"
 
 namespace libsnark {
 
@@ -31,6 +31,6 @@ bool run_ram_zksnark(const ram_example<ram_zksnark_machine_pp<ram_zksnark_ppT> >
 
 } // libsnark
 
-#include "zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.tcc"
+#include "run_ram_zksnark.tcc"
 
 #endif // RUN_RAM_ZKSNARK_HPP_

--- a/src/zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.tcc
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.tcc
@@ -15,7 +15,7 @@
 #ifndef RUN_RAM_ZKSNARK_TCC_
 #define RUN_RAM_ZKSNARK_TCC_
 
-#include "zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.hpp"
+#include "../ram_zksnark.hpp"
 
 #include <sstream>
 

--- a/src/zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.tcc
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.tcc
@@ -19,7 +19,7 @@
 
 #include <sstream>
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/zksnark/ram_zksnark/profiling/profile_ram_zksnark.cpp
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/profiling/profile_ram_zksnark.cpp
@@ -4,12 +4,12 @@
  *             and contributors (see AUTHORS).
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
-#include "common/default_types/ram_zksnark_pp.hpp"
-#include "relations/ram_computations/memory/examples/memory_contents_examples.hpp"
-#include "relations/ram_computations/rams/examples/ram_examples.hpp"
-#include "zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.hpp"
-#include "zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../../../../common/default_types/ram_zksnark_pp.hpp"
+#include "../../../../relations/ram_computations/memory/examples/memory_contents_examples.hpp"
+#include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
+#include "../ram_zksnark.hpp"
+#include "../examples/run_ram_zksnark.hpp"
+#include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
 
 #include <boost/program_options.hpp>
 

--- a/src/zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.hpp
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.hpp
@@ -37,12 +37,12 @@
 #ifndef RAM_COMPLIANCE_PREDICATE_HPP_
 #define RAM_COMPLIANCE_PREDICATE_HPP_
 
-#include "gadgetlib1/gadgets/delegated_ra_memory/memory_load_gadget.hpp"
-#include "gadgetlib1/gadgets/delegated_ra_memory/memory_load_store_gadget.hpp"
-#include "relations/ram_computations/memory/delegated_ra_memory.hpp"
-#include "relations/ram_computations/rams/ram_params.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
-#include "zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.hpp"
+#include "../../../gadgetlib1/gadgets/delegated_ra_memory/memory_load_gadget.hpp"
+#include "../../../gadgetlib1/gadgets/delegated_ra_memory/memory_load_store_gadget.hpp"
+#include "../../../relations/ram_computations/memory/delegated_ra_memory.hpp"
+#include "../../../relations/ram_computations/rams/ram_params.hpp"
+#include "../../pcd/r1cs_pcd/compliance_predicate/compliance_predicate.hpp"
+#include "../../pcd/r1cs_pcd/compliance_predicate/cp_handler.hpp"
 
 namespace libsnark {
 
@@ -243,6 +243,6 @@ public:
 
 } // libsnark
 
-#include "zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.tcc"
+#include "ram_compliance_predicate.tcc"
 
 #endif // RAM_COMPLIANCE_PREDICATE_HPP_

--- a/src/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.hpp
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.hpp
@@ -42,9 +42,9 @@
 
 #include <memory>
 
-#include "zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.hpp"
-#include "zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.hpp"
-#include "zk_proof_systems/zksnark/ram_zksnark/ram_zksnark_params.hpp"
+#include "../../pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.hpp"
+#include "ram_compliance_predicate.hpp"
+#include "ram_zksnark_params.hpp"
 
 namespace libsnark {
 
@@ -219,6 +219,6 @@ bool ram_zksnark_verifier(const ram_zksnark_verification_key<ram_zksnark_ppT> &v
 
 } // libsnark
 
-#include "zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.tcc"
+#include "ram_zksnark.tcc"
 
 #endif // RAM_ZKSNARK_HPP_

--- a/src/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.tcc
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.tcc
@@ -14,7 +14,7 @@
 #ifndef RAM_ZKSNARK_TCC_
 #define RAM_ZKSNARK_TCC_
 
-#include "common/profiling.hpp"
+#include <libff/common/profiling.hpp>
 
 namespace libsnark {
 

--- a/src/zk_proof_systems/zksnark/ram_zksnark/tests/test_ram_zksnark.cpp
+++ b/src/zk_proof_systems/zksnark/ram_zksnark/tests/test_ram_zksnark.cpp
@@ -5,10 +5,10 @@
  * @copyright  MIT license (see LICENSE file)
  *****************************************************************************/
 #include <sstream>
-#include "common/default_types/ram_zksnark_pp.hpp"
-#include "relations/ram_computations/rams/tinyram/tinyram_params.hpp"
-#include "zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp"
-#include "relations/ram_computations/rams/examples/ram_examples.hpp"
+#include "../../../../common/default_types/ram_zksnark_pp.hpp"
+#include "../../../../relations/ram_computations/rams/tinyram/tinyram_params.hpp"
+#include "../examples/run_ram_zksnark.hpp"
+#include "../../../../relations/ram_computations/rams/examples/ram_examples.hpp"
 
 using namespace libsnark;
 


### PR DESCRIPTION
This pull request:

- converts the paths in all local includes (i.e. those including files from within libsnark) from absolute to relative (see [pull request 7 in libff](https://github.com/scipr-lab/libff/pull/7) for justification)

- converts all libff/libfqfft includes from local to system-style (e.g. `#include "common/utils.hpp"` → `#include <libff/common/utils.hpp>`) to make it explicit and unambiguous when files from an external library are being included.

This pull request (as well as the accompanying ones in libff and libfqfft) was largely generated using a [Python script](https://gist.github.com/popoffka/9e7be59653e2122628b8c8e569a632ba).

