### PR TITLE
Adapt to new libff multiexp interface & use faster methods

### DIFF
--- a/libsnark/common/data_structures/sparse_vector.tcc
+++ b/libsnark/common/data_structures/sparse_vector.tcc
@@ -180,9 +180,11 @@ std::pair<T, sparse_vector<T> > sparse_vector<T>::accumulate(const typename std:
                                                              const typename std::vector<FieldT>::const_iterator &it_end,
                                                              const size_t offset) const
 {
-    // TODO: does not really belong here.
+#ifdef MULTICORE
+    const size_t chunks = omp_get_max_threads(); // to override, set OMP_NUM_THREADS env var or call omp_set_num_threads()
+#else
     const size_t chunks = 1;
-    const bool use_multiexp = true;
+#endif
 
     T accumulated_value = T::zero();
     sparse_vector<T> resulting_vector;
@@ -215,11 +217,12 @@ std::pair<T, sparse_vector<T> > sparse_vector<T>::accumulate(const typename std:
 #ifdef DEBUG
                 libff::print_indent(); printf("doing multiexp for w_%zu ... w_%zu\n", indices[first_pos], indices[last_pos]);
 #endif
-                accumulated_value = accumulated_value + libff::multi_exp<T, FieldT>(values.begin() + first_pos,
-                                                                             values.begin() + last_pos + 1,
-                                                                             it_begin + (indices[first_pos] - offset),
-                                                                             it_begin + (indices[last_pos] - offset) + 1,
-                                                                             chunks, use_multiexp);
+                accumulated_value = accumulated_value + libff::multi_exp<T, FieldT, libff::multi_exp_method_bos_coster>(
+                    values.begin() + first_pos,
+                    values.begin() + last_pos + 1,
+                    it_begin + (indices[first_pos] - offset),
+                    it_begin + (indices[last_pos] - offset) + 1,
+                    chunks);
             }
         }
         else
@@ -250,11 +253,12 @@ std::pair<T, sparse_vector<T> > sparse_vector<T>::accumulate(const typename std:
 #ifdef DEBUG
         libff::print_indent(); printf("doing multiexp for w_%zu ... w_%zu\n", indices[first_pos], indices[last_pos]);
 #endif
-        accumulated_value = accumulated_value + libff::multi_exp<T, FieldT>(values.begin() + first_pos,
-                                                                     values.begin() + last_pos + 1,
-                                                                     it_begin + (indices[first_pos] - offset),
-                                                                     it_begin + (indices[last_pos] - offset) + 1,
-                                                                     chunks, use_multiexp);
+        accumulated_value = accumulated_value + libff::multi_exp<T, FieldT, libff::multi_exp_method_bos_coster>(
+            values.begin() + first_pos,
+            values.begin() + last_pos + 1,
+            it_begin + (indices[first_pos] - offset),
+            it_begin + (indices[last_pos] - offset) + 1,
+            chunks);
     }
 
     return std::make_pair(accumulated_value, resulting_vector);

--- a/libsnark/common/data_structures/sparse_vector.tcc
+++ b/libsnark/common/data_structures/sparse_vector.tcc
@@ -16,6 +16,10 @@
 
 #include <numeric>
 
+#ifdef MULTICORE
+#include <omp.h>
+#endif
+
 #include <libff/algebra/scalar_multiplication/multiexp.hpp>
 
 namespace libsnark {

--- a/libsnark/knowledge_commitment/kc_multiexp.hpp
+++ b/libsnark/knowledge_commitment/kc_multiexp.hpp
@@ -17,6 +17,8 @@
   Will probably go away in more general exp refactoring.
 */
 
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
+
 #include <libsnark/knowledge_commitment/knowledge_commitment.hpp>
 
 namespace libsnark {
@@ -25,14 +27,13 @@ template<typename T1, typename T2, mp_size_t n>
 knowledge_commitment<T1,T2> opt_window_wnaf_exp(const knowledge_commitment<T1,T2> &base,
                                                 const libff::bigint<n> &scalar, const size_t scalar_bits);
 
-template<typename T1, typename T2, typename FieldT>
+template<typename T1, typename T2, typename FieldT, libff::multi_exp_method Method>
 knowledge_commitment<T1, T2> kc_multi_exp_with_mixed_addition(const knowledge_commitment_vector<T1, T2> &vec,
                                                                 const size_t min_idx,
                                                                 const size_t max_idx,
                                                                 typename std::vector<FieldT>::const_iterator scalar_start,
                                                                 typename std::vector<FieldT>::const_iterator scalar_end,
-                                                                const size_t chunks,
-                                                                const bool use_multiexp=false);
+                                                                const size_t chunks);
 
 template<typename T1, typename T2>
 void kc_batch_to_special(std::vector<knowledge_commitment<T1, T2> > &vec);

--- a/libsnark/knowledge_commitment/kc_multiexp.hpp
+++ b/libsnark/knowledge_commitment/kc_multiexp.hpp
@@ -35,9 +35,6 @@ knowledge_commitment<T1, T2> kc_multi_exp_with_mixed_addition(const knowledge_co
                                                                 typename std::vector<FieldT>::const_iterator scalar_end,
                                                                 const size_t chunks);
 
-template<typename T1, typename T2>
-void kc_batch_to_special(std::vector<knowledge_commitment<T1, T2> > &vec);
-
 template<typename T1, typename T2, typename FieldT>
 knowledge_commitment_vector<T1, T2> kc_batch_exp(const size_t scalar_size,
                                                  const size_t T1_window,

--- a/libsnark/knowledge_commitment/kc_multiexp.tcc
+++ b/libsnark/knowledge_commitment/kc_multiexp.tcc
@@ -18,14 +18,13 @@ knowledge_commitment<T1,T2> opt_window_wnaf_exp(const knowledge_commitment<T1,T2
                                        opt_window_wnaf_exp(base.h, scalar, scalar_bits));
 }
 
-template<typename T1, typename T2, typename FieldT>
+template<typename T1, typename T2, typename FieldT, libff::multi_exp_method Method>
 knowledge_commitment<T1, T2> kc_multi_exp_with_mixed_addition(const knowledge_commitment_vector<T1, T2> &vec,
                                                                 const size_t min_idx,
                                                                 const size_t max_idx,
                                                                 typename std::vector<FieldT>::const_iterator scalar_start,
                                                                 typename std::vector<FieldT>::const_iterator scalar_end,
-                                                                const size_t chunks,
-                                                                const bool use_multiexp)
+                                                                const size_t chunks)
 {
     libff::enter_block("Process scalar vector");
     auto index_it = std::lower_bound(vec.indices.begin(), vec.indices.end(), min_idx);
@@ -86,7 +85,7 @@ knowledge_commitment<T1, T2> kc_multi_exp_with_mixed_addition(const knowledge_co
     libff::print_indent(); printf("* Elements of w remaining: %zu (%0.2f%%)\n", num_other, 100.*num_other/(num_skip+num_add+num_other));
     libff::leave_block("Process scalar vector");
 
-    return acc + libff::multi_exp<knowledge_commitment<T1, T2>, FieldT>(g.begin(), g.end(), p.begin(), p.end(), chunks, use_multiexp);
+    return acc + libff::multi_exp<knowledge_commitment<T1, T2>, FieldT, Method>(g.begin(), g.end(), p.begin(), p.end(), chunks);
 }
 
 template<typename T1, typename T2>

--- a/libsnark/knowledge_commitment/knowledge_commitment.hpp
+++ b/libsnark/knowledge_commitment/knowledge_commitment.hpp
@@ -45,6 +45,11 @@ struct knowledge_commitment {
     knowledge_commitment<T1,T2>& operator=(const knowledge_commitment<T1,T2> &other) = default;
     knowledge_commitment<T1,T2>& operator=(knowledge_commitment<T1,T2> &&other) = default;
     knowledge_commitment<T1,T2> operator+(const knowledge_commitment<T1, T2> &other) const;
+    knowledge_commitment<T1,T2> mixed_add(const knowledge_commitment<T1, T2> &other) const;
+    knowledge_commitment<T1,T2> dbl() const;
+
+    void to_special();
+    bool is_special() const;
 
     bool is_zero() const;
     bool operator==(const knowledge_commitment<T1,T2> &other) const;
@@ -56,6 +61,9 @@ struct knowledge_commitment {
     void print() const;
 
     static size_t size_in_bits();
+
+    static void batch_to_special_all_non_zeros(
+        std::vector<knowledge_commitment<T1,T2> > &vec);
 };
 
 template<typename T1, typename T2, mp_size_t m>

--- a/libsnark/relations/arithmetic_programs/qap/qap.tcc
+++ b/libsnark/relations/arithmetic_programs/qap/qap.tcc
@@ -242,14 +242,22 @@ bool qap_instance_evaluation<FieldT>::is_satisfied(const qap_witness<FieldT> &wi
     FieldT ans_C = this->Ct[0] + witness.d3*this->Zt;
     FieldT ans_H = FieldT::zero();
 
-    ans_A = ans_A + libff::naive_plain_exp<FieldT, FieldT>(this->At.begin()+1, this->At.begin()+1+this->num_variables(),
-                                                    witness.coefficients_for_ABCs.begin(), witness.coefficients_for_ABCs.begin()+this->num_variables());
-    ans_B = ans_B + libff::naive_plain_exp<FieldT, FieldT>(this->Bt.begin()+1, this->Bt.begin()+1+this->num_variables(),
-                                                    witness.coefficients_for_ABCs.begin(), witness.coefficients_for_ABCs.begin()+this->num_variables());
-    ans_C = ans_C + libff::naive_plain_exp<FieldT, FieldT>(this->Ct.begin()+1, this->Ct.begin()+1+this->num_variables(),
-                                                    witness.coefficients_for_ABCs.begin(), witness.coefficients_for_ABCs.begin()+this->num_variables());
-    ans_H = ans_H + libff::naive_plain_exp<FieldT, FieldT>(this->Ht.begin(), this->Ht.begin()+this->degree()+1,
-                                                    witness.coefficients_for_H.begin(), witness.coefficients_for_H.begin()+this->degree()+1);
+    ans_A = ans_A + libff::inner_product<FieldT>(this->At.begin()+1,
+                                                 this->At.begin()+1+this->num_variables(),
+                                                 witness.coefficients_for_ABCs.begin(),
+                                                 witness.coefficients_for_ABCs.begin()+this->num_variables());
+    ans_B = ans_B + libff::inner_product<FieldT>(this->Bt.begin()+1,
+                                                 this->Bt.begin()+1+this->num_variables(),
+                                                 witness.coefficients_for_ABCs.begin(),
+                                                 witness.coefficients_for_ABCs.begin()+this->num_variables());
+    ans_C = ans_C + libff::inner_product<FieldT>(this->Ct.begin()+1,
+                                                 this->Ct.begin()+1+this->num_variables(),
+                                                 witness.coefficients_for_ABCs.begin(),
+                                                 witness.coefficients_for_ABCs.begin()+this->num_variables());
+    ans_H = ans_H + libff::inner_product<FieldT>(this->Ht.begin(),
+                                                 this->Ht.begin()+this->degree()+1,
+                                                 witness.coefficients_for_H.begin(),
+                                                 witness.coefficients_for_H.begin()+this->degree()+1);
 
     if (ans_A * ans_B - ans_C != ans_H * this->Zt)
     {

--- a/libsnark/relations/arithmetic_programs/ssp/ssp.tcc
+++ b/libsnark/relations/arithmetic_programs/ssp/ssp.tcc
@@ -209,10 +209,14 @@ bool ssp_instance_evaluation<FieldT>::is_satisfied(const ssp_witness<FieldT> &wi
     FieldT ans_V = this->Vt[0] + witness.d*this->Zt;
     FieldT ans_H = FieldT::zero();
 
-    ans_V = ans_V + libff::naive_plain_exp<FieldT, FieldT>(this->Vt.begin()+1, this->Vt.begin()+1+this->num_variables(),
-                                                    witness.coefficients_for_Vs.begin(), witness.coefficients_for_Vs.begin()+this->num_variables());
-    ans_H = ans_H + libff::naive_plain_exp<FieldT, FieldT>(this->Ht.begin(), this->Ht.begin()+this->degree()+1,
-                                                    witness.coefficients_for_H.begin(), witness.coefficients_for_H.begin()+this->degree()+1);
+    ans_V = ans_V + libff::inner_product<FieldT>(this->Vt.begin()+1,
+                                                 this->Vt.begin()+1+this->num_variables(),
+                                                 witness.coefficients_for_Vs.begin(),
+                                                 witness.coefficients_for_Vs.begin()+this->num_variables());
+    ans_H = ans_H + libff::inner_product<FieldT>(this->Ht.begin(),
+                                                 this->Ht.begin()+this->degree()+1,
+                                                 witness.coefficients_for_H.begin(),
+                                                 witness.coefficients_for_H.begin()+this->degree()+1);
 
     if (ans_V.squared() - FieldT::one() != ans_H * this->Zt)
     {

--- a/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
+++ b/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
@@ -572,6 +572,9 @@ r1cs_ppzkadsnark_keypair<ppT> r1cs_ppzkadsnark_generator(const r1cs_ppzkadsnark_
 
     libff::enter_block("Compute the H-query", false);
     libff::G1_vector<snark_pp<ppT>> H_query = batch_exp(libff::Fr<snark_pp<ppT>>::size_in_bits(), g1_window, g1_table, Ht);
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<snark_pp<ppT>> >(H_query);
+#endif
     libff::leave_block("Compute the H-query", false);
 
     libff::enter_block("Compute the K-query", false);
@@ -751,7 +754,7 @@ r1cs_ppzkadsnark_proof<ppT> r1cs_ppzkadsnark_prover(const r1cs_ppzkadsnark_provi
     libff::enter_block("Compute answer to H-query", false);
     g_H = g_H + libff::multi_exp<libff::G1<snark_pp<ppT>>,
                                  libff::Fr<snark_pp<ppT>>,
-                                 libff::multi_exp_method_bos_coster>(
+                                 libff::multi_exp_method_djb>(
         pk.H_query.begin(),
         pk.H_query.begin()+qap_wit.degree()+1,
         qap_wit.coefficients_for_H.begin(),

--- a/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
+++ b/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
@@ -754,7 +754,7 @@ r1cs_ppzkadsnark_proof<ppT> r1cs_ppzkadsnark_prover(const r1cs_ppzkadsnark_provi
     libff::enter_block("Compute answer to H-query", false);
     g_H = g_H + libff::multi_exp<libff::G1<snark_pp<ppT>>,
                                  libff::Fr<snark_pp<ppT>>,
-                                 libff::multi_exp_method_djb>(
+                                 libff::multi_exp_method_BDLO12>(
         pk.H_query.begin(),
         pk.H_query.begin()+qap_wit.degree()+1,
         qap_wit.coefficients_for_H.begin(),

--- a/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
+++ b/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
@@ -24,6 +24,10 @@ See r1cs_ppzkadsnark.hpp .
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 
+#ifdef MULTICORE
+#include <omp.h>
+#endif
+
 #include <libsnark/knowledge_commitment/kc_multiexp.hpp>
 #include <libsnark/reductions/r1cs_to_qap/r1cs_to_qap.hpp>
 

--- a/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
+++ b/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
@@ -696,52 +696,74 @@ r1cs_ppzkadsnark_proof<ppT> r1cs_ppzkadsnark_prover(const r1cs_ppzkadsnark_provi
     libff::enter_block("Compute the proof");
 
     libff::enter_block("Compute answer to A-query", false);
-    g_A = g_A + kc_multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>, libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(pk.A_query,
-                                                                                                           1+qap_wit.num_inputs(), 1+qap_wit.num_variables(),
-                                                                                                           qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_inputs(),
-                                                                                                           qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                                                           chunks, true);
+    g_A = g_A + kc_multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>,
+                                                 libff::G1<snark_pp<ppT>>,
+                                                 libff::Fr<snark_pp<ppT>>,
+                                                 libff::multi_exp_method_bos_coster>(
+        pk.A_query,
+        1+qap_wit.num_inputs(), 1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_inputs(),
+        qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to A-query", false);
 
     libff::enter_block("Compute answer to Ain-query", false);
-    g_Ain = g_Ain + kc_multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>, libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(pk.A_query,
-                                                                                                               1, 1+qap_wit.num_inputs(),
-                                                                                                               qap_wit.coefficients_for_ABCs.begin(),
-                                                                                                               qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_inputs(),
-                                                                                                               chunks, true);
+    g_Ain = g_Ain + kc_multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>,
+                                                     libff::G1<snark_pp<ppT>>,
+                                                     libff::Fr<snark_pp<ppT>>,
+                                                     libff::multi_exp_method_bos_coster>(
+        pk.A_query,
+        1, 1+qap_wit.num_inputs(),
+        qap_wit.coefficients_for_ABCs.begin(),
+        qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_inputs(),
+        chunks);
     //std :: cout << "The input proof term: " << g_Ain << "\n";
     libff::leave_block("Compute answer to Ain-query", false);
 
     libff::enter_block("Compute answer to B-query", false);
-    g_B = g_B + kc_multi_exp_with_mixed_addition<libff::G2<snark_pp<ppT>>, libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(pk.B_query,
-                                                                                                           1, 1+qap_wit.num_variables(),
-                                                                                                           qap_wit.coefficients_for_ABCs.begin(),
-                                                                                                           qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                                                           chunks, true);
+    g_B = g_B + kc_multi_exp_with_mixed_addition<libff::G2<snark_pp<ppT>>,
+                                                 libff::G1<snark_pp<ppT>>,
+                                                 libff::Fr<snark_pp<ppT>>,
+                                                 libff::multi_exp_method_bos_coster>(
+        pk.B_query,
+        1, 1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin(),
+        qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to B-query", false);
 
     libff::enter_block("Compute answer to C-query", false);
-    g_C = g_C + kc_multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>, libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(pk.C_query,
-                                                                                                           1, 1+qap_wit.num_variables(),
-                                                                                                           qap_wit.coefficients_for_ABCs.begin(),
-                                                                                                           qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                                                           chunks, true);
+    g_C = g_C + kc_multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>,
+                                                 libff::G1<snark_pp<ppT>>,
+                                                 libff::Fr<snark_pp<ppT>>,
+                                                 libff::multi_exp_method_bos_coster>(
+        pk.C_query,
+        1, 1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin(),
+        qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to C-query", false);
 
     libff::enter_block("Compute answer to H-query", false);
-    g_H = g_H + libff::multi_exp<libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(pk.H_query.begin(),
-                                                                 pk.H_query.begin()+qap_wit.degree()+1,
-                                                                 qap_wit.coefficients_for_H.begin(),
-                                                                 qap_wit.coefficients_for_H.begin()+qap_wit.degree()+1,
-                                                                 chunks, true);
+    g_H = g_H + libff::multi_exp<libff::G1<snark_pp<ppT>>,
+                                 libff::Fr<snark_pp<ppT>>,
+                                 libff::multi_exp_method_bos_coster>(
+        pk.H_query.begin(),
+        pk.H_query.begin()+qap_wit.degree()+1,
+        qap_wit.coefficients_for_H.begin(),
+        qap_wit.coefficients_for_H.begin()+qap_wit.degree()+1,
+        chunks);
     libff::leave_block("Compute answer to H-query", false);
 
     libff::enter_block("Compute answer to K-query", false);
-    g_K = g_K + libff::multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(pk.K_query.begin()+1,
-                                                                                     pk.K_query.begin()+1+qap_wit.num_variables(),
-                                                                                     qap_wit.coefficients_for_ABCs.begin(),
-                                                                                     qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                                     chunks, true);
+    g_K = g_K + libff::multi_exp_with_mixed_addition<libff::G1<snark_pp<ppT>>,
+                                                     libff::Fr<snark_pp<ppT>>,
+                                                     libff::multi_exp_method_bos_coster>(
+        pk.K_query.begin()+1,
+        pk.K_query.begin()+1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin(),
+        qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to K-query", false);
 
     libff::enter_block("Compute extra auth terms", false);
@@ -754,9 +776,12 @@ r1cs_ppzkadsnark_proof<ppT> r1cs_ppzkadsnark_prover(const r1cs_ppzkadsnark_provi
         Ains.emplace_back(pk.A_query[i+1].g);
     }
     libff::G1<snark_pp<ppT>> muA = dauth * pk.rA_i_Z_g1;
-    muA = muA + libff::multi_exp<libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(Ains.begin(), Ains.begin()+qap_wit.num_inputs(),
-                                                                 mus.begin(), mus.begin()+qap_wit.num_inputs(),
-                                                                 chunks, true);
+    muA = muA + libff::multi_exp<libff::G1<snark_pp<ppT>>,
+                                 libff::Fr<snark_pp<ppT>>,
+                                 libff::multi_exp_method_bos_coster>(
+        Ains.begin(), Ains.begin()+qap_wit.num_inputs(),
+        mus.begin(), mus.begin()+qap_wit.num_inputs(),
+        chunks);
 
     // To Do: Decide whether to include relevant parts of auth_data in proof
     libff::leave_block("Compute extra auth terms", false);
@@ -844,10 +869,13 @@ bool r1cs_ppzkadsnark_online_verifier(const r1cs_ppzkadsnark_processed_verificat
     }
     libff::leave_block("Compute PRFs");
     libff::G1<snark_pp<ppT>> prodA = sak.i * proof.g_Aau.g;
-    prodA = prodA + libff::multi_exp<libff::G1<snark_pp<ppT>>, libff::Fr<snark_pp<ppT>> >(pvk.Ain.begin(),
-                                                                     pvk.Ain.begin() + labels.size(),
-                                                                     lambdas.begin(),
-                                                                     lambdas.begin() + labels.size(), 1, true);
+    prodA = prodA + libff::multi_exp<libff::G1<snark_pp<ppT>>,
+                                     libff::Fr<snark_pp<ppT>>,
+                                     libff::multi_exp_method_bos_coster>(
+        pvk.Ain.begin(),
+        pvk.Ain.begin() + labels.size(),
+        lambdas.begin(),
+        lambdas.begin() + labels.size(), 1);
 
     bool result_auth = true;
 

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -430,44 +430,49 @@ r1cs_gg_ppzksnark_proof<ppT> r1cs_gg_ppzksnark_prover(const r1cs_gg_ppzksnark_pr
     libff::Fr_vector<ppT> const_padded_assignment(1, libff::Fr<ppT>::one());
     const_padded_assignment.insert(const_padded_assignment.end(), qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.end());
 
-    libff::G1<ppT> evaluation_At = libff::multi_exp_with_mixed_addition<libff::G1<ppT>, libff::Fr<ppT> >(
+    libff::G1<ppT> evaluation_At = libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
+                                                                        libff::Fr<ppT>,
+                                                                        libff::multi_exp_method_bos_coster>(
         pk.A_query.begin(),
         pk.A_query.begin() + qap_wit.num_variables() + 1,
         const_padded_assignment.begin(),
         const_padded_assignment.begin() + qap_wit.num_variables() + 1,
-        chunks,
-        true);
+        chunks);
     libff::leave_block("Compute evaluation to A-query", false);
 
     libff::enter_block("Compute evaluation to B-query", false);
-    knowledge_commitment<libff::G2<ppT>, libff::G1<ppT> > evaluation_Bt = kc_multi_exp_with_mixed_addition<libff::G2<ppT>, libff::G1<ppT>, libff::Fr<ppT> >(
+    knowledge_commitment<libff::G2<ppT>, libff::G1<ppT> > evaluation_Bt = kc_multi_exp_with_mixed_addition<libff::G2<ppT>,
+                                                                                                           libff::G1<ppT>,
+                                                                                                           libff::Fr<ppT>,
+                                                                                                           libff::multi_exp_method_bos_coster>(
         pk.B_query,
         0,
         qap_wit.num_variables() + 1,
         const_padded_assignment.begin(),
         const_padded_assignment.begin() + qap_wit.num_variables() + 1,
-        chunks,
-        true);
+        chunks);
     libff::leave_block("Compute evaluation to B-query", false);
 
     libff::enter_block("Compute evaluation to H-query", false);
-    libff::G1<ppT> evaluation_Ht = libff::multi_exp<libff::G1<ppT>, libff::Fr<ppT> >(
+    libff::G1<ppT> evaluation_Ht = libff::multi_exp<libff::G1<ppT>,
+                                                    libff::Fr<ppT>,
+                                                    libff::multi_exp_method_bos_coster>(
         pk.H_query.begin(),
         pk.H_query.begin() + (qap_wit.degree() - 1),
         qap_wit.coefficients_for_H.begin(),
         qap_wit.coefficients_for_H.begin() + (qap_wit.degree() - 1),
-        chunks,
-        true);
+        chunks);
     libff::leave_block("Compute evaluation to H-query", false);
 
     libff::enter_block("Compute evaluation to L-query", false);
-    libff::G1<ppT> evaluation_Lt = libff::multi_exp_with_mixed_addition<libff::G1<ppT>, libff::Fr<ppT> >(
+    libff::G1<ppT> evaluation_Lt = libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
+                                                                        libff::Fr<ppT>,
+                                                                        libff::multi_exp_method_bos_coster>(
         pk.L_query.begin(),
         pk.L_query.end(),
         const_padded_assignment.begin() + qap_wit.num_inputs() + 1,
         const_padded_assignment.begin() + qap_wit.num_variables() + 1,
-        chunks,
-        true);
+        chunks);
     libff::leave_block("Compute evaluation to L-query", false);
 
     /* A = alpha + sum_i(a_i*A_i(t)) + r*delta */

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -24,6 +24,10 @@ See r1cs_gg_ppzksnark.hpp .
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 
+#ifdef MULTICORE
+#include <omp.h>
+#endif
+
 #include <libsnark/knowledge_commitment/kc_multiexp.hpp>
 #include <libsnark/reductions/r1cs_to_qap/r1cs_to_qap.hpp>
 

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -441,7 +441,7 @@ r1cs_gg_ppzksnark_proof<ppT> r1cs_gg_ppzksnark_prover(const r1cs_gg_ppzksnark_pr
 
     libff::G1<ppT> evaluation_At = libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
                                                                         libff::Fr<ppT>,
-                                                                        libff::multi_exp_method_djb>(
+                                                                        libff::multi_exp_method_BDLO12>(
         pk.A_query.begin(),
         pk.A_query.begin() + qap_wit.num_variables() + 1,
         const_padded_assignment.begin(),
@@ -453,7 +453,7 @@ r1cs_gg_ppzksnark_proof<ppT> r1cs_gg_ppzksnark_prover(const r1cs_gg_ppzksnark_pr
     knowledge_commitment<libff::G2<ppT>, libff::G1<ppT> > evaluation_Bt = kc_multi_exp_with_mixed_addition<libff::G2<ppT>,
                                                                                                            libff::G1<ppT>,
                                                                                                            libff::Fr<ppT>,
-                                                                                                           libff::multi_exp_method_djb>(
+                                                                                                           libff::multi_exp_method_BDLO12>(
         pk.B_query,
         0,
         qap_wit.num_variables() + 1,
@@ -465,7 +465,7 @@ r1cs_gg_ppzksnark_proof<ppT> r1cs_gg_ppzksnark_prover(const r1cs_gg_ppzksnark_pr
     libff::enter_block("Compute evaluation to H-query", false);
     libff::G1<ppT> evaluation_Ht = libff::multi_exp<libff::G1<ppT>,
                                                     libff::Fr<ppT>,
-                                                    libff::multi_exp_method_djb>(
+                                                    libff::multi_exp_method_BDLO12>(
         pk.H_query.begin(),
         pk.H_query.begin() + (qap_wit.degree() - 1),
         qap_wit.coefficients_for_H.begin(),
@@ -476,7 +476,7 @@ r1cs_gg_ppzksnark_proof<ppT> r1cs_gg_ppzksnark_prover(const r1cs_gg_ppzksnark_pr
     libff::enter_block("Compute evaluation to L-query", false);
     libff::G1<ppT> evaluation_Lt = libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
                                                                         libff::Fr<ppT>,
-                                                                        libff::multi_exp_method_djb>(
+                                                                        libff::multi_exp_method_BDLO12>(
         pk.L_query.begin(),
         pk.L_query.end(),
         const_padded_assignment.begin() + qap_wit.num_inputs() + 1,

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -339,7 +339,7 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     libff::enter_block("Compute the L-query", false);
     libff::G1_vector<ppT> L_query = batch_exp(g1_scalar_size, g1_window_size, g1_table, Lt);
 #ifdef USE_MIXED_ADDITION
-    batch_to_special<libff::G1<ppT> >(L_query);
+    libff::batch_to_special<libff::G1<ppT> >(L_query);
 #endif
     libff::leave_block("Compute the L-query", false);
     libff::leave_block("Generate queries");

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -363,6 +363,9 @@ r1cs_ppzksnark_keypair<ppT> r1cs_ppzksnark_generator(const r1cs_ppzksnark_constr
 
     libff::enter_block("Compute the H-query", false);
     libff::G1_vector<ppT> H_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, Ht);
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(H_query);
+#endif
     libff::leave_block("Compute the H-query", false);
 
     libff::enter_block("Compute the K-query", false);
@@ -514,7 +517,7 @@ r1cs_ppzksnark_proof<ppT> r1cs_ppzksnark_prover(const r1cs_ppzksnark_proving_key
     libff::enter_block("Compute answer to H-query", false);
     g_H = g_H + libff::multi_exp<libff::G1<ppT>,
                                  libff::Fr<ppT>,
-                                 libff::multi_exp_method_bos_coster>(
+                                 libff::multi_exp_method_djb>(
         pk.H_query.begin(), pk.H_query.begin()+qap_wit.degree()+1,
         qap_wit.coefficients_for_H.begin(), qap_wit.coefficients_for_H.begin()+qap_wit.degree()+1,
         chunks);

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -475,36 +475,54 @@ r1cs_ppzksnark_proof<ppT> r1cs_ppzksnark_prover(const r1cs_ppzksnark_proving_key
     libff::enter_block("Compute the proof");
 
     libff::enter_block("Compute answer to A-query", false);
-    g_A = g_A + kc_multi_exp_with_mixed_addition<libff::G1<ppT>, libff::G1<ppT>, libff::Fr<ppT> >(pk.A_query,
-                                                                             1, 1+qap_wit.num_variables(),
-                                                                             qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                             chunks, true);
+    g_A = g_A + kc_multi_exp_with_mixed_addition<libff::G1<ppT>,
+                                                 libff::G1<ppT>,
+                                                 libff::Fr<ppT>,
+                                                 libff::multi_exp_method_bos_coster>(
+        pk.A_query,
+        1, 1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to A-query", false);
 
     libff::enter_block("Compute answer to B-query", false);
-    g_B = g_B + kc_multi_exp_with_mixed_addition<libff::G2<ppT>, libff::G1<ppT>, libff::Fr<ppT> >(pk.B_query,
-                                                                             1, 1+qap_wit.num_variables(),
-                                                                             qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                             chunks, true);
+    g_B = g_B + kc_multi_exp_with_mixed_addition<libff::G2<ppT>,
+                                                 libff::G1<ppT>,
+                                                 libff::Fr<ppT>,
+                                                 libff::multi_exp_method_bos_coster>(
+        pk.B_query,
+        1, 1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to B-query", false);
 
     libff::enter_block("Compute answer to C-query", false);
-    g_C = g_C + kc_multi_exp_with_mixed_addition<libff::G1<ppT>, libff::G1<ppT>, libff::Fr<ppT> >(pk.C_query,
-                                                                             1, 1+qap_wit.num_variables(),
-                                                                             qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                             chunks, true);
+    g_C = g_C + kc_multi_exp_with_mixed_addition<libff::G1<ppT>,
+                                                 libff::G1<ppT>,
+                                                 libff::Fr<ppT>,
+                                                 libff::multi_exp_method_bos_coster>(
+        pk.C_query,
+        1, 1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to C-query", false);
 
     libff::enter_block("Compute answer to H-query", false);
-    g_H = g_H + libff::multi_exp<libff::G1<ppT>, libff::Fr<ppT> >(pk.H_query.begin(), pk.H_query.begin()+qap_wit.degree()+1,
-                                             qap_wit.coefficients_for_H.begin(), qap_wit.coefficients_for_H.begin()+qap_wit.degree()+1,
-                                             chunks, true);
+    g_H = g_H + libff::multi_exp<libff::G1<ppT>,
+                                 libff::Fr<ppT>,
+                                 libff::multi_exp_method_bos_coster>(
+        pk.H_query.begin(), pk.H_query.begin()+qap_wit.degree()+1,
+        qap_wit.coefficients_for_H.begin(), qap_wit.coefficients_for_H.begin()+qap_wit.degree()+1,
+        chunks);
     libff::leave_block("Compute answer to H-query", false);
 
     libff::enter_block("Compute answer to K-query", false);
-    g_K = g_K + libff::multi_exp_with_mixed_addition<libff::G1<ppT>, libff::Fr<ppT> >(pk.K_query.begin()+1, pk.K_query.begin()+1+qap_wit.num_variables(),
-                                                                 qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
-                                                                 chunks, true);
+    g_K = g_K + libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
+                                                     libff::Fr<ppT>,
+                                                     libff::multi_exp_method_bos_coster>(
+        pk.K_query.begin()+1, pk.K_query.begin()+1+qap_wit.num_variables(),
+        qap_wit.coefficients_for_ABCs.begin(), qap_wit.coefficients_for_ABCs.begin()+qap_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute answer to K-query", false);
 
     libff::leave_block("Compute the proof");

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -517,7 +517,7 @@ r1cs_ppzksnark_proof<ppT> r1cs_ppzksnark_prover(const r1cs_ppzksnark_proving_key
     libff::enter_block("Compute answer to H-query", false);
     g_H = g_H + libff::multi_exp<libff::G1<ppT>,
                                  libff::Fr<ppT>,
-                                 libff::multi_exp_method_djb>(
+                                 libff::multi_exp_method_BDLO12>(
         pk.H_query.begin(), pk.H_query.begin()+qap_wit.degree()+1,
         qap_wit.coefficients_for_H.begin(), qap_wit.coefficients_for_H.begin()+qap_wit.degree()+1,
         chunks);

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -24,6 +24,10 @@ See r1cs_ppzksnark.hpp .
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 
+#ifdef MULTICORE
+#include <omp.h>
+#endif
+
 #include <libsnark/knowledge_commitment/kc_multiexp.hpp>
 #include <libsnark/reductions/r1cs_to_qap/r1cs_to_qap.hpp>
 

--- a/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
@@ -267,18 +267,30 @@ uscs_ppzksnark_keypair<ppT> uscs_ppzksnark_generator(const uscs_ppzksnark_constr
 
     libff::enter_block("Compute the query for V_g1", false);
     libff::G1_vector<ppT> V_g1_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, Vt_table_minus_Xt_table);
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(V_g1_query);
+#endif
     libff::leave_block("Compute the query for V_g1", false);
 
     libff::enter_block("Compute the query for alpha_V_g1", false);
     libff::G1_vector<ppT> alpha_V_g1_query = batch_exp_with_coeff(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, alpha, Vt_table_minus_Xt_table);
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(alpha_V_g1_query);
+#endif
     libff::leave_block("Compute the query for alpha_V_g1", false);
 
     libff::enter_block("Compute the query for H_g1", false);
     libff::G1_vector<ppT> H_g1_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, Ht_table);
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(H_g1_query);
+#endif
     libff::leave_block("Compute the query for H_g1", false);
 
     libff::enter_block("Compute the query for V_g2", false);
     libff::G2_vector<ppT> V_g2_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g2_window, g2_table, Vt_table);
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G2<ppT> >(V_g2_query);
+#endif
     libff::leave_block("Compute the query for V_g2", false);
 
     libff::leave_block("Generate proof components");
@@ -365,7 +377,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute V_g1, the 1st component of the proof", false);
     V_g1 = V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
                                                        libff::Fr<ppT>,
-                                                       libff::multi_exp_method_bos_coster>(
+                                                       libff::multi_exp_method_djb>(
         pk.V_g1_query.begin(), pk.V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
         ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
         chunks);
@@ -374,7 +386,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute alpha_V_g1, the 2nd component of the proof", false);
     alpha_V_g1 = alpha_V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
                                                                    libff::Fr<ppT>,
-                                                                   libff::multi_exp_method_bos_coster>(
+                                                                   libff::multi_exp_method_djb>(
         pk.alpha_V_g1_query.begin(), pk.alpha_V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
         ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
         chunks);
@@ -383,7 +395,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute H_g1, the 3rd component of the proof", false);
     H_g1 = H_g1 + libff::multi_exp<libff::G1<ppT>,
                                    libff::Fr<ppT>,
-                                   libff::multi_exp_method_bos_coster>(
+                                   libff::multi_exp_method_djb>(
         pk.H_g1_query.begin(), pk.H_g1_query.begin()+ssp_wit.degree()+1,
         ssp_wit.coefficients_for_H.begin(), ssp_wit.coefficients_for_H.begin()+ssp_wit.degree()+1,
         chunks);
@@ -392,7 +404,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute V_g2, the 4th component of the proof", false);
     V_g2 = V_g2 + libff::multi_exp<libff::G2<ppT>,
                                    libff::Fr<ppT>,
-                                   libff::multi_exp_method_bos_coster>(
+                                   libff::multi_exp_method_djb>(
         pk.V_g2_query.begin()+1, pk.V_g2_query.begin()+ssp_wit.num_variables()+1,
         ssp_wit.coefficients_for_Vs.begin(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
         chunks);

--- a/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
@@ -359,31 +359,39 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute the proof");
 
     libff::enter_block("Compute V_g1, the 1st component of the proof", false);
-    V_g1 = V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>, libff::Fr<ppT> >(pk.V_g1_query.begin(), pk.V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
-                                                                   ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
-                                                                   chunks,
-                                                                   true);
+    V_g1 = V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
+                                                       libff::Fr<ppT>,
+                                                       libff::multi_exp_method_bos_coster>(
+        pk.V_g1_query.begin(), pk.V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
+        ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute V_g1, the 1st component of the proof", false);
 
     libff::enter_block("Compute alpha_V_g1, the 2nd component of the proof", false);
-    alpha_V_g1 = alpha_V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>, libff::Fr<ppT> >(pk.alpha_V_g1_query.begin(), pk.alpha_V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
-                                                                               ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
-                                                                               chunks,
-                                                                               true);
+    alpha_V_g1 = alpha_V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
+                                                                   libff::Fr<ppT>,
+                                                                   libff::multi_exp_method_bos_coster>(
+        pk.alpha_V_g1_query.begin(), pk.alpha_V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
+        ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute alpha_V_g1, the 2nd component of the proof", false);
 
     libff::enter_block("Compute H_g1, the 3rd component of the proof", false);
-    H_g1 = H_g1 + libff::multi_exp<libff::G1<ppT>, libff::Fr<ppT> >(pk.H_g1_query.begin(), pk.H_g1_query.begin()+ssp_wit.degree()+1,
-                                               ssp_wit.coefficients_for_H.begin(), ssp_wit.coefficients_for_H.begin()+ssp_wit.degree()+1,
-                                               chunks,
-                                               true);
+    H_g1 = H_g1 + libff::multi_exp<libff::G1<ppT>,
+                                   libff::Fr<ppT>,
+                                   libff::multi_exp_method_bos_coster>(
+        pk.H_g1_query.begin(), pk.H_g1_query.begin()+ssp_wit.degree()+1,
+        ssp_wit.coefficients_for_H.begin(), ssp_wit.coefficients_for_H.begin()+ssp_wit.degree()+1,
+        chunks);
     libff::leave_block("Compute H_g1, the 3rd component of the proof", false);
 
     libff::enter_block("Compute V_g2, the 4th component of the proof", false);
-    V_g2 = V_g2 + libff::multi_exp<libff::G2<ppT>, libff::Fr<ppT> >(pk.V_g2_query.begin()+1, pk.V_g2_query.begin()+ssp_wit.num_variables()+1,
-                                               ssp_wit.coefficients_for_Vs.begin(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
-                                               chunks,
-                                               true);
+    V_g2 = V_g2 + libff::multi_exp<libff::G2<ppT>,
+                                   libff::Fr<ppT>,
+                                   libff::multi_exp_method_bos_coster>(
+        pk.V_g2_query.begin()+1, pk.V_g2_query.begin()+ssp_wit.num_variables()+1,
+        ssp_wit.coefficients_for_Vs.begin(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
+        chunks);
     libff::leave_block("Compute V_g2, the 4th component of the proof", false);
 
     libff::leave_block("Compute the proof");

--- a/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
@@ -22,6 +22,10 @@
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 
+#ifdef MULTICORE
+#include <omp.h>
+#endif
+
 #include <libsnark/reductions/uscs_to_ssp/uscs_to_ssp.hpp>
 #include <libsnark/relations/arithmetic_programs/ssp/ssp.hpp>
 

--- a/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
@@ -377,7 +377,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute V_g1, the 1st component of the proof", false);
     V_g1 = V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
                                                        libff::Fr<ppT>,
-                                                       libff::multi_exp_method_djb>(
+                                                       libff::multi_exp_method_BDLO12>(
         pk.V_g1_query.begin(), pk.V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
         ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
         chunks);
@@ -386,7 +386,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute alpha_V_g1, the 2nd component of the proof", false);
     alpha_V_g1 = alpha_V_g1 + libff::multi_exp_with_mixed_addition<libff::G1<ppT>,
                                                                    libff::Fr<ppT>,
-                                                                   libff::multi_exp_method_djb>(
+                                                                   libff::multi_exp_method_BDLO12>(
         pk.alpha_V_g1_query.begin(), pk.alpha_V_g1_query.begin()+(ssp_wit.num_variables()-ssp_wit.num_inputs()),
         ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_inputs(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
         chunks);
@@ -395,7 +395,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute H_g1, the 3rd component of the proof", false);
     H_g1 = H_g1 + libff::multi_exp<libff::G1<ppT>,
                                    libff::Fr<ppT>,
-                                   libff::multi_exp_method_djb>(
+                                   libff::multi_exp_method_BDLO12>(
         pk.H_g1_query.begin(), pk.H_g1_query.begin()+ssp_wit.degree()+1,
         ssp_wit.coefficients_for_H.begin(), ssp_wit.coefficients_for_H.begin()+ssp_wit.degree()+1,
         chunks);
@@ -404,7 +404,7 @@ uscs_ppzksnark_proof<ppT> uscs_ppzksnark_prover(const uscs_ppzksnark_proving_key
     libff::enter_block("Compute V_g2, the 4th component of the proof", false);
     V_g2 = V_g2 + libff::multi_exp<libff::G2<ppT>,
                                    libff::Fr<ppT>,
-                                   libff::multi_exp_method_djb>(
+                                   libff::multi_exp_method_BDLO12>(
         pk.V_g2_query.begin()+1, pk.V_g2_query.begin()+ssp_wit.num_variables()+1,
         ssp_wit.coefficients_for_Vs.begin(), ssp_wit.coefficients_for_Vs.begin()+ssp_wit.num_variables(),
         chunks);


### PR DESCRIPTION
[pull request 10 in libff](https://github.com/scipr-lab/libff/pull/10) introduces a new interface for multiexponentiation and a faster multiexponentiation algorithm, djb.

This pull request first just adapts the libsnark code to use this new interface, fixing a couple include-related bugs in the process, and then, in commit 613763680eb67f2d01344368c75048eaa7d5d8e3, switches the multiexponentiation method to the djb in the cases where we've found it to be beneficial.

Specifically, we have observed the following improvements:

- the prover in `./libsnark/profile_ram_ppzksnark 32 16 100 10 300` (a sample TinyRAM ppzkSNARK, which is reduced to a R1CS with 999788 constraints and 745726 variables) runs 25% faster

- the prover in `./libsnark/profile_uscs_ppzksnark 1000000 20` (1000000 constraints, 20 variables) runs 53% faster

- the prover in `./libsnark/profile_r1cs_gg_ppzksnark 1000000 700000` (1000000 constraints, 700000 variables) runs 33% faster

(all with `MULTICORE=off`, `USE_MIXED_ADDITION=on`, on my personal machine with a `Intel(R) Core(TM) i3-6100U CPU @ 2.30GHz` CPU)