### PR TITLE
Update libfqfft includes after refactoring get_evaluation_domain()

### DIFF
--- a/libsnark/reductions/r1cs_to_qap/r1cs_to_qap.tcc
+++ b/libsnark/reductions/r1cs_to_qap/r1cs_to_qap.tcc
@@ -16,7 +16,7 @@
 
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
-#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
+#include <libfqfft/evaluation_domain/get_evaluation_domain.hpp>
 
 namespace libsnark {
 

--- a/libsnark/reductions/uscs_to_ssp/uscs_to_ssp.tcc
+++ b/libsnark/reductions/uscs_to_ssp/uscs_to_ssp.tcc
@@ -16,7 +16,7 @@
 
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
-#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
+#include <libfqfft/evaluation_domain/get_evaluation_domain.hpp>
 
 namespace libsnark {
 

--- a/libsnark/relations/arithmetic_programs/qap/qap.hpp
+++ b/libsnark/relations/arithmetic_programs/qap/qap.hpp
@@ -22,6 +22,9 @@
 #ifndef QAP_HPP_
 #define QAP_HPP_
 
+#include <map>
+#include <memory>
+
 #include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 
 namespace libsnark {

--- a/libsnark/relations/arithmetic_programs/ssp/ssp.hpp
+++ b/libsnark/relations/arithmetic_programs/ssp/ssp.hpp
@@ -22,6 +22,9 @@
 #ifndef SSP_HPP_
 #define SSP_HPP_
 
+#include <map>
+#include <memory>
+
 #include <libfqfft/evaluation_domain/evaluation_domain.hpp>
 
 namespace libsnark {


### PR DESCRIPTION
This change updates libsnark to be compatible with the change in [libfqfft pull request 5](https://github.com/scipr-lab/libfqfft/pull/5)