### PR TITLE
Increase cmake version (helps with building on Mac OS X)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 project (libsnark)
 


### PR DESCRIPTION
Setting version to 3.1 enables using CMAKE_PREFIX_PATH to specify pkg-config locations (see https://github.com/Kitware/CMake/blob/master/Modules/FindPkgConfig.cmake#L115). This heps for example on Mac OS X if you want to provide a location for libcrypto. With this patch I was able to compile libsnark with

"cmake .. -DCMAKE_PREFIX_PATH=/usr/local/Cellar/openssl/1.0.2s -DWITH_PROCPS=OFF -DWITH_SUPERCOP=OFF"