### PR TITLE
Improve SE-ppzkSNARK generator runtime.

### DIFF
--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
@@ -315,6 +315,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 
     libff::enter_block("Generate R1CS proving key");
 
+    libff::enter_block("Compute the A-query", false);
     tmp_exponents.reserve(sap_inst.num_variables() + 1);
     for (size_t i = 0; i < At.size(); i++)
     {
@@ -331,7 +332,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(A_query);
 #endif
+    libff::leave_block("Compute the A-query", false);
 
+    libff::enter_block("Compute the B-query", false);
     libff::G2_vector<ppT> B_query = libff::batch_exp<libff::G2<ppT>,
                                                      libff::Fr<ppT> >(
         libff::Fr<ppT>::size_in_bits(),
@@ -341,7 +344,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G2<ppT> >(B_query);
 #endif
+    libff::leave_block("Compute the B-query", false);
 
+    libff::enter_block("Compute the G_gamma-query", false);
     libff::G1<ppT> G_gamma = gamma * G;
     libff::G1<ppT> G_gamma_Z = sap_inst.Zt * G_gamma;
     libff::G2<ppT> H_gamma_Z = sap_inst.Zt * H_gamma;
@@ -366,7 +371,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(G_gamma2_Z_t);
 #endif
+    libff::leave_block("Compute the G_gamma-query", false);
 
+    libff::enter_block("Compute the C_1-query", false);
     tmp_exponents.reserve(sap_inst.num_variables() - sap_inst.num_inputs());
     for (size_t i = sap_inst.num_inputs() + 1;
          i <= sap_inst.num_variables();
@@ -385,7 +392,9 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(C_query_1);
 #endif
+    libff::leave_block("Compute the C_1-query", false);
 
+    libff::enter_block("Compute the C_2-query", false);
     tmp_exponents.reserve(sap_inst.num_variables() + 1);
     libff::Fr<ppT> double_gamma2_Z = gamma * gamma * sap_inst.Zt;
     double_gamma2_Z = double_gamma2_Z + double_gamma2_Z;
@@ -403,6 +412,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(C_query_2);
 #endif
+    libff::leave_block("Compute the C_2-query", false);
 
     libff::leave_block("Generate R1CS proving key");
 


### PR DESCRIPTION
In [GM17] proof system the proving key contains elements of the form t^i * gamma^2 * G (0 <= i <=d ); these elements were previously  computing by performing d sequential exponentiations (i.e. d sequential calls to G1::operator*). This commit changes this computation to use batch exponentiation instead.

Performance impact: the generator runtime, reported by `profile_r1cs_se_ppzksnark 1000000 10` (i.e. million R1CS constraints and 10 inputs) on a system with i7-4770 Haswell CPU, decreases from ~358s to ~100s.
