### PR TITLE
Properly export include directory in CMake target

### DIFF
--- a/libsnark/CMakeLists.txt
+++ b/libsnark/CMakeLists.txt
@@ -73,6 +73,8 @@ else()
   )
 endif()
 
+target_include_directories(snark INTERFACE ..)
+
 install(
   DIRECTORY "" DESTINATION "include/libsnark"
   FILES_MATCHING


### PR DESCRIPTION
Right now this doesn't get exported so if you vendor libsnark as part of a cmake build rather than `make install`-ing it, you don't get the include directory automatically set. This fixes that.