### PR TITLE
Fix comment on closing header guard

### DIFF
--- a/libsnark/gadgetlib1/examples/simple_example.tcc
+++ b/libsnark/gadgetlib1/examples/simple_example.tcc
@@ -45,4 +45,4 @@ r1cs_example<FieldT> gen_r1cs_example_from_protoboard(const size_t num_constrain
 }
 
 } // libsnark
-#endif // R1CS_EXAMPLES_TCC_
+#endif // SIMPLE_EXAMPLE_TCC_


### PR DESCRIPTION
Fix copy / paste error in gadgetlib1 example comment

Signed-off-by: Dan Middleton <dan.middleton@intel.com>