### PR TITLE
Add pkg-config to the ubuntu 16.04 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Concretely, here are the requisite packages in some Linux distributions:
 
 * On Ubuntu 16.04 LTS:
 
-        $ sudo apt-get install build-essential cmake git libgmp3-dev libprocps4-dev python-markdown libboost-all-dev libssl-dev
+        $ sudo apt-get install build-essential cmake git libgmp3-dev libprocps4-dev pkg-config python-markdown libboost-all-dev libssl-dev
 
 * On Ubuntu 14.04 LTS:
 


### PR DESCRIPTION
My build failed because I didn't have pkg-config installed.