### PR TITLE
Fix tinyram prelude, tinyram read from aux input.

### DIFF
--- a/libsnark/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
+++ b/libsnark/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
@@ -326,12 +326,12 @@ void tinyram_cpu_checker<FieldT>::generate_r1cs_witness_other(tinyram_input_tape
     }
 
     this->pb.val(read_not1) = this->pb.val(opcode_indicators[tinyram_opcode_READ]) * (FieldT::one() - this->pb.val(arg2val->packed));
-    if (this->pb.val(read_not1) != FieldT::one())
+    if (this->pb.val(read_not1) != FieldT::zero())
     {
-        /* reading from tape other than 0 raises the flag */
+        /* reading from tape other than 1 raises the flag */
         this->pb.val(instruction_flags[tinyram_opcode_READ]) = FieldT::one();
     }
-    else
+    else if (this->pb.val(opcode_indicators[tinyram_opcode_READ]) != FieldT::zero())
     {
         /* otherwise perform the actual read */
         if (aux_it != aux_end)

--- a/libsnark/relations/ram_computations/rams/tinyram/tinyram_aux.cpp
+++ b/libsnark/relations/ram_computations/rams/tinyram/tinyram_aux.cpp
@@ -117,7 +117,7 @@ void ensure_tinyram_opcode_value_map()
 std::vector<tinyram_instruction> generate_tinyram_prelude(const tinyram_architecture_params &ap)
 {
     std::vector<tinyram_instruction> result;
-    const size_t increment = libff::log2(ap.w)/8;
+    const size_t increment = ap.w/8;
     const size_t mem_start = 1ul<<(ap.w-1);
     result.emplace_back(tinyram_instruction(tinyram_opcode_STOREW,  true, 0, 0, 0));         // 0: store.w 0, r0
     result.emplace_back(tinyram_instruction(tinyram_opcode_MOV,     true, 0, 0, mem_start)); // 1: mov r0, 2^{W-1}


### PR DESCRIPTION
When trying to get a simple example (attached) to function with the `demo_ram_ppzksnark` executable, I encountered a problem that the `read` opcode wasn't functioning as specified.

Two mistakes I noticed there were:
  a) the flag on `read` was being incorrectly set when `read_not1` was != 1, while it should be when `read_not1` is != 0 (this matches the r1cs constraints one `read_not1`, and further correctly sets the flag for tape 0 and *not* for tape 1).
  b) Fixing this resulted in values being consumed from tape 1 regardless of opcode, as the tape reading did not expicitly check for a `read` opcode.

Unrelated during my debugging of this, I found that the prelude generation of tinyram increments by `log(w)/8`. This is clearly a mistake, as `w` is already a size in bits.

-----

<details>
<summary>
The example I was using which did not work before:
</summary>

command:
```
$ libsnark/demo_ram_ppzksnark --assembly simple.s --processed_assembly simple.proc --architecture_params simple.params --computation_bounds simple.bounds --primary_input simple.input --auxiliary_input simple.input
```

`simple.s`:
```asm
; TinyRAM V=1.00 W=32 K=8

; Simple test program. Read from the input tape, from the aux tape, and check
; if they're equal.

; begin prelude
store.w 0, r0
mov r0, 2147483648
read r1, 0
cjmp 7
add r0, r0, 4
store.w r0, r1
jmp 2
store.w 2147483648, r0
; end prelude
load.w r0, 2147483648 ; The first word of the primary input tape should be here. (memory 0x8000 0000, this is 1<<(w-1))
read r1, 1
xor r0, r0, r1 ; r0 is 0 iff r0 = r1
answer r0
```

<details>
<summary>

`simple.proc`

</summary>

```
store.w
1
0
0
0
mov
1
0
0
2147483648
read
1
0
0
1
cjmp
1
0
0
7
add
1
0
0
4
store.w
0
1
0
0
jmp
1
0
0
2
store.w
1
0
0
2147483648
load.w
1
0
0
2147483648
read
1
1
0
1
xor
0
0
0
1
answer
0
0
0
0
```

</details>

`simple.params`:
```
32
8
```

`simple.bounds`:
```
32
32
32
```

`simple.input`:
```
42
```

</details>

-----

P.S. Is there a public assember for TinyRAM? I had to write the processed assembly by hand, and while it'd be easy enough to write one, I'd prefer to avoid duplicating effort.