### PR TITLE
Add build target for gadgetlib2 tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ To compile and run the tests for this library, run:
 
     $ make check
 
+To compile and run the gadgetlib2 tutorial, run:
+
+    $ make gadgetlib2_tutorial
+    $ ./libsnark/gadgetlib2_tutorial
+
 ### Using libsnark as a library
 
 To develop an application that uses libsnark, it's recommended to use your own build system that incorporates libsnark and dependencies. If you're using CMake, add libsnark as a git submodule, and then add it as a subdirectory. Then, add `snark` as a library dependency to the appropriate rules.

--- a/libsnark/CMakeLists.txt
+++ b/libsnark/CMakeLists.txt
@@ -473,6 +473,21 @@ target_link_libraries(
 )
 
 add_executable(
+  gadgetlib2_tutorial
+  EXCLUDE_FROM_ALL
+
+  gadgetlib2/examples/tutorial.cpp
+  gadgetlib2/examples/simple_example.cpp
+  gadgetlib2/examples/simple_example.hpp
+)
+target_link_libraries(
+  gadgetlib2_tutorial
+
+  snark
+  gtest_main
+)
+
+add_executable(
   relations_qap_test
   EXCLUDE_FROM_ALL
 


### PR DESCRIPTION
From build directory:
cmake ..
make gadgetlib2_tutorial

Run resulting binary:
./libsnark/gadgetlib2_tutorial

Signed-off-by: Dan Middleton <dan.middleton@intel.com>