### PR TITLE
changes to field and member assignment in G1_variable

### DIFF
--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp
@@ -26,9 +26,9 @@ namespace libsnark {
  * Gadget that represents a G1 variable.
  */
 template<typename ppT>
-class G1_variable : public gadget<libff::Fr<ppT> > {
+class G1_variable : public gadget<libff::Fq<ppT> > {
 public:
-    typedef libff::Fr<ppT> FieldT;
+    typedef libff::Fq<ppT> FieldT;
 
     pb_linear_combination<FieldT> X;
     pb_linear_combination<FieldT> Y;
@@ -53,9 +53,9 @@ public:
  * Gadget that creates constraints for the validity of a G1 variable.
  */
 template<typename ppT>
-class G1_checker_gadget : public gadget<libff::Fr<ppT> > {
+class G1_checker_gadget : public gadget<libff::Fq<ppT> > {
 public:
-    typedef libff::Fr<ppT> FieldT;
+    typedef libff::Fq<ppT> FieldT;
 
     G1_variable<ppT> P;
     pb_variable<FieldT> P_X_squared;
@@ -72,9 +72,9 @@ public:
  * Gadget that creates constraints for G1 addition.
  */
 template<typename ppT>
-class G1_add_gadget : public gadget<libff::Fr<ppT> > {
+class G1_add_gadget : public gadget<libff::Fq<ppT> > {
 public:
-    typedef libff::Fr<ppT> FieldT;
+    typedef libff::Fq<ppT> FieldT;
 
     pb_variable<FieldT> lambda;
     pb_variable<FieldT> inv;
@@ -96,9 +96,9 @@ public:
  * Gadget that creates constraints for G1 doubling.
  */
 template<typename ppT>
-class G1_dbl_gadget : public gadget<libff::Fr<ppT> > {
+class G1_dbl_gadget : public gadget<libff::Fq<ppT> > {
 public:
-    typedef libff::Fr<ppT> FieldT;
+    typedef libff::Fq<ppT> FieldT;
 
     pb_variable<FieldT> Xsquared;
     pb_variable<FieldT> lambda;
@@ -118,9 +118,9 @@ public:
  * Gadget that creates constraints for G1 multi-scalar multiplication.
  */
 template<typename ppT>
-class G1_multiscalar_mul_gadget : public gadget<libff::Fr<ppT> > {
+class G1_multiscalar_mul_gadget : public gadget<libff::Fq<ppT> > {
 public:
-    typedef libff::Fr<ppT> FieldT;
+    typedef libff::Fq<ppT> FieldT;
 
     std::vector<G1_variable<ppT> > computed_results;
     std::vector<G1_variable<ppT> > chosen_results;

--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
@@ -42,8 +42,8 @@ G1_variable<ppT>::G1_variable(protoboard<FieldT> &pb,
     libff::G1<other_curve<ppT> > Pcopy = P;
     Pcopy.to_affine_coordinates();
 
-    X.assign(pb, Pcopy.X());
-    Y.assign(pb, Pcopy.Y());
+    X.assign(pb, Pcopy.X);
+    Y.assign(pb, Pcopy.Y);
     X.evaluate(pb);
     Y.evaluate(pb);
     all_vars.emplace_back(X);
@@ -316,8 +316,8 @@ void G1_multiscalar_mul_gadget<ppT>::generate_r1cs_witness()
     for (size_t i = 0; i < scalar_size; ++i)
     {
         adders[i].generate_r1cs_witness();
-        this->pb.lc_val(chosen_results[i+1].X) = (this->pb.val(scalars[i]) == libff::Fr<ppT>::zero() ? this->pb.lc_val(chosen_results[i].X) : this->pb.lc_val(computed_results[i].X));
-        this->pb.lc_val(chosen_results[i+1].Y) = (this->pb.val(scalars[i]) == libff::Fr<ppT>::zero() ? this->pb.lc_val(chosen_results[i].Y) : this->pb.lc_val(computed_results[i].Y));
+        this->pb.lc_val(chosen_results[i+1].X) = (this->pb.val(scalars[i]) == libff::Fq<ppT>::zero() ? this->pb.lc_val(chosen_results[i].X) : this->pb.lc_val(computed_results[i].X));
+        this->pb.lc_val(chosen_results[i+1].Y) = (this->pb.val(scalars[i]) == libff::Fq<ppT>::zero() ? this->pb.lc_val(chosen_results[i].Y) : this->pb.lc_val(computed_results[i].Y));
     }
 }
 


### PR DESCRIPTION
To get some tests for the weierstrass_g1_gadget working, I had to fix these issues

- Line 45 and 46 of the original weierstrass_g1_gadget.tcc has been changed to X.assign(pb, Pcopy.X); Y.assign(pb, Pcopy.Y);
- The field FieldT is changed to reflect libff::Fq<ppT> instead of libff::Fr<ppT>. The group G1 is defined on the curve Y^2 = X^3 + 3 over the field Fq with p = 21888242871839275222246405745257275088696311157297823662689037894645226208583