### PR TITLE
Used r1cs_auxiliary_input instead of r1cs_primary_input for consistency

### DIFF
--- a/libsnark/gadgetlib1/protoboard.tcc
+++ b/libsnark/gadgetlib1/protoboard.tcc
@@ -177,7 +177,7 @@ r1cs_primary_input<FieldT> protoboard<FieldT>::primary_input() const
 template<typename FieldT>
 r1cs_auxiliary_input<FieldT> protoboard<FieldT>::auxiliary_input() const
 {
-    return r1cs_primary_input<FieldT>(values.begin() + num_inputs(), values.end());
+    return r1cs_auxiliary_input<FieldT>(values.begin() + num_inputs(), values.end());
 }
 
 template<typename FieldT>


### PR DESCRIPTION
In the `auxiliary_input()` function of the `gadgetlib1/protoboard.tcc` file, a `r1cs_primary_input` object is returned in the return statement: 
```
return r1cs_primary_input<FieldT>(values.begin() + num_inputs(), values.end());
```

While `r1cs_primary_input`, and `r1cs_auxiliary_input` are basically different aliases for `std::vector<FieldT>`; I guess, it's better to use `r1cs_auxiliary_input` here to keep it consistent.