### PR TITLE
Implement Simulation-Extractable ppzkSNARKs per [GM17]

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,13 @@ The libsnark library currently provides a C++ implementation of:
     4. A preprocessing SNARK for a language of Boolean circuits, "TBCS"
        (_Two-input Boolean Circuit Satisfiability_). Internally, it reduces to USCS.
        This is much more  efficient than going through R1CS.
-    5. ADSNARK, a preprocessing SNARKs for proving statements on authenticated
+    5. A simulation-extractable preprocessing SNARK for R1CS.
+       This construction uses the approach described in \[GM17]. For arithmetic
+       circuits, it is slower than the \[BCTV14a] approach, but produces shorter
+       proofs.
+    6. ADSNARK, a preprocessing SNARKs for proving statements on authenticated
        data, as described in \[BBFR15].
-    6. Proof-Carrying Data (PCD). This uses recursive composition of SNARKs, as
+    7. Proof-Carrying Data (PCD). This uses recursive composition of SNARKs, as
        explained in \[BCCT13] and optimized in \[BCTV14b].
 2.  Gadget libraries (gadgetlib1 and gadgetlib2) for constructing R1CS
     instances out of modular "gadget" classes.
@@ -585,6 +589,13 @@ References
 ](https://eprint.iacr.org/2014/718),
   George Danezis, Cedric Fournet, Jens Groth, Markulf Kohlweiss,
   ASIACCS 2014
+
+\[GM17] [
+  Snarky Signatures: Minimal Signatures of Knowledge from Simulation-Extractable
+  SNARKs
+](https://eprint.iacr.org/2017/540),
+  Jens Groth and Mary Maller,
+  IACR-CRYPTO-2017
 
 \[GGPR13] [
   _Quadratic span programs and succinct NIZKs without PCPs_

--- a/libsnark/CMakeLists.txt
+++ b/libsnark/CMakeLists.txt
@@ -194,6 +194,18 @@ target_link_libraries(
 )
 
 add_executable(
+  profile_r1cs_ppzksnark
+  EXCLUDE_FROM_ALL
+
+  zk_proof_systems/ppzksnark/r1cs_ppzksnark/profiling/profile_r1cs_ppzksnark.cpp
+)
+target_link_libraries(
+  profile_r1cs_ppzksnark
+
+  snark
+)
+
+add_executable(
   profile_r1cs_mp_ppzkpcd
   EXCLUDE_FROM_ALL
 

--- a/libsnark/CMakeLists.txt
+++ b/libsnark/CMakeLists.txt
@@ -206,6 +206,18 @@ target_link_libraries(
 )
 
 add_executable(
+  profile_r1cs_se_ppzksnark
+  EXCLUDE_FROM_ALL
+
+  zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/profiling/profile_r1cs_se_ppzksnark.cpp
+)
+target_link_libraries(
+  profile_r1cs_se_ppzksnark
+
+  snark
+)
+
+add_executable(
   profile_r1cs_mp_ppzkpcd
   EXCLUDE_FROM_ALL
 
@@ -512,6 +524,18 @@ target_link_libraries(
 )
 
 add_executable(
+  zk_proof_systems_r1cs_se_ppzksnark_test
+  EXCLUDE_FROM_ALL
+
+  zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/tests/test_r1cs_se_ppzksnark.cpp
+)
+target_link_libraries(
+  zk_proof_systems_r1cs_se_ppzksnark_test
+
+  snark
+)
+
+add_executable(
   zk_proof_systems_r1cs_gg_ppzksnark_test
   EXCLUDE_FROM_ALL
 
@@ -681,6 +705,10 @@ add_test(
   COMMAND zk_proof_systems_r1cs_ppzksnark_test
 )
 add_test(
+  NAME zk_proof_systems_r1cs_se_ppzksnark_test
+  COMMAND zk_proof_systems_r1cs_se_ppzksnark_test
+)
+add_test(
   NAME zk_proof_systems_r1cs_gg_ppzksnark_test
   COMMAND zk_proof_systems_r1cs_gg_ppzksnark_test
 )
@@ -737,6 +765,7 @@ add_dependencies(check relations_sap_test)
 add_dependencies(check relations_ssp_test)
 add_dependencies(check zk_proof_systems_bacs_ppzksnark_test)
 add_dependencies(check zk_proof_systems_r1cs_ppzksnark_test)
+add_dependencies(check zk_proof_systems_r1cs_se_ppzksnark_test)
 add_dependencies(check zk_proof_systems_r1cs_gg_ppzksnark_test)
 add_dependencies(check zk_proof_systems_r1cs_sp_ppzkpcd_test)
 add_dependencies(check zk_proof_systems_ram_ppzksnark_test)

--- a/libsnark/CMakeLists.txt
+++ b/libsnark/CMakeLists.txt
@@ -440,6 +440,18 @@ target_link_libraries(
 )
 
 add_executable(
+  relations_sap_test
+  EXCLUDE_FROM_ALL
+
+  relations/arithmetic_programs/sap/tests/test_sap.cpp
+)
+target_link_libraries(
+  relations_sap_test
+
+  snark
+)
+
+add_executable(
   relations_ssp_test
   EXCLUDE_FROM_ALL
 
@@ -641,6 +653,10 @@ add_test(
   COMMAND relations_qap_test
 )
 add_test(
+  NAME relations_sap_test
+  COMMAND relations_sap_test
+)
+add_test(
   NAME relations_ssp_test
   COMMAND relations_ssp_test
 )
@@ -705,6 +721,7 @@ add_dependencies(check gadgetlib2_integration_test)
 add_dependencies(check gadgetlib2_protoboard_test)
 add_dependencies(check gadgetlib2_variable_test)
 add_dependencies(check relations_qap_test)
+add_dependencies(check relations_sap_test)
 add_dependencies(check relations_ssp_test)
 add_dependencies(check zk_proof_systems_bacs_ppzksnark_test)
 add_dependencies(check zk_proof_systems_r1cs_ppzksnark_test)

--- a/libsnark/common/default_types/r1cs_se_ppzksnark_pp.hpp
+++ b/libsnark/common/default_types/r1cs_se_ppzksnark_pp.hpp
@@ -1,0 +1,22 @@
+/** @file
+ *****************************************************************************
+
+ This file defines default_r1cs_se_ppzksnark_pp based on the elliptic curve
+ choice selected in ec_pp.hpp.
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef R1CS_SE_PPZKSNARK_PP_HPP_
+#define R1CS_SE_PPZKSNARK_PP_HPP_
+
+#include <libff/common/default_types/ec_pp.hpp>
+
+namespace libsnark {
+typedef libff::default_ec_pp default_r1cs_se_ppzksnark_pp;
+} // libsnark
+
+#endif // R1CS_SE_PPZKSNARK_PP_HPP_

--- a/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.hpp
+++ b/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.hpp
@@ -1,0 +1,70 @@
+/** @file
+ *****************************************************************************
+
+ Declaration of interfaces for a R1CS-to-SAP reduction, that is, constructing
+ a SAP ("Square Arithmetic Program") from a R1CS ("Rank-1 Constraint System").
+
+ SAPs are defined and constructed from R1CS in \[GM17].
+
+ The implementation of the reduction follows, extends, and optimizes
+ the efficient approach described in Appendix E of \[BCGTV13].
+
+ References:
+
+ \[BCGTV13]
+ "SNARKs for C: Verifying Program Executions Succinctly and in Zero Knowledge",
+ Eli Ben-Sasson, Alessandro Chiesa, Daniel Genkin, Eran Tromer, Madars Virza,
+ CRYPTO 2013,
+ <http://eprint.iacr.org/2013/507>
+
+ \[GM17]:
+ "Snarky Signatures: Minimal Signatures of Knowledge from
+  Simulation-Extractable SNARKs",
+ Jens Groth and Mary Maller,
+ IACR-CRYPTO-2017,
+ <https://eprint.iacr.org/2017/540>
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef R1CS_TO_SAP_HPP_
+#define R1CS_TO_SAP_HPP_
+
+#include <libsnark/relations/arithmetic_programs/sap/sap.hpp>
+#include <libsnark/relations/constraint_satisfaction_problems/r1cs/r1cs.hpp>
+
+namespace libsnark {
+
+/**
+ * Instance map for the R1CS-to-QAP reduction.
+ */
+template<typename FieldT>
+sap_instance<FieldT> r1cs_to_sap_instance_map(const r1cs_constraint_system<FieldT> &cs);
+
+/**
+ * Instance map for the R1CS-to-QAP reduction followed by evaluation of the resulting QAP instance.
+ */
+template<typename FieldT>
+sap_instance_evaluation<FieldT> r1cs_to_sap_instance_map_with_evaluation(const r1cs_constraint_system<FieldT> &cs,
+                                                                         const FieldT &t);
+
+/**
+ * Witness map for the R1CS-to-QAP reduction.
+ *
+ * The witness map takes zero knowledge into account when d1,d2 are random.
+ */
+template<typename FieldT>
+sap_witness<FieldT> r1cs_to_sap_witness_map(const r1cs_constraint_system<FieldT> &cs,
+                                            const r1cs_primary_input<FieldT> &primary_input,
+                                            const r1cs_auxiliary_input<FieldT> &auxiliary_input,
+                                            const FieldT &d1,
+                                            const FieldT &d2);
+
+} // libsnark
+
+#include <libsnark/reductions/r1cs_to_sap/r1cs_to_sap.tcc>
+
+#endif // R1CS_TO_SAP_HPP_

--- a/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.hpp
+++ b/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.hpp
@@ -39,6 +39,13 @@
 namespace libsnark {
 
 /**
+ * Helper function to find evaluation domain that will be used by the reduction
+ * for a given R1CS instance.
+ */
+template<typename FieldT>
+std::shared_ptr<libfqfft::evaluation_domain<FieldT> > r1cs_to_sap_get_domain(const r1cs_constraint_system<FieldT> &cs);
+
+/**
  * Instance map for the R1CS-to-QAP reduction.
  */
 template<typename FieldT>

--- a/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.tcc
+++ b/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.tcc
@@ -31,6 +31,24 @@ FieldT times_four(FieldT x)
 }
 
 /**
+ * Helper function to find evaluation domain that will be used by the reduction
+ * for a given R1CS instance.
+ */
+template<typename FieldT>
+std::shared_ptr<libfqfft::evaluation_domain<FieldT> > r1cs_to_sap_get_domain(const r1cs_constraint_system<FieldT> &cs)
+{
+    /*
+     * the SAP instance will have:
+     * - two constraints for every constraint in the original constraint system
+     * - two constraints for every public input, except the 0th, which
+     *   contributes just one extra constraint
+     * see comments in r1cs_to_sap_instance_map for details on where these
+     * constraints come from.
+     */
+    return libfqfft::get_evaluation_domain<FieldT>(2 * cs.num_constraints() + 2 * cs.num_inputs() + 1);
+}
+
+/**
  * Instance map for the R1CS-to-SAP reduction.
  */
 template<typename FieldT>
@@ -39,7 +57,7 @@ sap_instance<FieldT> r1cs_to_sap_instance_map(const r1cs_constraint_system<Field
     libff::enter_block("Call to r1cs_to_sap_instance_map");
 
     const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
-        libfqfft::get_evaluation_domain<FieldT>(2 * cs.num_constraints() + 2 * cs.num_inputs() + 1);
+        r1cs_to_sap_get_domain(cs);
 
     size_t sap_num_variables = cs.num_variables() + cs.num_constraints() + cs.num_inputs();
 
@@ -157,7 +175,7 @@ sap_instance_evaluation<FieldT> r1cs_to_sap_instance_map_with_evaluation(const r
     libff::enter_block("Call to r1cs_to_sap_instance_map_with_evaluation");
 
     const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
-        libfqfft::get_evaluation_domain<FieldT>(2 * cs.num_constraints() + 2 * cs.num_inputs() + 1);
+        r1cs_to_sap_get_domain(cs);
 
     size_t sap_num_variables = cs.num_variables() + cs.num_constraints() + cs.num_inputs();
 
@@ -284,7 +302,7 @@ sap_witness<FieldT> r1cs_to_sap_witness_map(const r1cs_constraint_system<FieldT>
     assert(cs.is_satisfied(primary_input, auxiliary_input));
 
     const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
-        libfqfft::get_evaluation_domain<FieldT>(2 * cs.num_constraints() + 2 * cs.num_inputs() + 1);
+        r1cs_to_sap_get_domain(cs);
 
     size_t sap_num_variables = cs.num_variables() + cs.num_constraints() + cs.num_inputs();
 

--- a/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.tcc
+++ b/libsnark/reductions/r1cs_to_sap/r1cs_to_sap.tcc
@@ -1,0 +1,464 @@
+/** @file
+ *****************************************************************************
+
+ Implementation of interfaces for a R1CS-to-SAP reduction.
+
+ See r1cs_to_qap.hpp .
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef R1CS_TO_SAP_TCC_
+#define R1CS_TO_SAP_TCC_
+
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libfqfft/evaluation_domain/get_evaluation_domain.hpp>
+
+namespace libsnark {
+
+/**
+ * Helper function to multiply a field element by 4 efficiently
+ */
+template<typename FieldT>
+FieldT times_four(FieldT x)
+{
+    FieldT times_two = x + x;
+    return times_two + times_two;
+}
+
+/**
+ * Instance map for the R1CS-to-SAP reduction.
+ */
+template<typename FieldT>
+sap_instance<FieldT> r1cs_to_sap_instance_map(const r1cs_constraint_system<FieldT> &cs)
+{
+    libff::enter_block("Call to r1cs_to_sap_instance_map");
+
+    const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
+        libfqfft::get_evaluation_domain<FieldT>(2 * cs.num_constraints() + 2 * cs.num_inputs() + 1);
+
+    size_t sap_num_variables = cs.num_variables() + cs.num_constraints() + cs.num_inputs();
+
+    std::vector<std::map<size_t, FieldT> > A_in_Lagrange_basis(sap_num_variables + 1);
+    std::vector<std::map<size_t, FieldT> > C_in_Lagrange_basis(sap_num_variables + 1);
+
+    libff::enter_block("Compute polynomials A, C in Lagrange basis");
+    /**
+     * process R1CS constraints, converting a constraint of the form
+     *   \sum a_i x_i * \sum b_i x_i = \sum c_i x_i
+     * into two constraints
+     *   (\sum (a_i + b_i) x_i)^2 = 4 \sum c_i x_i + x'_i
+     *   (\sum (a_i - b_i) x_i)^2 = x'_i
+     * where x'_i is an extra variable (a separate one for each original
+     * constraint)
+     *
+     * this adds 2 * cs.num_constraints() constraints
+     *   (numbered 0 .. 2 * cs.num_constraints() - 1)
+     * and cs.num_constraints() extra variables
+     *   (numbered cs.num_variables() + 1 .. cs.num_variables() + cs.num_constraints())
+     */
+    size_t extra_var_offset = cs.num_variables() + 1;
+    for (size_t i = 0; i < cs.num_constraints(); ++i)
+    {
+        for (size_t j = 0; j < cs.constraints[i].a.terms.size(); ++j)
+        {
+            A_in_Lagrange_basis[cs.constraints[i].a.terms[j].index][2 * i] +=
+                cs.constraints[i].a.terms[j].coeff;
+            A_in_Lagrange_basis[cs.constraints[i].a.terms[j].index][2 * i + 1] +=
+                cs.constraints[i].a.terms[j].coeff;
+        }
+
+        for (size_t j = 0; j < cs.constraints[i].b.terms.size(); ++j)
+        {
+            A_in_Lagrange_basis[cs.constraints[i].b.terms[j].index][2 * i] +=
+                cs.constraints[i].b.terms[j].coeff;
+            A_in_Lagrange_basis[cs.constraints[i].b.terms[j].index][2 * i + 1] -=
+                cs.constraints[i].b.terms[j].coeff;
+        }
+
+        for (size_t j = 0; j < cs.constraints[i].c.terms.size(); ++j)
+        {
+            C_in_Lagrange_basis[cs.constraints[i].c.terms[j].index][2 * i] +=
+                  times_four(cs.constraints[i].c.terms[j].coeff);
+        }
+
+        C_in_Lagrange_basis[extra_var_offset + i][2 * i] += FieldT::one();
+        C_in_Lagrange_basis[extra_var_offset + i][2 * i + 1] += FieldT::one();
+    }
+
+    /**
+     * add and convert the extra constraints
+     *     x_i * 1 = x_i
+     * to ensure that the polynomials 0 .. cs.num_inputs() are linearly
+     * independent from each other and the rest, which is required for security
+     * proofs (see [GM17, p. 29])
+     *
+     * note that i = 0 is a special case, where this constraint is expressible
+     * as x_0^2 = x_0,
+     * whereas for every other i we introduce an extra variable x''_i and do
+     *   (x_i + x_0)^2 = 4 x_i + x''_i
+     *   (x_i - x_0)^2 = x''_i
+     *
+     * this adds 2 * cs.num_inputs() + 1 extra constraints
+     *   (numbered 2 * cs.num_constraints() ..
+     *             2 * cs.num_constraints() + 2 * cs.num_inputs())
+     * and cs.num_inputs() extra variables
+     *   (numbered cs.num_variables() + cs.num_constraints() + 1 ..
+     *             cs.num_variables() + cs.num_constraints() + cs.num_inputs())
+     */
+
+    size_t extra_constr_offset = 2 * cs.num_constraints();
+    size_t extra_var_offset2 = cs.num_variables() + cs.num_constraints();
+    /**
+     * NB: extra variables start at (extra_var_offset2 + 1), because i starts at
+     *     1 below
+     */
+
+    A_in_Lagrange_basis[0][extra_constr_offset] = FieldT::one();
+    C_in_Lagrange_basis[0][extra_constr_offset] = FieldT::one();
+
+    for (size_t i = 1; i <= cs.num_inputs(); ++i)
+    {
+        A_in_Lagrange_basis[i][extra_constr_offset + 2 * i - 1] += FieldT::one();
+        A_in_Lagrange_basis[0][extra_constr_offset + 2 * i - 1] += FieldT::one();
+        C_in_Lagrange_basis[i][extra_constr_offset + 2 * i - 1] +=
+            times_four(FieldT::one());
+        C_in_Lagrange_basis[extra_var_offset2 + i][extra_constr_offset + 2 * i - 1] += FieldT::one();
+
+        A_in_Lagrange_basis[i][extra_constr_offset + 2 * i] += FieldT::one();
+        A_in_Lagrange_basis[0][extra_constr_offset + 2 * i] -= FieldT::one();
+        C_in_Lagrange_basis[extra_var_offset2 + i][2 * cs.num_constraints() + 2 * i] += FieldT::one();
+    }
+
+    libff::leave_block("Compute polynomials A, C in Lagrange basis");
+
+    libff::leave_block("Call to r1cs_to_sap_instance_map");
+
+    return sap_instance<FieldT>(domain,
+                                sap_num_variables,
+                                domain->m,
+                                cs.num_inputs(),
+                                std::move(A_in_Lagrange_basis),
+                                std::move(C_in_Lagrange_basis));
+}
+
+/**
+ * Instance map for the R1CS-to-SAP reduction followed by evaluation
+ * of the resulting QAP instance.
+ */
+template<typename FieldT>
+sap_instance_evaluation<FieldT> r1cs_to_sap_instance_map_with_evaluation(const r1cs_constraint_system<FieldT> &cs,
+                                                                         const FieldT &t)
+{
+    libff::enter_block("Call to r1cs_to_sap_instance_map_with_evaluation");
+
+    const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
+        libfqfft::get_evaluation_domain<FieldT>(2 * cs.num_constraints() + 2 * cs.num_inputs() + 1);
+
+    size_t sap_num_variables = cs.num_variables() + cs.num_constraints() + cs.num_inputs();
+
+    std::vector<FieldT> At, Ct, Ht;
+
+    At.resize(sap_num_variables + 1, FieldT::zero());
+    Ct.resize(sap_num_variables + 1, FieldT::zero());
+    Ht.reserve(domain->m+1);
+
+    const FieldT Zt = domain->compute_vanishing_polynomial(t);
+
+    libff::enter_block("Compute evaluations of A, C, H at t");
+    const std::vector<FieldT> u = domain->evaluate_all_lagrange_polynomials(t);
+    /**
+     * add and process all constraints as in r1cs_to_sap_instance_map
+     */
+    size_t extra_var_offset = cs.num_variables() + 1;
+    for (size_t i = 0; i < cs.num_constraints(); ++i)
+    {
+        for (size_t j = 0; j < cs.constraints[i].a.terms.size(); ++j)
+        {
+            At[cs.constraints[i].a.terms[j].index] +=
+                u[2 * i] * cs.constraints[i].a.terms[j].coeff;
+            At[cs.constraints[i].a.terms[j].index] +=
+                u[2 * i + 1] * cs.constraints[i].a.terms[j].coeff;
+        }
+
+        for (size_t j = 0; j < cs.constraints[i].b.terms.size(); ++j)
+        {
+            At[cs.constraints[i].b.terms[j].index] +=
+                u[2 * i] * cs.constraints[i].b.terms[j].coeff;
+            At[cs.constraints[i].b.terms[j].index] -=
+                u[2 * i + 1] * cs.constraints[i].b.terms[j].coeff;
+        }
+
+        for (size_t j = 0; j < cs.constraints[i].c.terms.size(); ++j)
+        {
+            Ct[cs.constraints[i].c.terms[j].index] +=
+                times_four(u[2 * i] * cs.constraints[i].c.terms[j].coeff);
+        }
+
+        Ct[extra_var_offset + i] += u[2 * i];
+        Ct[extra_var_offset + i] += u[2 * i + 1];
+    }
+
+    size_t extra_constr_offset = 2 * cs.num_constraints();
+    size_t extra_var_offset2 = cs.num_variables() + cs.num_constraints();
+
+    At[0] += u[extra_constr_offset];
+    Ct[0] += u[extra_constr_offset];
+
+    for (size_t i = 1; i <= cs.num_inputs(); ++i)
+    {
+        At[i] += u[extra_constr_offset + 2 * i - 1];
+        At[0] += u[extra_constr_offset + 2 * i - 1];
+        Ct[i] += times_four(u[extra_constr_offset + 2 * i - 1]);
+        Ct[extra_var_offset2 + i] += u[extra_constr_offset + 2 * i - 1];
+
+        At[i] += u[extra_constr_offset + 2 * i];
+        At[0] -= u[extra_constr_offset + 2 * i];
+        Ct[extra_var_offset2 + i] += u[extra_constr_offset + 2 * i];
+    }
+
+    FieldT ti = FieldT::one();
+    for (size_t i = 0; i < domain->m+1; ++i)
+    {
+        Ht.emplace_back(ti);
+        ti *= t;
+    }
+    libff::leave_block("Compute evaluations of A, C, H at t");
+
+    libff::leave_block("Call to r1cs_to_sap_instance_map_with_evaluation");
+
+    return sap_instance_evaluation<FieldT>(domain,
+                                           sap_num_variables,
+                                           domain->m,
+                                           cs.num_inputs(),
+                                           t,
+                                           std::move(At),
+                                           std::move(Ct),
+                                           std::move(Ht),
+                                           Zt);
+}
+
+/**
+ * Witness map for the R1CS-to-SAP reduction.
+ *
+ * The witness map takes zero knowledge into account when d1, d2 are random.
+ *
+ * More precisely, compute the coefficients
+ *     h_0,h_1,...,h_n
+ * of the polynomial
+ *     H(z) := (A(z)*A(z)-C(z))/Z(z)
+ * where
+ *   A(z) := A_0(z) + \sum_{k=1}^{m} w_k A_k(z) + d1 * Z(z)
+ *   C(z) := C_0(z) + \sum_{k=1}^{m} w_k C_k(z) + d2 * Z(z)
+ *   Z(z) := "vanishing polynomial of set S"
+ * and
+ *   m = number of variables of the SAP
+ *   n = degree of the SAP
+ *
+ * This is done as follows:
+ *  (1) compute evaluations of A,C on S = {sigma_1,...,sigma_n}
+ *  (2) compute coefficients of A,C
+ *  (3) compute evaluations of A,C on T = "coset of S"
+ *  (4) compute evaluation of H on T
+ *  (5) compute coefficients of H
+ *  (6) patch H to account for d1,d2
+        (i.e., add coefficients of the polynomial (2*d1*A - d2 + d1^2 * Z))
+ *
+ * The code below is not as simple as the above high-level description due to
+ * some reshuffling to save space.
+ */
+template<typename FieldT>
+sap_witness<FieldT> r1cs_to_sap_witness_map(const r1cs_constraint_system<FieldT> &cs,
+                                            const r1cs_primary_input<FieldT> &primary_input,
+                                            const r1cs_auxiliary_input<FieldT> &auxiliary_input,
+                                            const FieldT &d1,
+                                            const FieldT &d2)
+{
+    libff::enter_block("Call to r1cs_to_sap_witness_map");
+
+    /* sanity check */
+    assert(cs.is_satisfied(primary_input, auxiliary_input));
+
+    const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
+        libfqfft::get_evaluation_domain<FieldT>(2 * cs.num_constraints() + 2 * cs.num_inputs() + 1);
+
+    size_t sap_num_variables = cs.num_variables() + cs.num_constraints() + cs.num_inputs();
+
+    r1cs_variable_assignment<FieldT> full_variable_assignment = primary_input;
+    full_variable_assignment.insert(full_variable_assignment.end(), auxiliary_input.begin(), auxiliary_input.end());
+    /**
+     * we need to generate values of all the extra variables that we added
+     * during the reduction
+     *
+     * note: below, we pass full_variable_assignment into the .evaluate()
+     * method of the R1CS constraints. however, these extra variables shouldn't
+     * be a problem, because .evaluate() only accessess the variables that are
+     * actually used in the constraint.
+     */
+    for (size_t i = 0; i < cs.num_constraints(); ++i)
+    {
+        /**
+         * this is variable (extra_var_offset + i), an extra variable
+         * we introduced that is not present in the input.
+         * its value is (a - b)^2
+         */
+        FieldT extra_var = cs.constraints[i].a.evaluate(full_variable_assignment) -
+            cs.constraints[i].b.evaluate(full_variable_assignment);
+        extra_var = extra_var * extra_var;
+        full_variable_assignment.push_back(extra_var);
+    }
+    for (size_t i = 1; i <= cs.num_inputs(); ++i)
+    {
+        /**
+         * this is variable (extra_var_offset2 + i), an extra variable
+         * we introduced that is not present in the input.
+         * its value is (x_i - 1)^2
+         */
+        FieldT extra_var = full_variable_assignment[i - 1] - FieldT::one();
+        extra_var = extra_var * extra_var;
+        full_variable_assignment.push_back(extra_var);
+    }
+
+    libff::enter_block("Compute evaluation of polynomial A on set S");
+    std::vector<FieldT> aA(domain->m, FieldT::zero());
+
+    /* account for all constraints, as in r1cs_to_sap_instance_map */
+    for (size_t i = 0; i < cs.num_constraints(); ++i)
+    {
+        aA[2 * i] += cs.constraints[i].a.evaluate(full_variable_assignment);
+        aA[2 * i] += cs.constraints[i].b.evaluate(full_variable_assignment);
+
+        aA[2 * i + 1] += cs.constraints[i].a.evaluate(full_variable_assignment);
+        aA[2 * i + 1] -= cs.constraints[i].b.evaluate(full_variable_assignment);
+    }
+
+    size_t extra_constr_offset = 2 * cs.num_constraints();
+
+    aA[extra_constr_offset] += FieldT::one();
+
+    for (size_t i = 1; i <= cs.num_inputs(); ++i)
+    {
+        aA[extra_constr_offset + 2 * i - 1] += full_variable_assignment[i - 1];
+        aA[extra_constr_offset + 2 * i - 1] += FieldT::one();
+
+        aA[extra_constr_offset + 2 * i] += full_variable_assignment[i - 1];
+        aA[extra_constr_offset + 2 * i] -= FieldT::one();
+    }
+
+    libff::leave_block("Compute evaluation of polynomial A on set S");
+
+    libff::enter_block("Compute coefficients of polynomial A");
+    domain->iFFT(aA);
+    libff::leave_block("Compute coefficients of polynomial A");
+
+    libff::enter_block("Compute ZK-patch");
+    std::vector<FieldT> coefficients_for_H(domain->m+1, FieldT::zero());
+#ifdef MULTICORE
+#pragma omp parallel for
+#endif
+    /* add coefficients of the polynomial (2*d1*A - d2) + d1*d1*Z */
+    for (size_t i = 0; i < domain->m; ++i)
+    {
+        coefficients_for_H[i] = (d1 * aA[i]) + (d1 * aA[i]);
+    }
+    coefficients_for_H[0] -= d2;
+    domain->add_poly_Z(d1 * d1, coefficients_for_H);
+    libff::leave_block("Compute ZK-patch");
+
+    libff::enter_block("Compute evaluation of polynomial A on set T");
+    domain->cosetFFT(aA, FieldT::multiplicative_generator);
+    libff::leave_block("Compute evaluation of polynomial A on set T");
+
+    libff::enter_block("Compute evaluation of polynomial H on set T");
+    std::vector<FieldT> &H_tmp = aA; // can overwrite aA because it is not used later
+#ifdef MULTICORE
+#pragma omp parallel for
+#endif
+    for (size_t i = 0; i < domain->m; ++i)
+    {
+        H_tmp[i] = aA[i]*aA[i];
+    }
+
+    libff::enter_block("Compute evaluation of polynomial C on set S");
+    std::vector<FieldT> aC(domain->m, FieldT::zero());
+    /* again, accounting for all constraints */
+    size_t extra_var_offset = cs.num_variables() + 1;
+    for (size_t i = 0; i < cs.num_constraints(); ++i)
+    {
+        aC[2 * i] +=
+            times_four(cs.constraints[i].c.evaluate(full_variable_assignment));
+
+        aC[2 * i] += full_variable_assignment[extra_var_offset + i - 1];
+        aC[2 * i + 1] += full_variable_assignment[extra_var_offset + i - 1];
+    }
+
+    size_t extra_var_offset2 = cs.num_variables() + cs.num_constraints();
+    aC[extra_constr_offset] += FieldT::one();
+
+    for (size_t i = 1; i <= cs.num_inputs(); ++i)
+    {
+        aC[extra_constr_offset + 2 * i - 1] +=
+            times_four(full_variable_assignment[i - 1]);
+
+        aC[extra_constr_offset + 2 * i - 1] +=
+            full_variable_assignment[extra_var_offset2 + i - 1];
+        aC[extra_constr_offset + 2 * i] +=
+            full_variable_assignment[extra_var_offset2 + i - 1];
+    }
+
+    libff::leave_block("Compute evaluation of polynomial C on set S");
+
+    libff::enter_block("Compute coefficients of polynomial C");
+    domain->iFFT(aC);
+    libff::leave_block("Compute coefficients of polynomial C");
+
+    libff::enter_block("Compute evaluation of polynomial C on set T");
+    domain->cosetFFT(aC, FieldT::multiplicative_generator);
+    libff::leave_block("Compute evaluation of polynomial C on set T");
+
+#ifdef MULTICORE
+#pragma omp parallel for
+#endif
+    for (size_t i = 0; i < domain->m; ++i)
+    {
+        H_tmp[i] = (H_tmp[i]-aC[i]);
+    }
+
+    libff::enter_block("Divide by Z on set T");
+    domain->divide_by_Z_on_coset(H_tmp);
+    libff::leave_block("Divide by Z on set T");
+
+    libff::leave_block("Compute evaluation of polynomial H on set T");
+
+    libff::enter_block("Compute coefficients of polynomial H");
+    domain->icosetFFT(H_tmp, FieldT::multiplicative_generator);
+    libff::leave_block("Compute coefficients of polynomial H");
+
+    libff::enter_block("Compute sum of H and ZK-patch");
+#ifdef MULTICORE
+#pragma omp parallel for
+#endif
+    for (size_t i = 0; i < domain->m; ++i)
+    {
+        coefficients_for_H[i] += H_tmp[i];
+    }
+    libff::leave_block("Compute sum of H and ZK-patch");
+
+    libff::leave_block("Call to r1cs_to_sap_witness_map");
+
+    return sap_witness<FieldT>(sap_num_variables,
+                               domain->m,
+                               cs.num_inputs(),
+                               d1,
+                               d2,
+                               full_variable_assignment,
+                               std::move(coefficients_for_H));
+}
+
+} // libsnark
+
+#endif // R1CS_TO_SAP_TCC_

--- a/libsnark/relations/arithmetic_programs/sap/sap.hpp
+++ b/libsnark/relations/arithmetic_programs/sap/sap.hpp
@@ -1,0 +1,190 @@
+/** @file
+ *****************************************************************************
+
+ Declaration of interfaces for a SAP ("Square Arithmetic Program").
+
+ SAPs are defined in \[GM17].
+
+ References:
+
+ \[GM17]:
+ "Snarky Signatures: Minimal Signatures of Knowledge from
+  Simulation-Extractable SNARKs",
+ Jens Groth and Mary Maller,
+ IACR-CRYPTO-2017,
+ <https://eprint.iacr.org/2017/540>
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef SAP_HPP_
+#define SAP_HPP_
+
+#include <map>
+#include <memory>
+
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
+
+namespace libsnark {
+
+/* forward declaration */
+template<typename FieldT>
+class sap_witness;
+
+/**
+ * A SAP instance.
+ *
+ * Specifically, the datastructure stores:
+ * - a choice of domain (corresponding to a certain subset of the field);
+ * - the number of variables, the degree, and the number of inputs; and
+ * - coefficients of the A,C polynomials in the Lagrange basis.
+ *
+ * There is no need to store the Z polynomial because it is uniquely
+ * determined by the domain (as Z is its vanishing polynomial).
+ */
+template<typename FieldT>
+class sap_instance {
+private:
+    size_t num_variables_;
+    size_t degree_;
+    size_t num_inputs_;
+
+public:
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain;
+
+    std::vector<std::map<size_t, FieldT> > A_in_Lagrange_basis;
+    std::vector<std::map<size_t, FieldT> > C_in_Lagrange_basis;
+
+    sap_instance(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                 const size_t num_variables,
+                 const size_t degree,
+                 const size_t num_inputs,
+                 const std::vector<std::map<size_t, FieldT> > &A_in_Lagrange_basis,
+                 const std::vector<std::map<size_t, FieldT> > &C_in_Lagrange_basis);
+
+    sap_instance(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                 const size_t num_variables,
+                 const size_t degree,
+                 const size_t num_inputs,
+                 std::vector<std::map<size_t, FieldT> > &&A_in_Lagrange_basis,
+                 std::vector<std::map<size_t, FieldT> > &&C_in_Lagrange_basis);
+
+    sap_instance(const sap_instance<FieldT> &other) = default;
+    sap_instance(sap_instance<FieldT> &&other) = default;
+    sap_instance& operator=(const sap_instance<FieldT> &other) = default;
+    sap_instance& operator=(sap_instance<FieldT> &&other) = default;
+
+    size_t num_variables() const;
+    size_t degree() const;
+    size_t num_inputs() const;
+
+    bool is_satisfied(const sap_witness<FieldT> &witness) const;
+};
+
+/**
+ * A SAP instance evaluation is a SAP instance that is evaluated at a field element t.
+ *
+ * Specifically, the datastructure stores:
+ * - a choice of domain (corresponding to a certain subset of the field);
+ * - the number of variables, the degree, and the number of inputs;
+ * - a field element t;
+ * - evaluations of the A,C (and Z) polynomials at t;
+ * - evaluations of all monomials of t;
+ * - counts about how many of the above evaluations are in fact non-zero.
+ */
+template<typename FieldT>
+class sap_instance_evaluation {
+private:
+    size_t num_variables_;
+    size_t degree_;
+    size_t num_inputs_;
+public:
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain;
+
+    FieldT t;
+
+    std::vector<FieldT> At, Ct, Ht;
+
+    FieldT Zt;
+
+    sap_instance_evaluation(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                            const size_t num_variables,
+                            const size_t degree,
+                            const size_t num_inputs,
+                            const FieldT &t,
+                            const std::vector<FieldT> &At,
+                            const std::vector<FieldT> &Ct,
+                            const std::vector<FieldT> &Ht,
+                            const FieldT &Zt);
+    sap_instance_evaluation(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                            const size_t num_variables,
+                            const size_t degree,
+                            const size_t num_inputs,
+                            const FieldT &t,
+                            std::vector<FieldT> &&At,
+                            std::vector<FieldT> &&Ct,
+                            std::vector<FieldT> &&Ht,
+                            const FieldT &Zt);
+
+    sap_instance_evaluation(const sap_instance_evaluation<FieldT> &other) = default;
+    sap_instance_evaluation(sap_instance_evaluation<FieldT> &&other) = default;
+    sap_instance_evaluation& operator=(const sap_instance_evaluation<FieldT> &other) = default;
+    sap_instance_evaluation& operator=(sap_instance_evaluation<FieldT> &&other) = default;
+
+    size_t num_variables() const;
+    size_t degree() const;
+    size_t num_inputs() const;
+
+    bool is_satisfied(const sap_witness<FieldT> &witness) const;
+};
+
+/**
+ * A SAP witness.
+ */
+template<typename FieldT>
+class sap_witness {
+private:
+    size_t num_variables_;
+    size_t degree_;
+    size_t num_inputs_;
+
+public:
+    FieldT d1, d2;
+
+    std::vector<FieldT> coefficients_for_ACs;
+    std::vector<FieldT> coefficients_for_H;
+
+    sap_witness(const size_t num_variables,
+                const size_t degree,
+                const size_t num_inputs,
+                const FieldT &d1,
+                const FieldT &d2,
+                const std::vector<FieldT> &coefficients_for_ACs,
+                const std::vector<FieldT> &coefficients_for_H);
+
+    sap_witness(const size_t num_variables,
+                const size_t degree,
+                const size_t num_inputs,
+                const FieldT &d1,
+                const FieldT &d2,
+                const std::vector<FieldT> &coefficients_for_ACs,
+                std::vector<FieldT> &&coefficients_for_H);
+
+    sap_witness(const sap_witness<FieldT> &other) = default;
+    sap_witness(sap_witness<FieldT> &&other) = default;
+    sap_witness& operator=(const sap_witness<FieldT> &other) = default;
+    sap_witness& operator=(sap_witness<FieldT> &&other) = default;
+
+    size_t num_variables() const;
+    size_t degree() const;
+    size_t num_inputs() const;
+};
+
+} // libsnark
+
+#include <libsnark/relations/arithmetic_programs/sap/sap.tcc>
+
+#endif // SAP_HPP_

--- a/libsnark/relations/arithmetic_programs/sap/sap.tcc
+++ b/libsnark/relations/arithmetic_programs/sap/sap.tcc
@@ -1,0 +1,307 @@
+/** @file
+*****************************************************************************
+
+Implementation of interfaces for a SAP ("Square Arithmetic Program").
+
+See sap.hpp .
+
+*****************************************************************************
+* @author     This file is part of libsnark, developed by SCIPR Lab
+*             and contributors (see AUTHORS).
+* @copyright  MIT license (see LICENSE file)
+*****************************************************************************/
+
+#ifndef SAP_TCC_
+#define SAP_TCC_
+
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libfqfft/evaluation_domain/evaluation_domain.hpp>
+
+namespace libsnark {
+
+template<typename FieldT>
+sap_instance<FieldT>::sap_instance(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                                   const size_t num_variables,
+                                   const size_t degree,
+                                   const size_t num_inputs,
+                                   const std::vector<std::map<size_t, FieldT> > &A_in_Lagrange_basis,
+                                   const std::vector<std::map<size_t, FieldT> > &C_in_Lagrange_basis) :
+    num_variables_(num_variables),
+    degree_(degree),
+    num_inputs_(num_inputs),
+    domain(domain),
+    A_in_Lagrange_basis(A_in_Lagrange_basis),
+    C_in_Lagrange_basis(C_in_Lagrange_basis)
+{
+}
+
+template<typename FieldT>
+sap_instance<FieldT>::sap_instance(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                                   const size_t num_variables,
+                                   const size_t degree,
+                                   const size_t num_inputs,
+                                   std::vector<std::map<size_t, FieldT> > &&A_in_Lagrange_basis,
+                                   std::vector<std::map<size_t, FieldT> > &&C_in_Lagrange_basis) :
+    num_variables_(num_variables),
+    degree_(degree),
+    num_inputs_(num_inputs),
+    domain(domain),
+    A_in_Lagrange_basis(std::move(A_in_Lagrange_basis)),
+    C_in_Lagrange_basis(std::move(C_in_Lagrange_basis))
+{
+}
+
+template<typename FieldT>
+size_t sap_instance<FieldT>::num_variables() const
+{
+    return num_variables_;
+}
+
+template<typename FieldT>
+size_t sap_instance<FieldT>::degree() const
+{
+    return degree_;
+}
+
+template<typename FieldT>
+size_t sap_instance<FieldT>::num_inputs() const
+{
+    return num_inputs_;
+}
+
+template<typename FieldT>
+bool sap_instance<FieldT>::is_satisfied(const sap_witness<FieldT> &witness) const
+{
+    const FieldT t = FieldT::random_element();
+
+    std::vector<FieldT> At(this->num_variables()+1, FieldT::zero());
+    std::vector<FieldT> Ct(this->num_variables()+1, FieldT::zero());
+    std::vector<FieldT> Ht(this->degree()+1);
+
+    const FieldT Zt = this->domain->compute_vanishing_polynomial(t);
+
+    const std::vector<FieldT> u = this->domain->evaluate_all_lagrange_polynomials(t);
+
+    for (size_t i = 0; i < this->num_variables()+1; ++i)
+    {
+        for (auto &el : A_in_Lagrange_basis[i])
+        {
+            At[i] += u[el.first] * el.second;
+        }
+
+        for (auto &el : C_in_Lagrange_basis[i])
+        {
+            Ct[i] += u[el.first] * el.second;
+        }
+    }
+
+    FieldT ti = FieldT::one();
+    for (size_t i = 0; i < this->degree()+1; ++i)
+    {
+        Ht[i] = ti;
+        ti *= t;
+    }
+
+    const sap_instance_evaluation<FieldT> eval_sap_inst(this->domain,
+                                                        this->num_variables(),
+                                                        this->degree(),
+                                                        this->num_inputs(),
+                                                        t,
+                                                        std::move(At),
+                                                        std::move(Ct),
+                                                        std::move(Ht),
+                                                        Zt);
+    return eval_sap_inst.is_satisfied(witness);
+}
+
+template<typename FieldT>
+sap_instance_evaluation<FieldT>::sap_instance_evaluation(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                                                         const size_t num_variables,
+                                                         const size_t degree,
+                                                         const size_t num_inputs,
+                                                         const FieldT &t,
+                                                         const std::vector<FieldT> &At,
+                                                         const std::vector<FieldT> &Ct,
+                                                         const std::vector<FieldT> &Ht,
+                                                         const FieldT &Zt) :
+    num_variables_(num_variables),
+    degree_(degree),
+    num_inputs_(num_inputs),
+    domain(domain),
+    t(t),
+    At(At),
+    Ct(Ct),
+    Ht(Ht),
+    Zt(Zt)
+{
+}
+
+template<typename FieldT>
+sap_instance_evaluation<FieldT>::sap_instance_evaluation(const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > &domain,
+                                                         const size_t num_variables,
+                                                         const size_t degree,
+                                                         const size_t num_inputs,
+                                                         const FieldT &t,
+                                                         std::vector<FieldT> &&At,
+                                                         std::vector<FieldT> &&Ct,
+                                                         std::vector<FieldT> &&Ht,
+                                                         const FieldT &Zt) :
+    num_variables_(num_variables),
+    degree_(degree),
+    num_inputs_(num_inputs),
+    domain(domain),
+    t(t),
+    At(std::move(At)),
+    Ct(std::move(Ct)),
+    Ht(std::move(Ht)),
+    Zt(Zt)
+{
+}
+
+template<typename FieldT>
+size_t sap_instance_evaluation<FieldT>::num_variables() const
+{
+    return num_variables_;
+}
+
+template<typename FieldT>
+size_t sap_instance_evaluation<FieldT>::degree() const
+{
+    return degree_;
+}
+
+template<typename FieldT>
+size_t sap_instance_evaluation<FieldT>::num_inputs() const
+{
+    return num_inputs_;
+}
+
+template<typename FieldT>
+bool sap_instance_evaluation<FieldT>::is_satisfied(const sap_witness<FieldT> &witness) const
+{
+    if (this->num_variables() != witness.num_variables())
+    {
+        return false;
+    }
+
+    if (this->degree() != witness.degree())
+    {
+        return false;
+    }
+
+    if (this->num_inputs() != witness.num_inputs())
+    {
+        return false;
+    }
+
+    if (this->num_variables() != witness.coefficients_for_ACs.size())
+    {
+        return false;
+    }
+
+    if (this->degree()+1 != witness.coefficients_for_H.size())
+    {
+        return false;
+    }
+
+    if (this->At.size() != this->num_variables()+1 || this->Ct.size() != this->num_variables()+1)
+    {
+        return false;
+    }
+
+    if (this->Ht.size() != this->degree()+1)
+    {
+        return false;
+    }
+
+    if (this->Zt != this->domain->compute_vanishing_polynomial(this->t))
+    {
+        return false;
+    }
+
+    FieldT ans_A = this->At[0] + witness.d1*this->Zt;
+    FieldT ans_C = this->Ct[0] + witness.d2*this->Zt;
+    FieldT ans_H = FieldT::zero();
+
+    ans_A = ans_A + libff::inner_product<FieldT>(this->At.begin()+1,
+                                                 this->At.begin()+1+this->num_variables(),
+                                                 witness.coefficients_for_ACs.begin(),
+                                                 witness.coefficients_for_ACs.begin()+this->num_variables());
+    ans_C = ans_C + libff::inner_product<FieldT>(this->Ct.begin()+1,
+                                                 this->Ct.begin()+1+this->num_variables(),
+                                                 witness.coefficients_for_ACs.begin(),
+                                                 witness.coefficients_for_ACs.begin()+this->num_variables());
+    ans_H = ans_H + libff::inner_product<FieldT>(this->Ht.begin(),
+                                                 this->Ht.begin()+this->degree()+1,
+                                                 witness.coefficients_for_H.begin(),
+                                                 witness.coefficients_for_H.begin()+this->degree()+1);
+
+    if (ans_A * ans_A - ans_C != ans_H * this->Zt)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+template<typename FieldT>
+sap_witness<FieldT>::sap_witness(const size_t num_variables,
+                                 const size_t degree,
+                                 const size_t num_inputs,
+                                 const FieldT &d1,
+                                 const FieldT &d2,
+                                 const std::vector<FieldT> &coefficients_for_ACs,
+                                 const std::vector<FieldT> &coefficients_for_H) :
+    num_variables_(num_variables),
+    degree_(degree),
+    num_inputs_(num_inputs),
+    d1(d1),
+    d2(d2),
+    coefficients_for_ACs(coefficients_for_ACs),
+    coefficients_for_H(coefficients_for_H)
+{
+}
+
+template<typename FieldT>
+sap_witness<FieldT>::sap_witness(const size_t num_variables,
+                                 const size_t degree,
+                                 const size_t num_inputs,
+                                 const FieldT &d1,
+                                 const FieldT &d2,
+                                 const std::vector<FieldT> &coefficients_for_ACs,
+                                 std::vector<FieldT> &&coefficients_for_H) :
+    num_variables_(num_variables),
+    degree_(degree),
+    num_inputs_(num_inputs),
+    d1(d1),
+    d2(d2),
+    coefficients_for_ACs(coefficients_for_ACs),
+    coefficients_for_H(std::move(coefficients_for_H))
+{
+}
+
+
+template<typename FieldT>
+size_t sap_witness<FieldT>::num_variables() const
+{
+    return num_variables_;
+}
+
+template<typename FieldT>
+size_t sap_witness<FieldT>::degree() const
+{
+    return degree_;
+}
+
+template<typename FieldT>
+size_t sap_witness<FieldT>::num_inputs() const
+{
+    return num_inputs_;
+}
+
+
+} // libsnark
+
+#endif // SAP_TCC_

--- a/libsnark/relations/arithmetic_programs/sap/tests/test_sap.cpp
+++ b/libsnark/relations/arithmetic_programs/sap/tests/test_sap.cpp
@@ -1,0 +1,119 @@
+/**
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+
+#include <libsnark/reductions/r1cs_to_sap/r1cs_to_sap.hpp>
+#include <libsnark/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp>
+
+using namespace libsnark;
+
+template<typename FieldT>
+void test_sap(const size_t sap_degree, const size_t num_inputs, const bool binary_input)
+{
+    /*
+      We construct an instance where the SAP degree is <= sap_degree.
+      The R1CS-to-SAP reduction produces SAPs with degree
+        (2 * num_constraints + 2 * num_inputs + 1).
+      So we generate an instance of R1CS where the number of constraints is
+        (sap_degree - 1) / 2 - num_inputs.
+    */
+    libff::enter_block("Call to test_sap");
+
+    const size_t num_constraints = (sap_degree - 1) / 2 - num_inputs;
+    assert(num_constraints >= 1);
+
+    libff::print_indent(); printf("* Requested SAP degree: %zu\n", sap_degree);
+    libff::print_indent(); printf("* Actual SAP degree: %zu\n", 2 * num_constraints + 2 * num_inputs + 1);
+    libff::print_indent(); printf("* Number of inputs: %zu\n", num_inputs);
+    libff::print_indent(); printf("* Number of R1CS constraints: %zu\n", num_constraints);
+    libff::print_indent(); printf("* Input type: %s\n", binary_input ? "binary" : "field");
+
+    libff::enter_block("Generate constraint system and assignment");
+    r1cs_example<FieldT> example;
+    if (binary_input)
+    {
+        example = generate_r1cs_example_with_binary_input<FieldT>(num_constraints, num_inputs);
+    }
+    else
+    {
+        example = generate_r1cs_example_with_field_input<FieldT>(num_constraints, num_inputs);
+    }
+    libff::leave_block("Generate constraint system and assignment");
+
+    libff::enter_block("Check satisfiability of constraint system");
+    assert(example.constraint_system.is_satisfied(example.primary_input, example.auxiliary_input));
+    libff::leave_block("Check satisfiability of constraint system");
+
+    const FieldT t = FieldT::random_element(),
+    d1 = FieldT::random_element(),
+    d2 = FieldT::random_element();
+
+    libff::enter_block("Compute SAP instance 1");
+    sap_instance<FieldT> sap_inst_1 = r1cs_to_sap_instance_map(example.constraint_system);
+    libff::leave_block("Compute SAP instance 1");
+
+    libff::enter_block("Compute SAP instance 2");
+    sap_instance_evaluation<FieldT> sap_inst_2 = r1cs_to_sap_instance_map_with_evaluation(example.constraint_system, t);
+    libff::leave_block("Compute SAP instance 2");
+
+    libff::enter_block("Compute SAP witness");
+    sap_witness<FieldT> sap_wit = r1cs_to_sap_witness_map(example.constraint_system, example.primary_input, example.auxiliary_input, d1, d2);
+    libff::leave_block("Compute SAP witness");
+
+    libff::enter_block("Check satisfiability of SAP instance 1");
+    assert(sap_inst_1.is_satisfied(sap_wit));
+    libff::leave_block("Check satisfiability of SAP instance 1");
+
+    libff::enter_block("Check satisfiability of SAP instance 2");
+    assert(sap_inst_2.is_satisfied(sap_wit));
+    libff::leave_block("Check satisfiability of SAP instance 2");
+
+    libff::leave_block("Call to test_sap");
+}
+
+int main()
+{
+    libff::start_profiling();
+
+    libff::mnt6_pp::init_public_params();
+
+    const size_t num_inputs = 10;
+
+    /**
+     * due to the specifics of our reduction, we can only get SAPs with odd
+     * degrees, so we can only test "special" versions of the domains
+     */
+
+    const size_t basic_domain_size_special = (1ul<<libff::mnt6_Fr::s) - 1ul;
+    const size_t step_domain_size_special = (1ul<<10) + (1ul<<8) - 1ul;
+    const size_t extended_domain_size_special = (1ul<<(libff::mnt6_Fr::s+1)) - 1ul;
+
+    libff::enter_block("Test SAP with binary input");
+
+    test_sap<libff::Fr<libff::mnt6_pp> >(basic_domain_size_special, num_inputs, true);
+    test_sap<libff::Fr<libff::mnt6_pp> >(step_domain_size_special, num_inputs, true);
+    test_sap<libff::Fr<libff::mnt6_pp> >(extended_domain_size_special, num_inputs, true);
+
+    libff::leave_block("Test SAP with binary input");
+
+    libff::enter_block("Test SAP with field input");
+
+    test_sap<libff::Fr<libff::mnt6_pp> >(basic_domain_size_special, num_inputs, false);
+    test_sap<libff::Fr<libff::mnt6_pp> >(step_domain_size_special, num_inputs, false);
+    test_sap<libff::Fr<libff::mnt6_pp> >(extended_domain_size_special, num_inputs, false);
+
+    libff::leave_block("Test SAP with field input");
+}

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.hpp
@@ -1,0 +1,37 @@
+/** @file
+ *****************************************************************************
+
+ Declaration of functionality that runs the R1CS SEppzkSNARK for
+ a given R1CS example.
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef RUN_R1CS_SE_PPZKSNARK_HPP_
+#define RUN_R1CS_SE_PPZKSNARK_HPP_
+
+#include <libff/common/default_types/ec_pp.hpp>
+
+#include <libsnark/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp>
+
+namespace libsnark {
+
+/**
+ * Runs the SEppzkSNARK (generator, prover, and verifier) for a given
+ * R1CS example (specified by a constraint system, input, and witness).
+ *
+ * Optionally, also test the serialization routines for keys and proofs.
+ * (This takes additional time.)
+ */
+template<typename ppT>
+bool run_r1cs_se_ppzksnark(const r1cs_example<libff::Fr<ppT> > &example,
+                           const bool test_serialization);
+
+} // libsnark
+
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.tcc>
+
+#endif // RUN_R1CS_SE_PPZKSNARK_HPP_

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.tcc
@@ -1,0 +1,88 @@
+/** @file
+ *****************************************************************************
+
+ Implementation of functionality that runs the R1CS SEppzkSNARK for
+ a given R1CS example.
+
+ See run_r1cs_se_ppzksnark.hpp .
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef RUN_R1CS_SE_PPZKSNARK_TCC_
+#define RUN_R1CS_SE_PPZKSNARK_TCC_
+
+#include <sstream>
+#include <type_traits>
+
+#include <libff/common/profiling.hpp>
+
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp>
+
+namespace libsnark {
+
+/**
+ * The code below provides an example of all stages of running a R1CS SEppzkSNARK.
+ *
+ * Of course, in a real-life scenario, we would have three distinct entities,
+ * mangled into one in the demonstration below. The three entities are as follows.
+ * (1) The "generator", which runs the SEppzkSNARK generator on input a given
+ *     constraint system CS to create a proving and a verification key for CS.
+ * (2) The "prover", which runs the SEppzkSNARK prover on input the proving key,
+ *     a primary input for CS, and an auxiliary input for CS.
+ * (3) The "verifier", which runs the SEppzkSNARK verifier on input the verification key,
+ *     a primary input for CS, and a proof.
+ */
+template<typename ppT>
+bool run_r1cs_se_ppzksnark(const r1cs_example<libff::Fr<ppT> > &example,
+                        const bool test_serialization)
+{
+    libff::enter_block("Call to run_r1cs_se_ppzksnark");
+
+    libff::print_header("R1CS SEppzkSNARK Generator");
+    r1cs_se_ppzksnark_keypair<ppT> keypair = r1cs_se_ppzksnark_generator<ppT>(example.constraint_system);
+    printf("\n"); libff::print_indent(); libff::print_mem("after generator");
+
+    libff::print_header("Preprocess verification key");
+    r1cs_se_ppzksnark_processed_verification_key<ppT> pvk = r1cs_se_ppzksnark_verifier_process_vk<ppT>(keypair.vk);
+
+    if (test_serialization)
+    {
+        libff::enter_block("Test serialization of keys");
+        keypair.pk = libff::reserialize<r1cs_se_ppzksnark_proving_key<ppT> >(keypair.pk);
+        keypair.vk = libff::reserialize<r1cs_se_ppzksnark_verification_key<ppT> >(keypair.vk);
+        pvk = libff::reserialize<r1cs_se_ppzksnark_processed_verification_key<ppT> >(pvk);
+        libff::leave_block("Test serialization of keys");
+    }
+
+    libff::print_header("R1CS SEppzkSNARK Prover");
+    r1cs_se_ppzksnark_proof<ppT> proof = r1cs_se_ppzksnark_prover<ppT>(keypair.pk, example.primary_input, example.auxiliary_input);
+    printf("\n"); libff::print_indent(); libff::print_mem("after prover");
+
+    if (test_serialization)
+    {
+        libff::enter_block("Test serialization of proof");
+        proof = libff::reserialize<r1cs_se_ppzksnark_proof<ppT> >(proof);
+        libff::leave_block("Test serialization of proof");
+    }
+
+    libff::print_header("R1CS SEppzkSNARK Verifier");
+    const bool ans = r1cs_se_ppzksnark_verifier_strong_IC<ppT>(keypair.vk, example.primary_input, proof);
+    printf("\n"); libff::print_indent(); libff::print_mem("after verifier");
+    printf("* The verification result is: %s\n", (ans ? "PASS" : "FAIL"));
+
+    libff::print_header("R1CS SEppzkSNARK Online Verifier");
+    const bool ans2 = r1cs_se_ppzksnark_online_verifier_strong_IC<ppT>(pvk, example.primary_input, proof);
+    assert(ans == ans2);
+
+    libff::leave_block("Call to run_r1cs_se_ppzksnark");
+
+    return ans;
+}
+
+} // libsnark
+
+#endif // RUN_R1CS_SE_PPZKSNARK_TCC_

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/profiling/profile_r1cs_se_ppzksnark.cpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/profiling/profile_r1cs_se_ppzksnark.cpp
@@ -1,0 +1,72 @@
+/** @file
+ *****************************************************************************
+ Profiling program that exercises the SEppzkSNARK (first generator, then prover,
+ then verifier) on a synthetic R1CS instance.
+
+ The command
+
+     $ libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/profiling/profile_r1cs_se_ppzksnark 1000 10 Fr
+
+ exercises the SEppzkSNARK (first generator, then prover, then verifier) on an R1CS instance with 1000 equations and an input consisting of 10 field elements.
+
+ (If you get the error `zmInit ERR:can't protect`, see the discussion [above](#elliptic-curve-choices).)
+
+ The command
+
+     $ libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/profiling/profile_r1cs_se_ppzksnark 1000 10 bytes
+
+ does the same but now the input consists of 10 bytes.
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+#include <cassert>
+#include <cstdio>
+
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+
+#include <libsnark/common/default_types/r1cs_se_ppzksnark_pp.hpp>
+#include <libsnark/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.hpp>
+
+using namespace libsnark;
+
+int main(int argc, const char * argv[])
+{
+    default_r1cs_se_ppzksnark_pp::init_public_params();
+    libff::start_profiling();
+
+    if (argc == 2 && strcmp(argv[1], "-v") == 0)
+    {
+        libff::print_compilation_info();
+        return 0;
+    }
+
+    if (argc != 3 && argc != 4)
+    {
+        printf("usage: %s num_constraints input_size [Fr|bytes]\n", argv[0]);
+        return 1;
+    }
+    const int num_constraints = atoi(argv[1]);
+    int input_size = atoi(argv[2]);
+    if (argc == 4)
+    {
+        assert(strcmp(argv[3], "Fr") == 0 || strcmp(argv[3], "bytes") == 0);
+        if (strcmp(argv[3], "bytes") == 0)
+        {
+            input_size = libff::div_ceil(8 * input_size, libff::Fr<libff::default_ec_pp>::capacity());
+        }
+    }
+
+    libff::enter_block("Generate R1CS example");
+    r1cs_example<libff::Fr<default_r1cs_se_ppzksnark_pp> > example = generate_r1cs_example_with_field_input<libff::Fr<default_r1cs_se_ppzksnark_pp> >(num_constraints, input_size);
+    libff::leave_block("Generate R1CS example");
+
+    libff::print_header("(enter) Profile R1CS SEppzkSNARK");
+    const bool test_serialization = true;
+    run_r1cs_se_ppzksnark<default_r1cs_se_ppzksnark_pp>(example, test_serialization);
+    libff::print_header("(leave) Profile R1CS SEppzkSNARK");
+}

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
@@ -140,7 +140,7 @@ public:
 
     size_t G2_size() const
     {
-        return B_query.size();
+        return B_query.size() + 1;
     }
 
     size_t size_in_bits() const

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp
@@ -1,0 +1,467 @@
+/** @file
+ *****************************************************************************
+
+ Declaration of interfaces for a SEppzkSNARK for R1CS.
+
+ This includes:
+ - class for proving key
+ - class for verification key
+ - class for processed verification key
+ - class for key pair (proving key & verification key)
+ - class for proof
+ - generator algorithm
+ - prover algorithm
+ - verifier algorithm (with strong or weak input consistency)
+ - online verifier algorithm (with strong or weak input consistency)
+
+ The implementation instantiates (a modification of) the protocol of \[GM17],
+ by following extending, and optimizing the approach described in \[BCTV14].
+
+
+ Acronyms:
+
+ - R1CS = "Rank-1 Constraint Systems"
+ - SEppzkSNARK = "Simulation-Extractable PreProcessing Zero-Knowledge Succinct
+     Non-interactive ARgument of Knowledge"
+
+ References:
+
+ \[BCTV14]:
+ "Succinct Non-Interactive Zero Knowledge for a von Neumann Architecture",
+ Eli Ben-Sasson, Alessandro Chiesa, Eran Tromer, Madars Virza,
+ USENIX Security 2014,
+ <http://eprint.iacr.org/2013/879>
+
+ \[GM17]:
+ "Snarky Signatures: Minimal Signatures of Knowledge from
+  Simulation-Extractable SNARKs",
+ Jens Groth and Mary Maller,
+ IACR-CRYPTO-2017,
+ <https://eprint.iacr.org/2017/540>
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef R1CS_SE_PPZKSNARK_HPP_
+#define R1CS_SE_PPZKSNARK_HPP_
+
+#include <memory>
+
+#include <libff/algebra/curves/public_params.hpp>
+
+#include <libsnark/common/data_structures/accumulation_vector.hpp>
+#include <libsnark/knowledge_commitment/knowledge_commitment.hpp>
+#include <libsnark/relations/constraint_satisfaction_problems/r1cs/r1cs.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark_params.hpp>
+
+namespace libsnark {
+
+/******************************** Proving key ********************************/
+
+template<typename ppT>
+class r1cs_se_ppzksnark_proving_key;
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_proving_key<ppT> &pk);
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_proving_key<ppT> &pk);
+
+/**
+ * A proving key for the R1CS SEppzkSNARK.
+ */
+template<typename ppT>
+class r1cs_se_ppzksnark_proving_key {
+public:
+    // G^{gamma * A_i(t)} for 0 <= i <= sap.num_variables()
+    libff::G1_vector<ppT> A_query;
+
+    // H^{gamma * A_i(t)} for 0 <= i <= sap.num_variables()
+    libff::G2_vector<ppT> B_query;
+
+    // G^{gamma^2 * C_i(t) + (alpha + beta) * gamma * A_i(t)}
+    // for sap.num_inputs() + 1 < i <= sap.num_variables()
+    libff::G1_vector<ppT> C_query_1;
+
+    // G^{2 * gamma^2 * Z(t) * A_i(t)} for 0 <= i <= sap.num_variables()
+    libff::G1_vector<ppT> C_query_2;
+
+    // G^{gamma * Z(t)}
+    libff::G1<ppT> G_gamma_Z;
+
+    // H^{gamma * Z(t)}
+    libff::G2<ppT> H_gamma_Z;
+
+    // G^{(alpha + beta) * gamma * Z(t)}
+    libff::G1<ppT> G_ab_gamma_Z;
+
+    // G^{gamma^2 * Z(t)^2}
+    libff::G1<ppT> G_gamma2_Z2;
+
+    // G^{gamma^2 * Z(t) * t^i} for 0 <= i < sap.degree
+    libff::G1_vector<ppT> G_gamma2_Z_t;
+
+    r1cs_se_ppzksnark_constraint_system<ppT> constraint_system;
+
+    r1cs_se_ppzksnark_proving_key() {};
+    r1cs_se_ppzksnark_proving_key<ppT>& operator=(const r1cs_se_ppzksnark_proving_key<ppT> &other) = default;
+    r1cs_se_ppzksnark_proving_key(const r1cs_se_ppzksnark_proving_key<ppT> &other) = default;
+    r1cs_se_ppzksnark_proving_key(r1cs_se_ppzksnark_proving_key<ppT> &&other) = default;
+    r1cs_se_ppzksnark_proving_key(libff::G1_vector<ppT> &&A_query,
+        libff::G2_vector<ppT> &&B_query,
+        libff::G1_vector<ppT> &&C_query_1,
+        libff::G1_vector<ppT> &&C_query_2,
+        libff::G1<ppT> &G_gamma_Z,
+        libff::G2<ppT> &H_gamma_Z,
+        libff::G1<ppT> &G_ab_gamma_Z,
+        libff::G1<ppT> &G_gamma2_Z2,
+        libff::G1_vector<ppT> &&G_gamma2_Z_t,
+        r1cs_se_ppzksnark_constraint_system<ppT> &&constraint_system) :
+        A_query(std::move(A_query)),
+        B_query(std::move(B_query)),
+        C_query_1(std::move(C_query_1)),
+        C_query_2(std::move(C_query_2)),
+        G_gamma_Z(G_gamma_Z),
+        H_gamma_Z(H_gamma_Z),
+        G_ab_gamma_Z(G_ab_gamma_Z),
+        G_gamma2_Z2(G_gamma2_Z2),
+        G_gamma2_Z_t(std::move(G_gamma2_Z_t)),
+        constraint_system(std::move(constraint_system))
+    {};
+
+    size_t G1_size() const
+    {
+        return A_query.size() + C_query_1.size() + C_query_2.size() + 3
+               + G_gamma2_Z_t.size();
+    }
+
+    size_t G2_size() const
+    {
+        return B_query.size();
+    }
+
+    size_t size_in_bits() const
+    {
+        return G1_size() * libff::G1<ppT>::size_in_bits() +
+               G2_size() * libff::G2<ppT>::size_in_bits();
+    }
+
+    void print_size() const
+    {
+        libff::print_indent(); printf("* G1 elements in PK: %zu\n", this->G1_size());
+        libff::print_indent(); printf("* G2 elements in PK: %zu\n", this->G2_size());
+        libff::print_indent(); printf("* PK size in bits: %zu\n", this->size_in_bits());
+    }
+
+    bool operator==(const r1cs_se_ppzksnark_proving_key<ppT> &other) const;
+    friend std::ostream& operator<< <ppT>(std::ostream &out, const r1cs_se_ppzksnark_proving_key<ppT> &pk);
+    friend std::istream& operator>> <ppT>(std::istream &in, r1cs_se_ppzksnark_proving_key<ppT> &pk);
+};
+
+
+/******************************* Verification key ****************************/
+
+template<typename ppT>
+class r1cs_se_ppzksnark_verification_key;
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_verification_key<ppT> &vk);
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_verification_key<ppT> &vk);
+
+/**
+ * A verification key for the R1CS SEppzkSNARK.
+ */
+template<typename ppT>
+class r1cs_se_ppzksnark_verification_key {
+public:
+    // H
+    libff::G2<ppT> H;
+
+    // G^{alpha}
+    libff::G1<ppT> G_alpha;
+
+    // H^{beta}
+    libff::G2<ppT> H_beta;
+
+    // G^{gamma}
+    libff::G1<ppT> G_gamma;
+
+    // H^{gamma}
+    libff::G2<ppT> H_gamma;
+
+    // G^{gamma * A_i(t) + (alpha + beta) * A_i(t)}
+    // for 0 <= i <= sap.num_inputs()
+    libff::G1_vector<ppT> query;
+
+    r1cs_se_ppzksnark_verification_key() = default;
+    r1cs_se_ppzksnark_verification_key(const libff::G2<ppT> &H,
+        const libff::G1<ppT> &G_alpha,
+        const libff::G2<ppT> &H_beta,
+        const libff::G1<ppT> &G_gamma,
+        const libff::G2<ppT> &H_gamma,
+        libff::G1_vector<ppT> &&query) :
+        H(H),
+        G_alpha(G_alpha),
+        H_beta(H_beta),
+        G_gamma(G_gamma),
+        H_gamma(H_gamma),
+        query(std::move(query))
+    {};
+
+    size_t G1_size() const
+    {
+        return 2 + query.size();
+    }
+
+    size_t G2_size() const
+    {
+        return 3;
+    }
+
+    size_t size_in_bits() const
+    {
+        return (G1_size() * libff::G1<ppT>::size_in_bits() +
+                G2_size() * libff::G2<ppT>::size_in_bits());
+    }
+
+    void print_size() const
+    {
+        libff::print_indent(); printf("* G1 elements in VK: %zu\n",
+            this->G1_size());
+        libff::print_indent(); printf("* G2 elements in VK: %zu\n",
+            this->G2_size());
+        libff::print_indent(); printf("* VK size in bits: %zu\n",
+            this->size_in_bits());
+    }
+
+    bool operator==(const r1cs_se_ppzksnark_verification_key<ppT> &other) const;
+    friend std::ostream& operator<< <ppT>(std::ostream &out, const r1cs_se_ppzksnark_verification_key<ppT> &vk);
+    friend std::istream& operator>> <ppT>(std::istream &in, r1cs_se_ppzksnark_verification_key<ppT> &vk);
+
+    static r1cs_se_ppzksnark_verification_key<ppT> dummy_verification_key(const size_t input_size);
+};
+
+/************************ Processed verification key *************************/
+
+template<typename ppT>
+class r1cs_se_ppzksnark_processed_verification_key;
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk);
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk);
+
+/**
+ * A processed verification key for the R1CS SEppzkSNARK.
+ *
+ * Compared to a (non-processed) verification key, a processed verification key
+ * contains a small constant amount of additional pre-computed information that
+ * enables a faster verification time.
+ */
+template<typename ppT>
+class r1cs_se_ppzksnark_processed_verification_key {
+public:
+    libff::G1<ppT> G_alpha;
+    libff::G2<ppT> H_beta;
+    libff::Fqk<ppT> G_alpha_H_beta_ml;
+    libff::G1_precomp<ppT> G_gamma_pc;
+    libff::G2_precomp<ppT> H_gamma_pc;
+    libff::G2_precomp<ppT> H_pc;
+
+    libff::G1_vector<ppT> query;
+
+    bool operator==(const r1cs_se_ppzksnark_processed_verification_key &other) const;
+    friend std::ostream& operator<< <ppT>(std::ostream &out, const r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk);
+    friend std::istream& operator>> <ppT>(std::istream &in, r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk);
+};
+
+/********************************** Key pair *********************************/
+
+/**
+ * A key pair for the R1CS SEppzkSNARK, which consists of a proving key and a verification key.
+ */
+template<typename ppT>
+class r1cs_se_ppzksnark_keypair {
+public:
+    r1cs_se_ppzksnark_proving_key<ppT> pk;
+    r1cs_se_ppzksnark_verification_key<ppT> vk;
+
+    r1cs_se_ppzksnark_keypair() = default;
+    r1cs_se_ppzksnark_keypair(const r1cs_se_ppzksnark_keypair<ppT> &other) = default;
+    r1cs_se_ppzksnark_keypair(r1cs_se_ppzksnark_proving_key<ppT> &&pk,
+                              r1cs_se_ppzksnark_verification_key<ppT> &&vk) :
+        pk(std::move(pk)),
+        vk(std::move(vk))
+    {}
+
+    r1cs_se_ppzksnark_keypair(r1cs_se_ppzksnark_keypair<ppT> &&other) = default;
+};
+
+
+/*********************************** Proof ***********************************/
+
+template<typename ppT>
+class r1cs_se_ppzksnark_proof;
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_proof<ppT> &proof);
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_proof<ppT> &proof);
+
+/**
+ * A proof for the R1CS SEppzkSNARK.
+ *
+ * While the proof has a structure, externally one merely opaquely produces,
+ * seralizes/deserializes, and verifies proofs. We only expose some information
+ * about the structure for statistics purposes.
+ */
+template<typename ppT>
+class r1cs_se_ppzksnark_proof {
+public:
+    libff::G1<ppT> A;
+    libff::G2<ppT> B;
+    libff::G1<ppT> C;
+
+    r1cs_se_ppzksnark_proof()
+    {}
+    r1cs_se_ppzksnark_proof(libff::G1<ppT> &&A,
+        libff::G2<ppT> &&B,
+        libff::G1<ppT> &&C) :
+        A(std::move(A)),
+        B(std::move(B)),
+        C(std::move(C))
+    {};
+
+    size_t G1_size() const
+    {
+        return 2;
+    }
+
+    size_t G2_size() const
+    {
+        return 1;
+    }
+
+    size_t size_in_bits() const
+    {
+        return G1_size() * libff::G1<ppT>::size_in_bits() +
+               G2_size() * libff::G2<ppT>::size_in_bits();
+    }
+
+    void print_size() const
+    {
+        libff::print_indent(); printf("* G1 elements in proof: %zu\n",
+            this->G1_size());
+        libff::print_indent(); printf("* G2 elements in proof: %zu\n",
+            this->G2_size());
+        libff::print_indent(); printf("* Proof size in bits: %zu\n",
+            this->size_in_bits());
+    }
+
+    bool is_well_formed() const
+    {
+        return (A.is_well_formed() && B.is_well_formed() &&
+                C.is_well_formed());
+    }
+
+    bool operator==(const r1cs_se_ppzksnark_proof<ppT> &other) const;
+    friend std::ostream& operator<< <ppT>(std::ostream &out, const r1cs_se_ppzksnark_proof<ppT> &proof);
+    friend std::istream& operator>> <ppT>(std::istream &in, r1cs_se_ppzksnark_proof<ppT> &proof);
+};
+
+
+/***************************** Main algorithms *******************************/
+
+/**
+ * A generator algorithm for the R1CS SEppzkSNARK.
+ *
+ * Given a R1CS constraint system CS, this algorithm produces proving and verification keys for CS.
+ */
+template<typename ppT>
+r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksnark_constraint_system<ppT> &cs);
+
+/**
+ * A prover algorithm for the R1CS SEppzkSNARK.
+ *
+ * Given a R1CS primary input X and a R1CS auxiliary input Y, this algorithm
+ * produces a proof (of knowledge) that attests to the following statement:
+ *               ``there exists Y such that CS(X,Y)=0''.
+ * Above, CS is the R1CS constraint system that was given as input to the generator algorithm.
+ */
+template<typename ppT>
+r1cs_se_ppzksnark_proof<ppT> r1cs_se_ppzksnark_prover(const r1cs_se_ppzksnark_proving_key<ppT> &pk,
+                                                      const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                                      const r1cs_se_ppzksnark_auxiliary_input<ppT> &auxiliary_input);
+
+/*
+ Below are four variants of verifier algorithm for the R1CS SEppzkSNARK.
+
+ These are the four cases that arise from the following two choices:
+
+ (1) The verifier accepts a (non-processed) verification key or, instead, a processed verification key.
+     In the latter case, we call the algorithm an "online verifier".
+
+ (2) The verifier checks for "weak" input consistency or, instead, "strong" input consistency.
+     Strong input consistency requires that |primary_input| = CS.num_inputs, whereas
+     weak input consistency requires that |primary_input| <= CS.num_inputs (and
+     the primary input is implicitly padded with zeros up to length CS.num_inputs).
+ */
+
+/**
+ * A verifier algorithm for the R1CS SEppzkSNARK that:
+ * (1) accepts a non-processed verification key, and
+ * (2) has weak input consistency.
+ */
+template<typename ppT>
+bool r1cs_se_ppzksnark_verifier_weak_IC(const r1cs_se_ppzksnark_verification_key<ppT> &vk,
+                                        const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                        const r1cs_se_ppzksnark_proof<ppT> &proof);
+
+/**
+ * A verifier algorithm for the R1CS SEppzkSNARK that:
+ * (1) accepts a non-processed verification key, and
+ * (2) has strong input consistency.
+ */
+template<typename ppT>
+bool r1cs_se_ppzksnark_verifier_strong_IC(const r1cs_se_ppzksnark_verification_key<ppT> &vk,
+                                          const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                          const r1cs_se_ppzksnark_proof<ppT> &proof);
+
+/**
+ * Convert a (non-processed) verification key into a processed verification key.
+ */
+template<typename ppT>
+r1cs_se_ppzksnark_processed_verification_key<ppT> r1cs_se_ppzksnark_verifier_process_vk(const r1cs_se_ppzksnark_verification_key<ppT> &vk);
+
+/**
+ * A verifier algorithm for the R1CS ppzkSNARK that:
+ * (1) accepts a processed verification key, and
+ * (2) has weak input consistency.
+ */
+template<typename ppT>
+bool r1cs_se_ppzksnark_online_verifier_weak_IC(const r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk,
+                                               const r1cs_se_ppzksnark_primary_input<ppT> &input,
+                                               const r1cs_se_ppzksnark_proof<ppT> &proof);
+
+/**
+ * A verifier algorithm for the R1CS ppzkSNARK that:
+ * (1) accepts a processed verification key, and
+ * (2) has strong input consistency.
+ */
+template<typename ppT>
+bool r1cs_se_ppzksnark_online_verifier_strong_IC(const r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk,
+                                                 const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                                 const r1cs_se_ppzksnark_proof<ppT> &proof);
+
+} // libsnark
+
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc>
+
+#endif // R1CS_SE_PPZKSNARK_HPP_

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
@@ -327,6 +327,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
         G_table,
         tmp_exponents);
     tmp_exponents.clear();
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(A_query);
+#endif
 
     libff::G2_vector<ppT> B_query = libff::batch_exp<libff::G2<ppT>,
                                                      libff::Fr<ppT> >(
@@ -334,6 +337,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
         H_gamma_window,
         H_gamma_table,
         At);
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G2<ppT> >(B_query);
+#endif
 
     libff::G1<ppT> G_gamma = gamma * G;
     libff::G1<ppT> G_gamma_Z = sap_inst.Zt * G_gamma;
@@ -350,9 +356,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
         G_gamma2_Z_t.emplace_back(val);
         val = t * val;
     }
-    #ifdef USE_MIXED_ADDITION
+#ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(G_gamma2_Z_t);
-    #endif
+#endif
 
     tmp_exponents.reserve(sap_inst.num_variables() - sap_inst.num_inputs());
     for (size_t i = sap_inst.num_inputs() + 1;
@@ -369,6 +375,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
         G_table,
         tmp_exponents);
     tmp_exponents.clear();
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(C_query_1);
+#endif
 
     tmp_exponents.reserve(sap_inst.num_variables() + 1);
     libff::Fr<ppT> double_gamma2_Z = gamma * gamma * sap_inst.Zt;
@@ -384,6 +393,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
         G_table,
         tmp_exponents);
     tmp_exponents.clear();
+#ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(C_query_2);
+#endif
 
     libff::leave_block("Generate R1CS proving key");
 
@@ -461,7 +473,7 @@ r1cs_se_ppzksnark_proof<ppT> r1cs_se_ppzksnark_prover(const r1cs_se_ppzksnark_pr
         sap_wit.d1 * pk.G_gamma_Z + // ZK-patch
         libff::multi_exp<libff::G1<ppT>,
                          libff::Fr<ppT>,
-                         libff::multi_exp_method_bos_coster>(
+                         libff::multi_exp_method_BDLO12>(
             pk.A_query.begin() + 1,
             pk.A_query.end(),
             sap_wit.coefficients_for_ACs.begin(),
@@ -479,7 +491,7 @@ r1cs_se_ppzksnark_proof<ppT> r1cs_se_ppzksnark_prover(const r1cs_se_ppzksnark_pr
         sap_wit.d1 * pk.H_gamma_Z + // ZK-patch
         libff::multi_exp<libff::G2<ppT>,
                          libff::Fr<ppT>,
-                         libff::multi_exp_method_bos_coster>(
+                         libff::multi_exp_method_BDLO12>(
             pk.B_query.begin() + 1,
             pk.B_query.end(),
             sap_wit.coefficients_for_ACs.begin(),
@@ -500,7 +512,7 @@ r1cs_se_ppzksnark_proof<ppT> r1cs_se_ppzksnark_prover(const r1cs_se_ppzksnark_pr
      */
     libff::G1<ppT> C = libff::multi_exp<libff::G1<ppT>,
                                         libff::Fr<ppT>,
-                                        libff::multi_exp_method_bos_coster>(
+                                        libff::multi_exp_method_BDLO12>(
             pk.C_query_1.begin(),
             pk.C_query_1.end(),
             sap_wit.coefficients_for_ACs.begin() + sap_wit.num_inputs(),
@@ -513,7 +525,7 @@ r1cs_se_ppzksnark_proof<ppT> r1cs_se_ppzksnark_prover(const r1cs_se_ppzksnark_pr
         (r + r) * sap_wit.d1 * pk.G_gamma2_Z2 + // ZK-patch for C_query_2
         r * libff::multi_exp<libff::G1<ppT>,
                              libff::Fr<ppT>,
-                             libff::multi_exp_method_bos_coster>(
+                             libff::multi_exp_method_BDLO12>(
             pk.C_query_2.begin() + 1,
             pk.C_query_2.end(),
             sap_wit.coefficients_for_ACs.begin(),

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
@@ -228,8 +228,16 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 {
     libff::enter_block("Call to r1cs_se_ppzksnark_generator");
 
-    /* draw random element at which the SAP is evaluated */
-    const libff::Fr<ppT> t = libff::Fr<ppT>::random_element();
+    /**
+     * draw random element t at which the SAP is evaluated.
+     * it should be the case that Z(t) != 0
+     */
+    const std::shared_ptr<libfqfft::evaluation_domain<libff::Fr<ppT> > > domain =
+        r1cs_to_sap_get_domain(cs);
+    libff::Fr<ppT> t;
+    do {
+        t = libff::Fr<ppT>::random_element();
+    } while (domain->compute_vanishing_polynomial(t).is_zero());
 
     sap_instance_evaluation<libff::Fr<ppT> > sap_inst = r1cs_to_sap_instance_map_with_evaluation(cs, t);
 

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
@@ -448,7 +448,7 @@ r1cs_se_ppzksnark_proof<ppT> r1cs_se_ppzksnark_prover(const r1cs_se_ppzksnark_pr
     assert(pk.B_query.size() == sap_wit.num_variables() + 1);
     assert(pk.C_query_1.size() == sap_wit.num_variables() - sap_wit.num_inputs());
     assert(pk.C_query_2.size() == sap_wit.num_variables() + 1);
-    assert(pk.G_gamma2_Z_t >= sap_wit.degree() - 1);
+    assert(pk.G_gamma2_Z_t.size() >= sap_wit.degree() - 1);
 #endif
 
 #ifdef MULTICORE

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
@@ -1,0 +1,696 @@
+/** @file
+*****************************************************************************
+
+Implementation of interfaces for a SEppzkSNARK for R1CS.
+
+See r1cs_se_ppzksnark.hpp .
+
+*****************************************************************************
+* @author     This file is part of libsnark, developed by SCIPR Lab
+*             and contributors (see AUTHORS).
+* @copyright  MIT license (see LICENSE file)
+*****************************************************************************/
+
+#ifndef R1CS_SE_PPZKSNARK_TCC_
+#define R1CS_SE_PPZKSNARK_TCC_
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <iostream>
+#include <sstream>
+
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+
+#ifdef MULTICORE
+#include <omp.h>
+#endif
+
+#include <libsnark/knowledge_commitment/kc_multiexp.hpp>
+#include <libsnark/reductions/r1cs_to_sap/r1cs_to_sap.hpp>
+
+namespace libsnark {
+
+template<typename ppT>
+bool r1cs_se_ppzksnark_proving_key<ppT>::operator==(const r1cs_se_ppzksnark_proving_key<ppT> &other) const
+{
+    return (this->A_query == other.A_query &&
+            this->B_query == other.B_query &&
+            this->C_query_1 == other.C_query_1 &&
+            this->C_query_2 == other.C_query_2 &&
+            this->G_gamma_Z == other.G_gamma_Z &&
+            this->H_gamma_Z == other.H_gamma_Z &&
+            this->G_ab_gamma_Z == other.G_ab_gamma_Z &&
+            this->G_gamma2_Z2 == other.G_gamma2_Z2 &&
+            this->G_gamma2_Z_t == other.G_gamma2_Z_t &&
+            this->constraint_system == other.constraint_system);
+}
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_proving_key<ppT> &pk)
+{
+    out << pk.A_query;
+    out << pk.B_query;
+    out << pk.C_query_1;
+    out << pk.C_query_2;
+    out << pk.G_gamma_Z;
+    out << pk.H_gamma_Z;
+    out << pk.G_ab_gamma_Z;
+    out << pk.G_gamma2_Z2;
+    out << pk.G_gamma2_Z_t;
+    out << pk.constraint_system;
+
+    return out;
+}
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_proving_key<ppT> &pk)
+{
+    in >> pk.A_query;
+    in >> pk.B_query;
+    in >> pk.C_query_1;
+    in >> pk.C_query_2;
+    in >> pk.G_gamma_Z;
+    in >> pk.H_gamma_Z;
+    in >> pk.G_ab_gamma_Z;
+    in >> pk.G_gamma2_Z2;
+    in >> pk.G_gamma2_Z_t;
+    in >> pk.constraint_system;
+
+    return in;
+}
+
+template<typename ppT>
+bool r1cs_se_ppzksnark_verification_key<ppT>::operator==(const r1cs_se_ppzksnark_verification_key<ppT> &other) const
+{
+    return (this->H == other.H &&
+            this->G_alpha == other.G_alpha &&
+            this->H_beta == other.H_beta &&
+            this->G_gamma == other.G_gamma &&
+            this->H_gamma == other.H_gamma &&
+            this->query == other.query);
+}
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_verification_key<ppT> &vk)
+{
+    out << vk.H << OUTPUT_NEWLINE;
+    out << vk.G_alpha << OUTPUT_NEWLINE;
+    out << vk.H_beta << OUTPUT_NEWLINE;
+    out << vk.G_gamma << OUTPUT_NEWLINE;
+    out << vk.H_gamma << OUTPUT_NEWLINE;
+    out << vk.query << OUTPUT_NEWLINE;
+
+    return out;
+}
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_verification_key<ppT> &vk)
+{
+    in >> vk.H;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> vk.G_alpha;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> vk.H_beta;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> vk.G_gamma;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> vk.H_gamma;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> vk.query;
+    libff::consume_OUTPUT_NEWLINE(in);
+
+    return in;
+}
+
+template<typename ppT>
+bool r1cs_se_ppzksnark_processed_verification_key<ppT>::operator==(const r1cs_se_ppzksnark_processed_verification_key<ppT> &other) const
+{
+    return (this->G_alpha == other.G_alpha &&
+            this->H_beta == other.H_beta &&
+            this->G_alpha_H_beta_ml == other.G_alpha_H_beta_ml &&
+            this->G_gamma_pc == other.G_gamma_pc &&
+            this->H_gamma_pc == other.H_gamma_pc &&
+            this->H_pc == other.H_pc &&
+            this->query == other.query);
+}
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk)
+{
+    out << pvk.G_alpha << OUTPUT_NEWLINE;
+    out << pvk.H_beta << OUTPUT_NEWLINE;
+    out << pvk.G_alpha_H_beta_ml << OUTPUT_NEWLINE;
+    out << pvk.G_gamma_pc << OUTPUT_NEWLINE;
+    out << pvk.H_gamma_pc << OUTPUT_NEWLINE;
+    out << pvk.H_pc << OUTPUT_NEWLINE;
+    out << pvk.query << OUTPUT_NEWLINE;
+
+    return out;
+}
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk)
+{
+    in >> pvk.G_alpha;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> pvk.H_beta;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> pvk.G_alpha_H_beta_ml;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> pvk.G_gamma_pc;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> pvk.H_gamma_pc;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> pvk.H_pc;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> pvk.query;
+    libff::consume_OUTPUT_NEWLINE(in);
+
+    return in;
+}
+
+template<typename ppT>
+bool r1cs_se_ppzksnark_proof<ppT>::operator==(const r1cs_se_ppzksnark_proof<ppT> &other) const
+{
+    return (this->A == other.A &&
+            this->B == other.B &&
+            this->C == other.C);
+}
+
+template<typename ppT>
+std::ostream& operator<<(std::ostream &out, const r1cs_se_ppzksnark_proof<ppT> &proof)
+{
+    out << proof.A << OUTPUT_NEWLINE;
+    out << proof.B << OUTPUT_NEWLINE;
+    out << proof.C << OUTPUT_NEWLINE;
+
+    return out;
+}
+
+template<typename ppT>
+std::istream& operator>>(std::istream &in, r1cs_se_ppzksnark_proof<ppT> &proof)
+{
+    in >> proof.A;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> proof.B;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> proof.C;
+    libff::consume_OUTPUT_NEWLINE(in);
+
+    return in;
+}
+
+template<typename ppT>
+r1cs_se_ppzksnark_verification_key<ppT> r1cs_se_ppzksnark_verification_key<ppT>::dummy_verification_key(const size_t input_size)
+{
+    r1cs_se_ppzksnark_verification_key<ppT> result;
+    result.H = libff::Fr<ppT>::random_element() * libff::G2<ppT>::one();
+    result.G_alpha = libff::Fr<ppT>::random_element() * libff::G1<ppT>::one();
+    result.H_beta = libff::Fr<ppT>::random_element() * libff::G2<ppT>::one();
+    result.G_gamma = libff::Fr<ppT>::random_element() * libff::G1<ppT>::one();
+    result.H_gamma = libff::Fr<ppT>::random_element() * libff::G2<ppT>::one();
+
+    libff::G1_vector<ppT> v;
+    for (size_t i = 0; i < input_size + 1; ++i)
+    {
+        v.emplace_back(libff::Fr<ppT>::random_element() * libff::G1<ppT>::one());
+    }
+    result.query = std::move(v);
+
+    return result;
+}
+
+template <typename ppT>
+r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksnark_constraint_system<ppT> &cs)
+{
+    libff::enter_block("Call to r1cs_se_ppzksnark_generator");
+
+    /* draw random element at which the SAP is evaluated */
+    const libff::Fr<ppT> t = libff::Fr<ppT>::random_element();
+
+    sap_instance_evaluation<libff::Fr<ppT> > sap_inst = r1cs_to_sap_instance_map_with_evaluation(cs, t);
+
+    libff::print_indent(); printf("* SAP number of variables: %zu\n", sap_inst.num_variables());
+    libff::print_indent(); printf("* SAP pre degree: %zu\n", cs.constraints.size());
+    libff::print_indent(); printf("* SAP degree: %zu\n", sap_inst.degree());
+    libff::print_indent(); printf("* SAP number of input variables: %zu\n", sap_inst.num_inputs());
+
+    libff::enter_block("Compute query densities");
+    size_t non_zero_At = 0;
+    for (size_t i = 0; i < sap_inst.num_variables()+1; ++i)
+    {
+        if (!sap_inst.At[i].is_zero())
+        {
+            ++non_zero_At;
+        }
+    }
+    libff::leave_block("Compute query densities");
+
+    libff::Fr_vector<ppT> At = std::move(sap_inst.At);
+    libff::Fr_vector<ppT> Ct = std::move(sap_inst.Ct);
+    libff::Fr_vector<ppT> Ht = std::move(sap_inst.Ht);
+    /**
+     * sap_inst.{A,C,H}t are now in an unspecified state,
+     * but we do not use them below
+     */
+
+    const  libff::Fr<ppT> alpha = libff::Fr<ppT>::random_element(),
+        beta = libff::Fr<ppT>::random_element(),
+        gamma = libff::Fr<ppT>::random_element();
+    const libff::G1<ppT> G = libff::G1<ppT>::random_element();
+    const libff::G2<ppT> H = libff::G2<ppT>::random_element();
+
+    libff::enter_block("Generating G multiexp table");
+    size_t G_exp_count = sap_inst.num_inputs() + 1 // verifier_query
+                         + non_zero_At // A_query
+                         // C_query_1
+                         + sap_inst.num_variables() - sap_inst.num_inputs()
+                         + sap_inst.num_variables() + 1, // C_query_2
+           G_window = libff::get_exp_window_size<libff::G1<ppT> >(G_exp_count);
+    libff::print_indent(); printf("* G window: %zu\n", G_window);
+    libff::window_table<libff::G1<ppT> > G_table = get_window_table(
+        libff::Fr<ppT>::size_in_bits(), G_window, G);
+    libff::leave_block("Generating G multiexp table");
+
+    libff::enter_block("Generating H_gamma multiexp table");
+    libff::G2<ppT> H_gamma = gamma * H;
+    size_t H_gamma_exp_count = non_zero_At, // B_query
+           H_gamma_window = libff::get_exp_window_size<libff::G2<ppT> >(H_gamma_exp_count);
+    libff::print_indent(); printf("* H_gamma window: %zu\n", H_gamma_window);
+    libff::window_table<libff::G2<ppT> > H_gamma_table = get_window_table(
+        libff::Fr<ppT>::size_in_bits(), H_gamma_window, H_gamma);
+    libff::leave_block("Generating H_gamma multiexp table");
+
+    libff::enter_block("Generate R1CS verification key");
+    libff::G1<ppT> G_alpha = alpha * G;
+    libff::G2<ppT> H_beta = beta * H;
+
+    libff::Fr_vector<ppT> tmp_exponents;
+    tmp_exponents.reserve(sap_inst.num_inputs() + 1);
+    for (size_t i = 0; i <= sap_inst.num_inputs(); ++i)
+    {
+        tmp_exponents.emplace_back(gamma * Ct[i] + (alpha + beta) * At[i]);
+    }
+    libff::G1_vector<ppT> verifier_query = libff::batch_exp<libff::G1<ppT>,
+                                                            libff::Fr<ppT> >(
+        libff::Fr<ppT>::size_in_bits(),
+        G_window,
+        G_table,
+        tmp_exponents);
+    tmp_exponents.clear();
+
+    libff::leave_block("Generate R1CS verification key");
+
+    libff::enter_block("Generate R1CS proving key");
+
+    tmp_exponents.reserve(sap_inst.num_variables() + 1);
+    for (size_t i = 0; i < At.size(); i++)
+    {
+        tmp_exponents.emplace_back(gamma * At[i]);
+    }
+
+    libff::G1_vector<ppT> A_query = libff::batch_exp<libff::G1<ppT>,
+                                                     libff::Fr<ppT> >(
+        libff::Fr<ppT>::size_in_bits(),
+        G_window,
+        G_table,
+        tmp_exponents);
+    tmp_exponents.clear();
+
+    libff::G2_vector<ppT> B_query = libff::batch_exp<libff::G2<ppT>,
+                                                     libff::Fr<ppT> >(
+        libff::Fr<ppT>::size_in_bits(),
+        H_gamma_window,
+        H_gamma_table,
+        At);
+
+    libff::G1<ppT> G_gamma = gamma * G;
+    libff::G1<ppT> G_gamma_Z = sap_inst.Zt * G_gamma;
+    libff::G2<ppT> H_gamma_Z = sap_inst.Zt * H_gamma;
+    libff::G1<ppT> G_ab_gamma_Z = (alpha + beta) * G_gamma_Z;
+    libff::G1<ppT> G_gamma2_Z2 = (sap_inst.Zt * gamma) * G_gamma_Z;
+
+    libff::G1_vector<ppT> G_gamma2_Z_t;
+    G_gamma2_Z_t.reserve(sap_inst.degree() + 1);
+
+    libff::G1<ppT> val = gamma * G_gamma_Z;
+    for (size_t i = 0; i < sap_inst.degree() + 1; ++i)
+    {
+        G_gamma2_Z_t.emplace_back(val);
+        val = t * val;
+    }
+    #ifdef USE_MIXED_ADDITION
+    libff::batch_to_special<libff::G1<ppT> >(G_gamma2_Z_t);
+    #endif
+
+    tmp_exponents.reserve(sap_inst.num_variables() - sap_inst.num_inputs());
+    for (size_t i = sap_inst.num_inputs() + 1;
+         i <= sap_inst.num_variables();
+         ++i)
+    {
+        tmp_exponents.emplace_back(gamma *
+            (gamma * Ct[i] + (alpha + beta) * At[i]));
+    }
+    libff::G1_vector<ppT> C_query_1 = libff::batch_exp<libff::G1<ppT>,
+                                                       libff::Fr<ppT> >(
+        libff::Fr<ppT>::size_in_bits(),
+        G_window,
+        G_table,
+        tmp_exponents);
+    tmp_exponents.clear();
+
+    tmp_exponents.reserve(sap_inst.num_variables() + 1);
+    libff::Fr<ppT> double_gamma2_Z = gamma * gamma * sap_inst.Zt;
+    double_gamma2_Z = double_gamma2_Z + double_gamma2_Z;
+    for (size_t i = 0; i <= sap_inst.num_variables(); ++i)
+    {
+        tmp_exponents.emplace_back(double_gamma2_Z * At[i]);
+    }
+    libff::G1_vector<ppT> C_query_2 = libff::batch_exp<libff::G1<ppT>,
+                                                       libff::Fr<ppT> >(
+        libff::Fr<ppT>::size_in_bits(),
+        G_window,
+        G_table,
+        tmp_exponents);
+    tmp_exponents.clear();
+
+    libff::leave_block("Generate R1CS proving key");
+
+    libff::leave_block("Call to r1cs_se_ppzksnark_generator");
+
+    r1cs_se_ppzksnark_verification_key<ppT> vk =
+        r1cs_se_ppzksnark_verification_key<ppT>(H, G_alpha, H_beta, G_gamma,
+            H_gamma, std::move(verifier_query));
+
+    r1cs_se_ppzksnark_constraint_system<ppT> cs_copy(cs);
+
+    r1cs_se_ppzksnark_proving_key<ppT> pk = r1cs_se_ppzksnark_proving_key<ppT>(
+        std::move(A_query), std::move(B_query), std::move(C_query_1),
+        std::move(C_query_2), G_gamma_Z, H_gamma_Z, G_ab_gamma_Z, G_gamma2_Z2,
+        std::move(G_gamma2_Z_t), std::move(cs_copy));
+
+    pk.print_size();
+    vk.print_size();
+
+    return r1cs_se_ppzksnark_keypair<ppT>(std::move(pk), std::move(vk));
+}
+
+template <typename ppT>
+r1cs_se_ppzksnark_proof<ppT> r1cs_se_ppzksnark_prover(const r1cs_se_ppzksnark_proving_key<ppT> &pk,
+                                                const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                                const r1cs_se_ppzksnark_auxiliary_input<ppT> &auxiliary_input)
+{
+    libff::enter_block("Call to r1cs_se_ppzksnark_prover");
+
+#ifdef DEBUG
+    assert(pk.constraint_system.is_satisfied(primary_input, auxiliary_input));
+#endif
+
+    const libff::Fr<ppT> d1 = libff::Fr<ppT>::random_element(),
+        d2 = libff::Fr<ppT>::random_element();
+
+    libff::enter_block("Compute the polynomial H");
+    const sap_witness<libff::Fr<ppT> > sap_wit = r1cs_to_sap_witness_map(
+        pk.constraint_system, primary_input, auxiliary_input, d1, d2);
+    libff::leave_block("Compute the polynomial H");
+
+#ifdef DEBUG
+    const libff::Fr<ppT> t = libff::Fr<ppT>::random_element();
+    sap_instance_evaluation<libff::Fr<ppT> > sap_inst = r1cs_to_sap_instance_map_with_evaluation(pk.constraint_system, t);
+    assert(sap_inst.is_satisfied(sap_wit));
+#endif
+
+#ifdef DEBUG
+    assert(pk.A_query.size() == sap_wit.num_variables() + 1);
+    assert(pk.B_query.size() == sap_wit.num_variables() + 1);
+    assert(pk.C_query_1.size() == sap_wit.num_variables() - sap_wit.num_inputs());
+    assert(pk.C_query_2.size() == sap_wit.num_variables() + 1);
+    assert(pk.G_gamma2_Z_t >= sap_wit.degree() - 1);
+#endif
+
+#ifdef MULTICORE
+    const size_t chunks = omp_get_max_threads(); // to override, set OMP_NUM_THREADS env var or call omp_set_num_threads()
+#else
+    const size_t chunks = 1;
+#endif
+
+    const libff::Fr<ppT> r = libff::Fr<ppT>::random_element();
+
+    libff::enter_block("Compute the proof");
+
+    libff::enter_block("Compute answer to A-query", false);
+    /**
+     * compute A = G^{gamma * (\sum_{i=0}^m input_i * A_i(t) + r * Z(t))}
+     *           = \prod_{i=0}^m (G^{gamma * A_i(t)})^{input_i)
+     *             * (G^{gamma * Z(t)})^r
+     *           = \prod_{i=0}^m A_query[i]^{input_i} * G_gamma_Z^r
+     */
+    libff::G1<ppT> A = r * pk.G_gamma_Z +
+        pk.A_query[0] + // i = 0 is a special case because input_i = 1
+        sap_wit.d1 * pk.G_gamma_Z + // ZK-patch
+        libff::multi_exp<libff::G1<ppT>,
+                         libff::Fr<ppT>,
+                         libff::multi_exp_method_bos_coster>(
+            pk.A_query.begin() + 1,
+            pk.A_query.end(),
+            sap_wit.coefficients_for_ACs.begin(),
+            sap_wit.coefficients_for_ACs.end(),
+            chunks);
+
+    libff::leave_block("Compute answer to A-query", false);
+
+    libff::enter_block("Compute answer to B-query", false);
+    /**
+     * compute B exactly as A, except with H as the base
+     */
+    libff::G2<ppT> B = r * pk.H_gamma_Z +
+        pk.B_query[0] + // i = 0 is a special case because input_i = 1
+        sap_wit.d1 * pk.H_gamma_Z + // ZK-patch
+        libff::multi_exp<libff::G2<ppT>,
+                         libff::Fr<ppT>,
+                         libff::multi_exp_method_bos_coster>(
+            pk.B_query.begin() + 1,
+            pk.B_query.end(),
+            sap_wit.coefficients_for_ACs.begin(),
+            sap_wit.coefficients_for_ACs.end(),
+            chunks);
+    libff::leave_block("Compute answer to B-query", false);
+
+    libff::enter_block("Compute answer to C-query", false);
+    /**
+     * compute C = G^{f(input) +
+     *                r^2 * gamma^2 * Z(t)^2 +
+     *                r * (alpha + beta) * gamma * Z(t) +
+     *                2 * r * gamma^2 * Z(t) * \sum_{i=0}^m input_i A_i(t) +
+     *                gamma^2 * Z(t) * H(t)}
+     * where G^{f(input)} = \prod_{i=l+1}^m C_query_1 * input_i
+     * and G^{2 * r * gamma^2 * Z(t) * \sum_{i=0}^m input_i A_i(t)} =
+     *              = \prod_{i=0}^m C_query_2 * input_i
+     */
+    libff::G1<ppT> C = libff::multi_exp<libff::G1<ppT>,
+                                        libff::Fr<ppT>,
+                                        libff::multi_exp_method_bos_coster>(
+            pk.C_query_1.begin(),
+            pk.C_query_1.end(),
+            sap_wit.coefficients_for_ACs.begin() + sap_wit.num_inputs(),
+            sap_wit.coefficients_for_ACs.end(),
+            chunks) +
+        (r * r) * pk.G_gamma2_Z2 +
+        r * pk.G_ab_gamma_Z +
+        sap_wit.d1 * pk.G_ab_gamma_Z + // ZK-patch
+        r * pk.C_query_2[0] + // i = 0 is a special case for C_query_2
+        (r + r) * sap_wit.d1 * pk.G_gamma2_Z2 + // ZK-patch for C_query_2
+        r * libff::multi_exp<libff::G1<ppT>,
+                             libff::Fr<ppT>,
+                             libff::multi_exp_method_bos_coster>(
+            pk.C_query_2.begin() + 1,
+            pk.C_query_2.end(),
+            sap_wit.coefficients_for_ACs.begin(),
+            sap_wit.coefficients_for_ACs.end(),
+            chunks) +
+        sap_wit.d2 * pk.G_gamma2_Z_t[0] + // ZK-patch
+        libff::multi_exp<libff::G1<ppT>,
+                          libff::Fr<ppT>,
+                          libff::multi_exp_method_BDLO12>(
+            pk.G_gamma2_Z_t.begin(),
+            pk.G_gamma2_Z_t.end(),
+            sap_wit.coefficients_for_H.begin(),
+            sap_wit.coefficients_for_H.end(),
+            chunks);
+    libff::leave_block("Compute answer to C-query", false);
+
+    libff::leave_block("Compute the proof");
+
+    libff::leave_block("Call to r1cs_se_ppzksnark_prover");
+
+    r1cs_se_ppzksnark_proof<ppT> proof = r1cs_se_ppzksnark_proof<ppT>(
+        std::move(A), std::move(B), std::move(C));
+    proof.print_size();
+
+    return proof;
+}
+
+template <typename ppT>
+r1cs_se_ppzksnark_processed_verification_key<ppT> r1cs_se_ppzksnark_verifier_process_vk(const r1cs_se_ppzksnark_verification_key<ppT> &vk)
+{
+    libff::enter_block("Call to r1cs_se_ppzksnark_verifier_process_vk");
+
+    libff::G1_precomp<ppT> G_alpha_pc = ppT::precompute_G1(vk.G_alpha);
+    libff::G2_precomp<ppT> H_beta_pc = ppT::precompute_G2(vk.H_beta);
+
+    r1cs_se_ppzksnark_processed_verification_key<ppT> pvk;
+    pvk.G_alpha = vk.G_alpha;
+    pvk.H_beta = vk.H_beta;
+    pvk.G_alpha_H_beta_ml = ppT::miller_loop(G_alpha_pc, H_beta_pc);
+    pvk.G_gamma_pc = ppT::precompute_G1(vk.G_gamma);
+    pvk.H_gamma_pc = ppT::precompute_G2(vk.H_gamma);
+    pvk.H_pc = ppT::precompute_G2(vk.H);
+
+    pvk.query = vk.query;
+
+    libff::leave_block("Call to r1cs_se_ppzksnark_verifier_process_vk");
+
+    return pvk;
+}
+
+template <typename ppT>
+bool r1cs_se_ppzksnark_online_verifier_weak_IC(const r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk,
+                                               const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                               const r1cs_se_ppzksnark_proof<ppT> &proof)
+{
+    libff::enter_block("Call to r1cs_se_ppzksnark_online_verifier_weak_IC");
+
+    bool result = true;
+
+    libff::enter_block("Check if the proof is well-formed");
+    if (!proof.is_well_formed())
+    {
+        if (!libff::inhibit_profiling_info)
+        {
+            libff::print_indent(); printf("At least one of the proof elements does not lie on the curve.\n");
+        }
+        result = false;
+    }
+    libff::leave_block("Check if the proof is well-formed");
+
+    libff::enter_block("Pairing computations");
+
+#ifdef MULTICORE
+    const size_t chunks = omp_get_max_threads(); // to override, set OMP_NUM_THREADS env var or call omp_set_num_threads()
+#else
+    const size_t chunks = 1;
+#endif
+
+    libff::enter_block("Check first test");
+    /**
+     * e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma})
+     *                              * e(C, H)
+     * where psi = \sum_{i=0}^l input_i pvk.query[i]
+     */
+    libff::G1<ppT> G_psi = pvk.query[0] +
+        libff::multi_exp<libff::G1<ppT>,
+                         libff::Fr<ppT>,
+                         libff::multi_exp_method_bos_coster>(
+            pvk.query.begin() + 1, pvk.query.end(),
+            primary_input.begin(), primary_input.end(),
+            chunks);
+
+    libff::Fqk<ppT> test1_l = ppT::miller_loop(ppT::precompute_G1(proof.A + pvk.G_alpha),
+                                               ppT::precompute_G2(proof.B + pvk.H_beta)),
+                    test1_r1 = pvk.G_alpha_H_beta_ml,
+                    test1_r2 = ppT::miller_loop(ppT::precompute_G1(G_psi),
+                                                pvk.H_gamma_pc),
+                    test1_r3 = ppT::miller_loop(ppT::precompute_G1(proof.C),
+                                                pvk.H_pc);
+    libff::GT<ppT> test1 = ppT::final_exponentiation(
+        test1_l.unitary_inverse() * test1_r1 * test1_r2 * test1_r3);
+
+    if (test1 != libff::GT<ppT>::one())
+    {
+        if (!libff::inhibit_profiling_info)
+        {
+            libff::print_indent(); printf("First test failed.\n");
+        }
+        result = false;
+    }
+    libff::leave_block("Check first test");
+
+    libff::enter_block("Check second test");
+    /**
+     * e(A, H^{gamma}) = e(G^{gamma}, B)
+     */
+    libff::Fqk<ppT> test2_l = ppT::miller_loop(ppT::precompute_G1(proof.A),
+                                               pvk.H_gamma_pc),
+                    test2_r = ppT::miller_loop(pvk.G_gamma_pc,
+                                               ppT::precompute_G2(proof.B));
+    libff::GT<ppT> test2 = ppT::final_exponentiation(
+        test2_l * test2_r.unitary_inverse());
+
+    if (test2 != libff::GT<ppT>::one())
+    {
+        if (!libff::inhibit_profiling_info)
+        {
+            libff::print_indent(); printf("Second test failed.\n");
+        }
+        result = false;
+    }
+    libff::leave_block("Check second test");
+    libff::leave_block("Pairing computations");
+    libff::leave_block("Call to r1cs_se_ppzksnark_online_verifier_weak_IC");
+
+    return result;
+}
+
+template<typename ppT>
+bool r1cs_se_ppzksnark_verifier_weak_IC(const r1cs_se_ppzksnark_verification_key<ppT> &vk,
+                                        const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                        const r1cs_se_ppzksnark_proof<ppT> &proof)
+{
+    libff::enter_block("Call to r1cs_se_ppzksnark_verifier_weak_IC");
+    r1cs_se_ppzksnark_processed_verification_key<ppT> pvk = r1cs_se_ppzksnark_verifier_process_vk<ppT>(vk);
+    bool result = r1cs_se_ppzksnark_online_verifier_weak_IC<ppT>(pvk, primary_input, proof);
+    libff::leave_block("Call to r1cs_se_ppzksnark_verifier_weak_IC");
+    return result;
+}
+
+template<typename ppT>
+bool r1cs_se_ppzksnark_online_verifier_strong_IC(const r1cs_se_ppzksnark_processed_verification_key<ppT> &pvk,
+                                                 const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                                 const r1cs_se_ppzksnark_proof<ppT> &proof)
+{
+    libff::enter_block("Call to r1cs_se_ppzksnark_online_verifier_strong_IC");
+    bool result = true;
+
+    if (pvk.query.size() != primary_input.size() + 1)
+    {
+        libff::print_indent();
+        printf("Input length differs from expected (got %zu, expected %zu).\n",
+            primary_input.size(), pvk.query.size());
+        result = false;
+    }
+    else
+    {
+        result = r1cs_se_ppzksnark_online_verifier_weak_IC(pvk, primary_input, proof);
+    }
+
+    libff::leave_block("Call to r1cs_se_ppzksnark_online_verifier_strong_IC");
+    return result;
+}
+
+template<typename ppT>
+bool r1cs_se_ppzksnark_verifier_strong_IC(const r1cs_se_ppzksnark_verification_key<ppT> &vk,
+                                          const r1cs_se_ppzksnark_primary_input<ppT> &primary_input,
+                                          const r1cs_se_ppzksnark_proof<ppT> &proof)
+{
+    libff::enter_block("Call to r1cs_se_ppzksnark_verifier_strong_IC");
+    r1cs_se_ppzksnark_processed_verification_key<ppT> pvk = r1cs_se_ppzksnark_verifier_process_vk<ppT>(vk);
+    bool result = r1cs_se_ppzksnark_online_verifier_strong_IC<ppT>(pvk, primary_input, proof);
+    libff::leave_block("Call to r1cs_se_ppzksnark_verifier_strong_IC");
+    return result;
+}
+
+} // libsnark
+#endif // R1CS_SE_PPZKSNARK_TCC_

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark_params.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark_params.hpp
@@ -1,0 +1,36 @@
+/** @file
+ *****************************************************************************
+
+ Declaration of public-parameter selector for the R1CS SEppzkSNARK.
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#ifndef R1CS_SE_PPZKSNARK_PARAMS_HPP_
+#define R1CS_SE_PPZKSNARK_PARAMS_HPP_
+
+#include <libff/algebra/curves/public_params.hpp>
+
+#include <libsnark/relations/constraint_satisfaction_problems/r1cs/r1cs.hpp>
+
+namespace libsnark {
+
+/**
+ * Below are various template aliases (used for convenience).
+ */
+
+template<typename ppT>
+using r1cs_se_ppzksnark_constraint_system = r1cs_constraint_system<libff::Fr<ppT> >;
+
+template<typename ppT>
+using r1cs_se_ppzksnark_primary_input = r1cs_primary_input<libff::Fr<ppT> >;
+
+template<typename ppT>
+using r1cs_se_ppzksnark_auxiliary_input = r1cs_auxiliary_input<libff::Fr<ppT> >;
+
+} // libsnark
+
+#endif // R1CS_SE_PPZKSNARK_PARAMS_HPP_

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/tests/test_r1cs_se_ppzksnark.cpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/tests/test_r1cs_se_ppzksnark.cpp
@@ -1,0 +1,43 @@
+/** @file
+ *****************************************************************************
+ Test program that exercises the SEppzkSNARK (first generator, then
+ prover, then verifier) on a synthetic R1CS instance.
+
+ *****************************************************************************
+ * @author     This file is part of libsnark, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+#include <cassert>
+#include <cstdio>
+
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+
+#include <libsnark/common/default_types/r1cs_se_ppzksnark_pp.hpp>
+#include <libsnark/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.hpp>
+
+using namespace libsnark;
+
+template<typename ppT>
+void test_r1cs_se_ppzksnark(size_t num_constraints,
+                            size_t input_size)
+{
+    libff::print_header("(enter) Test R1CS SEppzkSNARK");
+
+    const bool test_serialization = true;
+    r1cs_example<libff::Fr<ppT> > example = generate_r1cs_example_with_binary_input<libff::Fr<ppT> >(num_constraints, input_size);
+    const bool bit = run_r1cs_se_ppzksnark<ppT>(example, test_serialization);
+    assert(bit);
+
+    libff::print_header("(leave) Test R1CS SEppzkSNARK");
+}
+
+int main()
+{
+    default_r1cs_se_ppzksnark_pp::init_public_params();
+    libff::start_profiling();
+
+    test_r1cs_se_ppzksnark<default_r1cs_se_ppzksnark_pp>(1000, 100);
+}


### PR DESCRIPTION
This pull request implements the proof system presented in [Groth and Maller's IACR-CRYPTO-2017 paper](https://eprint.iacr.org/2017/540.pdf).

Unlike the system from [BCTV14a], which internally operates on Quadratic Arithmetic Programs (which arise from R1CSs, systems of constraints of the form <a, w> * <b, w> = <c, w>), [GM17] operates on Square Arithmetic Programs (which arise from constraints of the form (<a, w>)² = <c, w>). It turns out that an R1CS constraint can be converted into two equivalent SAP-compatible constraints at the cost of introducing an extra variable. This pull request includes an implementation of SAPs along with an R1CS→SAP reduction that follows the existing R1CS→QAP reduction but also performs this additional conversion.

It should be noted that the proof system relies on an assumption that is stronger than KEA used in most LIP SNARK works, but weaker than generic group model (used in Groth'16).

When compared to [BCTV14a] on the same input R1CS systems, [GM17] is slower but produces shorter proofs (just 2 elements in G1 and 1 in G2).

Here are the results of some benchmarking of our implementations of [BCTV14a] and [GM17] on an R1CS instance with 100 000 constraints and 1000 inputs:

Indicator | [BCTV14a] (`r1cs_ppzksnark`) | [GM17] (`r1cs_se_ppzksnark`) | delta
---|---|---|---|
Generator runtime | 16.91s | 59.95s | +254%
Prover runtime | 19.27s | 19.45s | +0.9%
Verifier runtime | 0.03s | 0.03s | 0
Proving key size | 255954523 bits | 322670816 bits | +26%
Verification key size | 322310 bits | 257292 bits | **-20%**
Proof size | 2294 bits | 1019 bits | **-56%**

