### PR TITLE
Fix for SHA256 components to work on 32bit platforms

### DIFF
--- a/libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_components.hpp
+++ b/libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_components.hpp
@@ -78,7 +78,7 @@ public:
     pb_linear_combination_array<FieldT> g;
     pb_linear_combination_array<FieldT> h;
     pb_variable<FieldT> W;
-    long K;
+    const FieldT K;
     pb_linear_combination_array<FieldT> new_a;
     pb_linear_combination_array<FieldT> new_e;
 
@@ -92,7 +92,7 @@ public:
                                  const pb_linear_combination_array<FieldT> &g,
                                  const pb_linear_combination_array<FieldT> &h,
                                  const pb_variable<FieldT> &W,
-                                 const long &K,
+                                 const unsigned long &K,
                                  const pb_linear_combination_array<FieldT> &new_a,
                                  const pb_linear_combination_array<FieldT> &new_e,
                                  const std::string &annotation_prefix);

--- a/libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_components.tcc
+++ b/libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_components.tcc
@@ -149,7 +149,7 @@ sha256_round_function_gadget<FieldT>::sha256_round_function_gadget(protoboard<Fi
                                                                    const pb_linear_combination_array<FieldT> &g,
                                                                    const pb_linear_combination_array<FieldT> &h,
                                                                    const pb_variable<FieldT> &W,
-                                                                   const long &K,
+                                                                   const unsigned long &K,
                                                                    const pb_linear_combination_array<FieldT> &new_a,
                                                                    const pb_linear_combination_array<FieldT> &new_e,
                                                                    const std::string &annotation_prefix) :
@@ -163,7 +163,7 @@ sha256_round_function_gadget<FieldT>::sha256_round_function_gadget(protoboard<Fi
     g(g),
     h(h),
     W(W),
-    K(K),
+    K(K, true),
     new_a(new_a),
     new_e(new_e)
 {


### PR DESCRIPTION
Fixes #157 without modifying `libff`