### PR TITLE
Update libff to its latest version in develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ libsnark/zk_proof_systems/zksnark/ram_zksnark/profiling/profile_ram_zksnark
 libsnark/zk_proof_systems/zksnark/ram_zksnark/tests/test_ram_zksnark
 
 build
+.vscode

--- a/libsnark/gadgetlib1/gadgets/basic_gadgets.tcc
+++ b/libsnark/gadgetlib1/gadgets/basic_gadgets.tcc
@@ -108,7 +108,7 @@ void multipacking_gadget<FieldT>::generate_r1cs_witness_from_bits()
 template<typename FieldT>
 size_t multipacking_num_chunks(const size_t num_bits)
 {
-    return libff::div_ceil(num_bits, FieldT::capacity());
+    return libff::div_ceil(num_bits, FieldT::floor_size_in_bits());
 }
 
 template<typename FieldT>

--- a/libsnark/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
+++ b/libsnark/gadgetlib1/gadgets/cpu_checkers/tinyram/tinyram_cpu_checker.tcc
@@ -14,7 +14,7 @@
 #ifndef TINYRAM_CPU_CHECKER_TCC_
 #define TINYRAM_CPU_CHECKER_TCC_
 
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 
 namespace libsnark {
 

--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.tcc
@@ -42,8 +42,8 @@ G1_variable<ppT>::G1_variable(protoboard<FieldT> &pb,
     libff::G1<other_curve<ppT> > Pcopy = P;
     Pcopy.to_affine_coordinates();
 
-    X.assign(pb, Pcopy.X());
-    Y.assign(pb, Pcopy.Y());
+    X.assign(pb, Pcopy.X);
+    Y.assign(pb, Pcopy.Y);
     X.evaluate(pb);
     Y.evaluate(pb);
     all_vars.emplace_back(X);
@@ -56,14 +56,14 @@ void G1_variable<ppT>::generate_r1cs_witness(const libff::G1<other_curve<ppT> > 
     libff::G1<other_curve<ppT> > el_normalized = el;
     el_normalized.to_affine_coordinates();
 
-    this->pb.lc_val(X) = el_normalized.X();
-    this->pb.lc_val(Y) = el_normalized.Y();
+    this->pb.lc_val(X) = el_normalized.X;
+    this->pb.lc_val(Y) = el_normalized.Y;
 }
 
 template<typename ppT>
 size_t G1_variable<ppT>::size_in_bits()
 {
-    return 2 * FieldT::size_in_bits();
+    return 2 * FieldT::ceil_size_in_bits();
 }
 
 template<typename ppT>

--- a/libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.tcc
@@ -39,8 +39,8 @@ G2_variable<ppT>::G2_variable(protoboard<FieldT> &pb,
     libff::G2<other_curve<ppT> > Q_copy = Q;
     Q_copy.to_affine_coordinates();
 
-    X.reset(new Fqe_variable<ppT>(pb, Q_copy.X(), FMT(annotation_prefix, " X")));
-    Y.reset(new Fqe_variable<ppT>(pb, Q_copy.Y(), FMT(annotation_prefix, " Y")));
+    X.reset(new Fqe_variable<ppT>(pb, Q_copy.X, FMT(annotation_prefix, " X")));
+    Y.reset(new Fqe_variable<ppT>(pb, Q_copy.Y, FMT(annotation_prefix, " Y")));
 
     all_vars.insert(all_vars.end(), X->all_vars.begin(), X->all_vars.end());
     all_vars.insert(all_vars.end(), Y->all_vars.begin(), Y->all_vars.end());
@@ -52,8 +52,8 @@ void G2_variable<ppT>::generate_r1cs_witness(const libff::G2<other_curve<ppT> > 
     libff::G2<other_curve<ppT> > Qcopy = Q;
     Qcopy.to_affine_coordinates();
 
-    X->generate_r1cs_witness(Qcopy.X());
-    Y->generate_r1cs_witness(Qcopy.Y());
+    X->generate_r1cs_witness(Qcopy.X);
+    Y->generate_r1cs_witness(Qcopy.Y);
 }
 
 template<typename ppT>

--- a/libsnark/gadgetlib1/gadgets/fields/exponentiation_gadget.hpp
+++ b/libsnark/gadgetlib1/gadgets/fields/exponentiation_gadget.hpp
@@ -15,7 +15,7 @@
 #include <memory>
 #include <vector>
 
-#include <libff/algebra/fields/bigint.hpp>
+#include <libff/algebra/field_utils/bigint.hpp>
 #include <libff/algebra/scalar_multiplication/wnaf.hpp>
 
 #include <libsnark/gadgetlib1/gadget.hpp>

--- a/libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.tcc
+++ b/libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.tcc
@@ -150,7 +150,7 @@ bool Fp2_variable<Fp2T>::is_constant() const
 template<typename Fp2T>
 size_t Fp2_variable<Fp2T>::size_in_bits()
 {
-    return 2 * FieldT::size_in_bits();
+    return 2 * FieldT::ceil_size_in_bits();
 }
 
 template<typename Fp2T>

--- a/libsnark/gadgetlib1/gadgets/fields/fp3_gadgets.tcc
+++ b/libsnark/gadgetlib1/gadgets/fields/fp3_gadgets.tcc
@@ -169,7 +169,7 @@ bool Fp3_variable<Fp3T>::is_constant() const
 template<typename Fp3T>
 size_t Fp3_variable<Fp3T>::size_in_bits()
 {
-    return 3 * FieldT::size_in_bits();
+    return 3 * FieldT::ceil_size_in_bits();
 }
 
 template<typename Fp3T>

--- a/libsnark/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.tcc
@@ -14,7 +14,7 @@
 #ifndef KNAPSACK_GADGET_TCC_
 #define KNAPSACK_GADGET_TCC_
 
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 #include <libff/common/rng.hpp>
 
 namespace libsnark {
@@ -153,8 +153,8 @@ knapsack_CRH_with_bit_out_gadget<FieldT>::knapsack_CRH_with_bit_out_gadget(proto
 
     for (size_t i = 0; i < dimension; ++i)
     {
-        output[i].assign(pb, pb_packing_sum<FieldT>(pb_variable_array<FieldT>(output_digest.bits.begin() + i * FieldT::size_in_bits(),
-                                                                              output_digest.bits.begin() + (i + 1) * FieldT::size_in_bits())));
+        output[i].assign(pb, pb_packing_sum<FieldT>(pb_variable_array<FieldT>(output_digest.bits.begin() + i * FieldT::ceil_size_in_bits(),
+                                                                              output_digest.bits.begin() + (i + 1) * FieldT::ceil_size_in_bits())));
     }
 
     hasher.reset(new knapsack_CRH_with_field_out_gadget<FieldT>(pb, input_len, input_block, output, FMT(annotation_prefix, " hasher")));
@@ -184,8 +184,8 @@ void knapsack_CRH_with_bit_out_gadget<FieldT>::generate_r1cs_witness()
     const libff::bit_vector input = input_block.bits.get_bits(this->pb);
     for (size_t i = 0; i < dimension; ++i)
     {
-        pb_variable_array<FieldT> va(output_digest.bits.begin() + i * FieldT::size_in_bits(),
-                                     output_digest.bits.begin() + (i + 1) * FieldT::size_in_bits());
+        pb_variable_array<FieldT> va(output_digest.bits.begin() + i * FieldT::ceil_size_in_bits(),
+                                     output_digest.bits.begin() + (i + 1) * FieldT::ceil_size_in_bits());
         va.fill_with_bits_of_field_element(this->pb, this->pb.lc_val(output[i]));
     }
 }
@@ -193,7 +193,7 @@ void knapsack_CRH_with_bit_out_gadget<FieldT>::generate_r1cs_witness()
 template<typename FieldT>
 size_t knapsack_CRH_with_bit_out_gadget<FieldT>::get_digest_len()
 {
-    return knapsack_dimension<FieldT>::dimension * FieldT::size_in_bits();
+    return knapsack_dimension<FieldT>::dimension * FieldT::ceil_size_in_bits();
 }
 
 template<typename FieldT>

--- a/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.tcc
@@ -73,7 +73,7 @@ merkle_tree_check_read_gadget<FieldT, HashT>::merkle_tree_check_read_gadget(prot
                                                                 FMT(this->annotation_prefix, " digest_selector_%zu", i)));
     }
 
-    check_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_root->bits, root.bits, read_successful, FieldT::capacity(), FMT(annotation_prefix, " check_root")));
+    check_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_root->bits, root.bits, read_successful, FieldT::floor_size_in_bits(), FMT(annotation_prefix, " check_root")));
 }
 
 template<typename FieldT, typename HashT>
@@ -124,7 +124,7 @@ size_t merkle_tree_check_read_gadget<FieldT, HashT>::expected_constraints(const 
     const size_t hasher_constraints = tree_depth * HashT::expected_constraints(false);
     const size_t propagator_constraints = tree_depth * HashT::get_digest_len();
     const size_t authentication_path_constraints = 2 * tree_depth * HashT::get_digest_len();
-    const size_t check_root_constraints = 3 * libff::div_ceil(HashT::get_digest_len(), FieldT::capacity());
+    const size_t check_root_constraints = 3 * libff::div_ceil(HashT::get_digest_len(), FieldT::floor_size_in_bits());
 
     return hasher_constraints + propagator_constraints + authentication_path_constraints + check_root_constraints;
 }

--- a/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.tcc
@@ -74,7 +74,7 @@ merkle_tree_check_update_gadget<FieldT, HashT>::merkle_tree_check_update_gadget(
                                                                      FMT(this->annotation_prefix, " next_propagators_%zu", i)));
     }
 
-    check_next_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_next_root->bits, next_root_digest.bits, update_successful, FieldT::capacity(), FMT(annotation_prefix, " check_next_root")));
+    check_next_root.reset(new bit_vector_copy_gadget<FieldT>(pb, computed_next_root->bits, next_root_digest.bits, update_successful, FieldT::floor_size_in_bits(), FMT(annotation_prefix, " check_next_root")));
 }
 
 template<typename FieldT, typename HashT>
@@ -169,7 +169,7 @@ size_t merkle_tree_check_update_gadget<FieldT, HashT>::expected_constraints(cons
     const size_t prev_authentication_path_constraints = 2 * tree_depth * HashT::get_digest_len();
     const size_t prev_propagator_constraints = tree_depth * HashT::get_digest_len();
     const size_t next_propagator_constraints = tree_depth * HashT::get_digest_len();
-    const size_t check_next_root_constraints = 3 * libff::div_ceil(HashT::get_digest_len(), FieldT::capacity());
+    const size_t check_next_root_constraints = 3 * libff::div_ceil(HashT::get_digest_len(), FieldT::floor_size_in_bits());
     const size_t aux_equality_constraints = tree_depth * HashT::get_digest_len();
 
     return (prev_hasher_constraints + next_hasher_constraints + prev_authentication_path_constraints +

--- a/libsnark/gadgetlib1/gadgets/pairing/weierstrass_precomputation.tcc
+++ b/libsnark/gadgetlib1/gadgets/pairing/weierstrass_precomputation.tcc
@@ -34,7 +34,7 @@ G1_precomputation<ppT>::G1_precomputation(protoboard<FieldT> &pb,
     libff::G1<other_curve<ppT> > P_val_copy = P_val;
     P_val_copy.to_affine_coordinates();
     P.reset(new G1_variable<ppT>(pb, P_val_copy, FMT(annotation_prefix, " P")));
-    PY_twist_squared.reset(new Fqe_variable<ppT>(pb, P_val_copy.Y() * libff::G2<other_curve<ppT> >::twist.squared(), " PY_twist_squared"));
+    PY_twist_squared.reset(new Fqe_variable<ppT>(pb, P_val_copy.Y * libff::G2<other_curve<ppT> >::twist.squared(), " PY_twist_squared"));
 }
 
 template<typename ppT>

--- a/libsnark/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/routing/as_waksman_routing_gadget.tcc
@@ -34,7 +34,7 @@ as_waksman_routing_gadget<FieldT>::as_waksman_routing_gadget(protoboard<FieldT> 
     routing_input_bits(routing_input_bits),
     routing_output_bits(routing_output_bits),
     packet_size(routing_input_bits[0].size()),
-    num_subpackets(libff::div_ceil(packet_size, FieldT::capacity()))
+    num_subpackets(libff::div_ceil(packet_size, FieldT::floor_size_in_bits()))
 {
     neighbors = generate_as_waksman_topology(num_packets);
     routed_packets.resize(num_columns+1);
@@ -78,13 +78,13 @@ as_waksman_routing_gadget<FieldT>::as_waksman_routing_gadget(protoboard<FieldT> 
             multipacking_gadget<FieldT>(pb,
                                         pb_variable_array<FieldT>(routing_input_bits[packet_idx].begin(), routing_input_bits[packet_idx].end()),
                                         routed_packets[0][packet_idx],
-                                        FieldT::capacity(),
+                                        FieldT::floor_size_in_bits(),
                                         FMT(this->annotation_prefix, " pack_inputs_%zu", packet_idx)));
         unpack_outputs.emplace_back(
             multipacking_gadget<FieldT>(pb,
                                         pb_variable_array<FieldT>(routing_output_bits[packet_idx].begin(), routing_output_bits[packet_idx].end()),
                                         routed_packets[num_columns][packet_idx],
-                                        FieldT::capacity(),
+                                        FieldT::floor_size_in_bits(),
                                         FMT(this->annotation_prefix, " unpack_outputs_%zu", packet_idx)));
     }
 
@@ -245,7 +245,7 @@ void as_waksman_routing_gadget<FieldT>::generate_r1cs_witness(const integer_perm
 template<typename FieldT>
 void test_as_waksman_routing_gadget(const size_t num_packets, const size_t packet_size)
 {
-    printf("testing as_waksman_routing_gadget by routing %zu element vector of %zu bits (Fp fits all %zu bit integers)\n", num_packets, packet_size, FieldT::capacity());
+    printf("testing as_waksman_routing_gadget by routing %zu element vector of %zu bits (Fp fits all %zu bit integers)\n", num_packets, packet_size, FieldT::floor_size_in_bits());
     protoboard<FieldT> pb;
     integer_permutation permutation(num_packets);
     permutation.random_shuffle();

--- a/libsnark/gadgetlib1/gadgets/routing/benes_routing_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/routing/benes_routing_gadget.tcc
@@ -34,7 +34,7 @@ benes_routing_gadget<FieldT>::benes_routing_gadget(protoboard<FieldT> &pb,
     routing_output_bits(routing_output_bits),
     lines_to_unpack(lines_to_unpack),
     packet_size(routing_input_bits[0].size()),
-    num_subpackets(libff::div_ceil(packet_size, FieldT::capacity()))
+    num_subpackets(libff::div_ceil(packet_size, FieldT::floor_size_in_bits()))
 {
     assert(lines_to_unpack <= routing_input_bits.size());
     assert(num_packets == 1ul<<libff::log2(num_packets));
@@ -61,7 +61,7 @@ benes_routing_gadget<FieldT>::benes_routing_gadget(protoboard<FieldT> &pb,
             multipacking_gadget<FieldT>(pb,
                                         pb_variable_array<FieldT>(routing_input_bits[packet_idx].begin(), routing_input_bits[packet_idx].end()),
                                         routed_packets[0][packet_idx],
-                                        FieldT::capacity(),
+                                        FieldT::floor_size_in_bits(),
                                         FMT(this->annotation_prefix, " pack_inputs_%zu", packet_idx)));
         if (packet_idx < lines_to_unpack)
         {
@@ -69,7 +69,7 @@ benes_routing_gadget<FieldT>::benes_routing_gadget(protoboard<FieldT> &pb,
                 multipacking_gadget<FieldT>(pb,
                                             pb_variable_array<FieldT>(routing_output_bits[packet_idx].begin(), routing_output_bits[packet_idx].end()),
                                             routed_packets[num_columns][packet_idx],
-                                            FieldT::capacity(),
+                                            FieldT::floor_size_in_bits(),
                                             FMT(this->annotation_prefix, " unpack_outputs_%zu", packet_idx)));
         }
     }
@@ -196,7 +196,7 @@ void test_benes_routing_gadget(const size_t num_packets, const size_t packet_siz
     const size_t dimension = libff::log2(num_packets);
     assert(num_packets == 1ul<<dimension);
 
-    printf("testing benes_routing_gadget by routing 2^%zu-entry vector of %zu bits (Fp fits all %zu bit integers)\n", dimension, packet_size, FieldT::capacity());
+    printf("testing benes_routing_gadget by routing 2^%zu-entry vector of %zu bits (Fp fits all %zu bit integers)\n", dimension, packet_size, FieldT::floor_size_in_bits());
 
     protoboard<FieldT> pb;
     integer_permutation permutation(num_packets);

--- a/libsnark/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/verifiers/r1cs_ppzksnark_verifier_gadget.tcc
@@ -148,7 +148,7 @@ r1cs_ppzksnark_verification_key_variable<ppT>::r1cs_ppzksnark_verification_key_v
     assert(all_G2_vars.size() == num_G2);
     assert(all_vars.size() == (num_G1 * G1_variable<ppT>::num_variables() + num_G2 * G2_variable<ppT>::num_variables()));
 
-    packer.reset(new multipacking_gadget<FieldT>(pb, all_bits, all_vars, FieldT::size_in_bits(), FMT(annotation_prefix, " packer")));
+    packer.reset(new multipacking_gadget<FieldT>(pb, all_bits, all_vars, FieldT::ceil_size_in_bits(), FMT(annotation_prefix, " packer")));
 }
 
 template<typename ppT>

--- a/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/verifiers/tests/test_r1cs_ppzksnark_verifier_gadget.cpp
@@ -6,7 +6,7 @@
  *****************************************************************************/
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 
 #include <libsnark/gadgetlib1/gadgets/fields/fp2_gadgets.hpp>
 #include <libsnark/gadgetlib1/gadgets/fields/fp3_gadgets.hpp>
@@ -49,7 +49,7 @@ void test_verifier(const std::string &annotation_A, const std::string &annotatio
     bool bit = r1cs_ppzksnark_verifier_strong_IC<ppT_A>(keypair.vk, example.primary_input, pi);
     assert(bit);
 
-    const size_t elt_size = FieldT_A::size_in_bits();
+    const size_t elt_size = FieldT_A::ceil_size_in_bits();
     const size_t primary_input_size_in_bits = elt_size * primary_input_size;
     const size_t vk_size_in_bits = r1cs_ppzksnark_verification_key_variable<ppT_B>::size_in_bits(primary_input_size);
 
@@ -121,7 +121,7 @@ void test_hardcoded_verifier(const std::string &annotation_A, const std::string 
     bool bit = r1cs_ppzksnark_verifier_strong_IC<ppT_A>(keypair.vk, example.primary_input, pi);
     assert(bit);
 
-    const size_t elt_size = FieldT_A::size_in_bits();
+    const size_t elt_size = FieldT_A::ceil_size_in_bits();
     const size_t primary_input_size_in_bits = elt_size * primary_input_size;
 
     protoboard<FieldT_B> pb;

--- a/libsnark/gadgetlib2/pp.cpp
+++ b/libsnark/gadgetlib2/pp.cpp
@@ -24,7 +24,7 @@ PublicParams::~PublicParams() {}
 
 PublicParams initPublicParamsFromDefaultPp() {
     libff::default_ec_pp::init_public_params();
-    const std::size_t log_p = libff::Fr<libff::default_ec_pp>::size_in_bits();
+    const std::size_t log_p = libff::Fr<libff::default_ec_pp>::ceil_size_in_bits();
     return PublicParams(log_p);
 }
 

--- a/libsnark/knowledge_commitment/knowledge_commitment.hpp
+++ b/libsnark/knowledge_commitment/knowledge_commitment.hpp
@@ -14,7 +14,7 @@
 #ifndef KNOWLEDGE_COMMITMENT_HPP_
 #define KNOWLEDGE_COMMITMENT_HPP_
 
-#include <libff/algebra/fields/fp.hpp>
+#include <libff/algebra/fields/prime_base/fp.hpp>
 
 #include <libsnark/common/data_structures/sparse_vector.hpp>
 

--- a/libsnark/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
+++ b/libsnark/reductions/ram_to_r1cs/gadgets/ram_universal_gadget.tcc
@@ -14,7 +14,7 @@
 #ifndef RAM_UNIVERSAL_GADGET_TCC_
 #define RAM_UNIVERSAL_GADGET_TCC_
 
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 
@@ -69,7 +69,7 @@ ram_universal_gadget<ramT>::ram_universal_gadget(ram_protoboard<ramT> &pb,
     /* deal with packing of the input */
     libff::enter_block("Pack input");
     const size_t line_size_bits = pb.ap.address_size() + pb.ap.value_size();
-    const size_t max_chunk_size = FieldT::capacity();
+    const size_t max_chunk_size = FieldT::floor_size_in_bits();
     const size_t packed_line_size = libff::div_ceil(line_size_bits, max_chunk_size);
     assert(packed_input.size() == packed_line_size * boot_trace_size_bound);
 
@@ -411,7 +411,7 @@ template<typename ramT>
 size_t ram_universal_gadget<ramT>::packed_input_element_size(const ram_architecture_params<ramT> &ap)
 {
     const size_t line_size_bits = ap.address_size() + ap.value_size();
-    const size_t max_chunk_size = FieldT::capacity();
+    const size_t max_chunk_size = FieldT::floor_size_in_bits();
     const size_t packed_line_size = libff::div_ceil(line_size_bits, max_chunk_size);
 
     return packed_line_size;

--- a/libsnark/reductions/tbcs_to_uscs/tbcs_to_uscs.tcc
+++ b/libsnark/reductions/tbcs_to_uscs/tbcs_to_uscs.tcc
@@ -14,7 +14,7 @@ See tbcs_to_uscs.hpp .
 #ifndef TBCS_TO_USCS_TCC_
 #define TBCS_TO_USCS_TCC_
 
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 
 namespace libsnark {
 

--- a/libsnark/relations/arithmetic_programs/qap/tests/test_qap.cpp
+++ b/libsnark/relations/arithmetic_programs/qap/tests/test_qap.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 

--- a/libsnark/relations/arithmetic_programs/sap/tests/test_sap.cpp
+++ b/libsnark/relations/arithmetic_programs/sap/tests/test_sap.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 

--- a/libsnark/relations/arithmetic_programs/ssp/tests/test_ssp.cpp
+++ b/libsnark/relations/arithmetic_programs/ssp/tests/test_ssp.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 

--- a/libsnark/relations/constraint_satisfaction_problems/r1cs/r1cs.tcc
+++ b/libsnark/relations/constraint_satisfaction_problems/r1cs/r1cs.tcc
@@ -21,7 +21,7 @@
 #include <cassert>
 #include <set>
 
-#include <libff/algebra/fields/bigint.hpp>
+#include <libff/algebra/field_utils/bigint.hpp>
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 

--- a/libsnark/relations/constraint_satisfaction_problems/uscs/uscs.tcc
+++ b/libsnark/relations/constraint_satisfaction_problems/uscs/uscs.tcc
@@ -21,7 +21,7 @@
 #include <cassert>
 #include <set>
 
-#include <libff/algebra/fields/bigint.hpp>
+#include <libff/algebra/field_utils/bigint.hpp>
 #include <libff/common/profiling.hpp>
 #include <libff/common/utils.hpp>
 

--- a/libsnark/relations/variable.tcc
+++ b/libsnark/relations/variable.tcc
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <cassert>
 
-#include <libff/algebra/fields/bigint.hpp>
+#include <libff/algebra/field_utils/bigint.hpp>
 
 namespace libsnark {
 

--- a/libsnark/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.tcc
+++ b/libsnark/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/examples/tally_cp.tcc
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <functional>
 
-#include <libff/algebra/fields/field_utils.hpp>
+#include <libff/algebra/field_utils/field_utils.hpp>
 
 namespace libsnark {
 

--- a/libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
+++ b/libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.tcc
@@ -483,7 +483,7 @@ void mp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_witness(const set_
 template<typename ppT>
 size_t mp_compliance_step_pcd_circuit_maker<ppT>::field_logsize()
 {
-    return libff::Fr<ppT>::size_in_bits();
+    return libff::Fr<ppT>::ceil_size_in_bits();
 }
 
 template<typename ppT>
@@ -597,7 +597,7 @@ r1cs_auxiliary_input<libff::Fr<ppT> > mp_translation_step_pcd_circuit_maker<ppT>
 template<typename ppT>
 size_t mp_translation_step_pcd_circuit_maker<ppT>::field_logsize()
 {
-    return libff::Fr<ppT>::size_in_bits();
+    return libff::Fr<ppT>::ceil_size_in_bits();
 }
 
 template<typename ppT>

--- a/libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
+++ b/libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.tcc
@@ -324,7 +324,7 @@ void sp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_witness(const r1cs
 template<typename ppT>
 size_t sp_compliance_step_pcd_circuit_maker<ppT>::field_logsize()
 {
-    return libff::Fr<ppT>::size_in_bits();
+    return libff::Fr<ppT>::ceil_size_in_bits();
 }
 
 template<typename ppT>
@@ -446,7 +446,7 @@ r1cs_auxiliary_input<libff::Fr<ppT> > sp_translation_step_pcd_circuit_maker<ppT>
 template<typename ppT>
 size_t sp_translation_step_pcd_circuit_maker<ppT>::field_logsize()
 {
-    return libff::Fr<ppT>::size_in_bits();
+    return libff::Fr<ppT>::ceil_size_in_bits();
 }
 
 template<typename ppT>

--- a/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp
+++ b/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp
@@ -284,7 +284,7 @@ public:
 
     size_t size_in_bits() const
     {
-        return A_query.size_in_bits() + B_query.size_in_bits() + C_query.size_in_bits() + libff::size_in_bits(H_query) + libff::size_in_bits(K_query) + libff::G1<snark_pp<ppT>>::size_in_bits();
+        return A_query.size_in_bits() + B_query.size_in_bits() + C_query.size_in_bits() + libff::curve_size_in_bits(H_query) + libff::curve_size_in_bits(K_query) + libff::G1<snark_pp<ppT>>::size_in_bits();
     }
 
     void print_size() const

--- a/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
+++ b/libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.tcc
@@ -539,13 +539,13 @@ r1cs_ppzkadsnark_keypair<ppT> r1cs_ppzkadsnark_generator(const r1cs_ppzkadsnark_
 
     libff::enter_block("Generating G1 multiexp table");
     libff::window_table<libff::G1<snark_pp<ppT>> > g1_table =
-        get_window_table(libff::Fr<snark_pp<ppT>>::size_in_bits(), g1_window,
+        get_window_table(libff::Fr<snark_pp<ppT>>::ceil_size_in_bits(), g1_window,
                          libff::G1<snark_pp<ppT>>::one());
     libff::leave_block("Generating G1 multiexp table");
 
     libff::enter_block("Generating G2 multiexp table");
     libff::window_table<libff::G2<snark_pp<ppT>> > g2_table =
-        get_window_table(libff::Fr<snark_pp<ppT>>::size_in_bits(),
+        get_window_table(libff::Fr<snark_pp<ppT>>::ceil_size_in_bits(),
                          g2_window, libff::G2<snark_pp<ppT>>::one());
     libff::leave_block("Generating G2 multiexp table");
 
@@ -554,31 +554,31 @@ r1cs_ppzkadsnark_keypair<ppT> r1cs_ppzkadsnark_generator(const r1cs_ppzkadsnark_
     libff::enter_block("Generate knowledge commitments");
     libff::enter_block("Compute the A-query", false);
     knowledge_commitment_vector<libff::G1<snark_pp<ppT>>, libff::G1<snark_pp<ppT>> > A_query =
-        kc_batch_exp(libff::Fr<snark_pp<ppT>>::size_in_bits(), g1_window, g1_window, g1_table,
+        kc_batch_exp(libff::Fr<snark_pp<ppT>>::ceil_size_in_bits(), g1_window, g1_window, g1_table,
                      g1_table, rA, rA*alphaA, At, chunks);
     libff::leave_block("Compute the A-query", false);
 
     libff::enter_block("Compute the B-query", false);
     knowledge_commitment_vector<libff::G2<snark_pp<ppT>>, libff::G1<snark_pp<ppT>> > B_query =
-        kc_batch_exp(libff::Fr<snark_pp<ppT>>::size_in_bits(), g2_window, g1_window, g2_table,
+        kc_batch_exp(libff::Fr<snark_pp<ppT>>::ceil_size_in_bits(), g2_window, g1_window, g2_table,
                      g1_table, rB, rB*alphaB, Bt, chunks);
     libff::leave_block("Compute the B-query", false);
 
     libff::enter_block("Compute the C-query", false);
     knowledge_commitment_vector<libff::G1<snark_pp<ppT>>, libff::G1<snark_pp<ppT>> > C_query =
-        kc_batch_exp(libff::Fr<snark_pp<ppT>>::size_in_bits(), g1_window, g1_window, g1_table,
+        kc_batch_exp(libff::Fr<snark_pp<ppT>>::ceil_size_in_bits(), g1_window, g1_window, g1_table,
                      g1_table, rC, rC*alphaC, Ct, chunks);
     libff::leave_block("Compute the C-query", false);
 
     libff::enter_block("Compute the H-query", false);
-    libff::G1_vector<snark_pp<ppT>> H_query = batch_exp(libff::Fr<snark_pp<ppT>>::size_in_bits(), g1_window, g1_table, Ht);
+    libff::G1_vector<snark_pp<ppT>> H_query = batch_exp(libff::Fr<snark_pp<ppT>>::ceil_size_in_bits(), g1_window, g1_table, Ht);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<snark_pp<ppT>> >(H_query);
 #endif
     libff::leave_block("Compute the H-query", false);
 
     libff::enter_block("Compute the K-query", false);
-    libff::G1_vector<snark_pp<ppT>> K_query = batch_exp(libff::Fr<snark_pp<ppT>>::size_in_bits(), g1_window, g1_table, Kt);
+    libff::G1_vector<snark_pp<ppT>> K_query = batch_exp(libff::Fr<snark_pp<ppT>>::ceil_size_in_bits(), g1_window, g1_table, Kt);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<snark_pp<ppT>> >(K_query);
 #endif

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -130,8 +130,8 @@ public:
 
     size_t size_in_bits() const
     {
-        return (libff::size_in_bits(A_query) + B_query.size_in_bits() +
-                libff::size_in_bits(H_query) + libff::size_in_bits(L_query) +
+        return (libff::curve_size_in_bits(A_query) + B_query.size_in_bits() +
+                libff::curve_size_in_bits(H_query) + libff::curve_size_in_bits(L_query) +
                 1 * libff::G1<ppT>::size_in_bits() + 1 * libff::G2<ppT>::size_in_bits());
     }
 

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -296,7 +296,7 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     libff::enter_block("Generating G1 MSM window table");
     const libff::G1<ppT> g1_generator = libff::G1<ppT>::random_element();
     const size_t g1_scalar_count = non_zero_At + non_zero_Bt + qap.num_variables();
-    const size_t g1_scalar_size = libff::Fr<ppT>::size_in_bits();
+    const size_t g1_scalar_size = libff::Fr<ppT>::ceil_size_in_bits();
     const size_t g1_window_size = libff::get_exp_window_size<libff::G1<ppT> >(g1_scalar_count);
 
     libff::print_indent(); printf("* G1 window: %zu\n", g1_window_size);
@@ -306,7 +306,7 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     libff::enter_block("Generating G2 MSM window table");
     const libff::G2<ppT> G2_gen = libff::G2<ppT>::random_element();
     const size_t g2_scalar_count = non_zero_Bt;
-    const size_t g2_scalar_size = libff::Fr<ppT>::size_in_bits();
+    const size_t g2_scalar_size = libff::Fr<ppT>::ceil_size_in_bits();
     size_t g2_window_size = libff::get_exp_window_size<libff::G2<ppT> >(g2_scalar_count);
 
     libff::print_indent(); printf("* G2 window: %zu\n", g2_window_size);
@@ -329,7 +329,7 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     libff::leave_block("Compute the A-query", false);
 
     libff::enter_block("Compute the B-query", false);
-    knowledge_commitment_vector<libff::G2<ppT>, libff::G1<ppT> > B_query = kc_batch_exp(libff::Fr<ppT>::size_in_bits(), g2_window_size, g1_window_size, g2_table, g1_table, libff::Fr<ppT>::one(), libff::Fr<ppT>::one(), Bt, chunks);
+    knowledge_commitment_vector<libff::G2<ppT>, libff::G1<ppT> > B_query = kc_batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g2_window_size, g1_window_size, g2_table, g1_table, libff::Fr<ppT>::one(), libff::Fr<ppT>::one(), Bt, chunks);
     // NOTE: if USE_MIXED_ADDITION is defined,
     // kc_batch_exp will convert its output to special form internally
     libff::leave_block("Compute the B-query", false);

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp
@@ -122,7 +122,7 @@ public:
 
     size_t size_in_bits() const
     {
-        return A_query.size_in_bits() + B_query.size_in_bits() + C_query.size_in_bits() + libff::size_in_bits(H_query) + libff::size_in_bits(K_query);
+        return A_query.size_in_bits() + B_query.size_in_bits() + C_query.size_in_bits() + libff::curve_size_in_bits(H_query) + libff::curve_size_in_bits(K_query);
     }
 
     void print_size() const

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -339,37 +339,37 @@ r1cs_ppzksnark_keypair<ppT> r1cs_ppzksnark_generator(const r1cs_ppzksnark_constr
 #endif
 
     libff::enter_block("Generating G1 multiexp table");
-    libff::window_table<libff::G1<ppT> > g1_table = get_window_table(libff::Fr<ppT>::size_in_bits(), g1_window, libff::G1<ppT>::one());
+    libff::window_table<libff::G1<ppT> > g1_table = get_window_table(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, libff::G1<ppT>::one());
     libff::leave_block("Generating G1 multiexp table");
 
     libff::enter_block("Generating G2 multiexp table");
-    libff::window_table<libff::G2<ppT> > g2_table = get_window_table(libff::Fr<ppT>::size_in_bits(), g2_window, libff::G2<ppT>::one());
+    libff::window_table<libff::G2<ppT> > g2_table = get_window_table(libff::Fr<ppT>::ceil_size_in_bits(), g2_window, libff::G2<ppT>::one());
     libff::leave_block("Generating G2 multiexp table");
 
     libff::enter_block("Generate R1CS proving key");
 
     libff::enter_block("Generate knowledge commitments");
     libff::enter_block("Compute the A-query", false);
-    knowledge_commitment_vector<libff::G1<ppT>, libff::G1<ppT> > A_query = kc_batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_window, g1_table, g1_table, rA, rA*alphaA, At, chunks);
+    knowledge_commitment_vector<libff::G1<ppT>, libff::G1<ppT> > A_query = kc_batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_window, g1_table, g1_table, rA, rA*alphaA, At, chunks);
     libff::leave_block("Compute the A-query", false);
 
     libff::enter_block("Compute the B-query", false);
-    knowledge_commitment_vector<libff::G2<ppT>, libff::G1<ppT> > B_query = kc_batch_exp(libff::Fr<ppT>::size_in_bits(), g2_window, g1_window, g2_table, g1_table, rB, rB*alphaB, Bt, chunks);
+    knowledge_commitment_vector<libff::G2<ppT>, libff::G1<ppT> > B_query = kc_batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g2_window, g1_window, g2_table, g1_table, rB, rB*alphaB, Bt, chunks);
     libff::leave_block("Compute the B-query", false);
 
     libff::enter_block("Compute the C-query", false);
-    knowledge_commitment_vector<libff::G1<ppT>, libff::G1<ppT> > C_query = kc_batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_window, g1_table, g1_table, rC, rC*alphaC, Ct, chunks);
+    knowledge_commitment_vector<libff::G1<ppT>, libff::G1<ppT> > C_query = kc_batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_window, g1_table, g1_table, rC, rC*alphaC, Ct, chunks);
     libff::leave_block("Compute the C-query", false);
 
     libff::enter_block("Compute the H-query", false);
-    libff::G1_vector<ppT> H_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, Ht);
+    libff::G1_vector<ppT> H_query = batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_table, Ht);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(H_query);
 #endif
     libff::leave_block("Compute the H-query", false);
 
     libff::enter_block("Compute the K-query", false);
-    libff::G1_vector<ppT> K_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, Kt);
+    libff::G1_vector<ppT> K_query = batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_table, Kt);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(K_query);
 #endif
@@ -396,7 +396,7 @@ r1cs_ppzksnark_keypair<ppT> r1cs_ppzksnark_generator(const r1cs_ppzksnark_constr
     {
         multiplied_IC_coefficients.emplace_back(rA * IC_coefficients[i]);
     }
-    libff::G1_vector<ppT> encoded_IC_values = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, multiplied_IC_coefficients);
+    libff::G1_vector<ppT> encoded_IC_values = batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_table, multiplied_IC_coefficients);
 
     libff::leave_block("Encode IC query for R1CS verification key");
     libff::leave_block("Generate R1CS verification key");

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.tcc
@@ -281,7 +281,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
            G_window = libff::get_exp_window_size<libff::G1<ppT> >(G_exp_count);
     libff::print_indent(); printf("* G window: %zu\n", G_window);
     libff::window_table<libff::G1<ppT> > G_table = get_window_table(
-        libff::Fr<ppT>::size_in_bits(), G_window, G);
+        libff::Fr<ppT>::ceil_size_in_bits(), G_window, G);
     libff::leave_block("Generating G multiexp table");
 
     libff::enter_block("Generating H_gamma multiexp table");
@@ -290,7 +290,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
            H_gamma_window = libff::get_exp_window_size<libff::G2<ppT> >(H_gamma_exp_count);
     libff::print_indent(); printf("* H_gamma window: %zu\n", H_gamma_window);
     libff::window_table<libff::G2<ppT> > H_gamma_table = get_window_table(
-        libff::Fr<ppT>::size_in_bits(), H_gamma_window, H_gamma);
+        libff::Fr<ppT>::ceil_size_in_bits(), H_gamma_window, H_gamma);
     libff::leave_block("Generating H_gamma multiexp table");
 
     libff::enter_block("Generate R1CS verification key");
@@ -305,7 +305,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
     }
     libff::G1_vector<ppT> verifier_query = libff::batch_exp<libff::G1<ppT>,
                                                             libff::Fr<ppT> >(
-        libff::Fr<ppT>::size_in_bits(),
+        libff::Fr<ppT>::ceil_size_in_bits(),
         G_window,
         G_table,
         tmp_exponents);
@@ -324,7 +324,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
 
     libff::G1_vector<ppT> A_query = libff::batch_exp<libff::G1<ppT>,
                                                      libff::Fr<ppT> >(
-        libff::Fr<ppT>::size_in_bits(),
+        libff::Fr<ppT>::ceil_size_in_bits(),
         G_window,
         G_table,
         tmp_exponents);
@@ -337,7 +337,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
     libff::enter_block("Compute the B-query", false);
     libff::G2_vector<ppT> B_query = libff::batch_exp<libff::G2<ppT>,
                                                      libff::Fr<ppT> >(
-        libff::Fr<ppT>::size_in_bits(),
+        libff::Fr<ppT>::ceil_size_in_bits(),
         H_gamma_window,
         H_gamma_table,
         At);
@@ -364,7 +364,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
     }
     libff::G1_vector<ppT> G_gamma2_Z_t = libff::batch_exp<libff::G1<ppT>,
                                                           libff::Fr<ppT> >(
-        libff::Fr<ppT>::size_in_bits(),
+        libff::Fr<ppT>::ceil_size_in_bits(),
         G_window,
         G_table,
         tmp_exponents);
@@ -385,7 +385,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
     }
     libff::G1_vector<ppT> C_query_1 = libff::batch_exp<libff::G1<ppT>,
                                                        libff::Fr<ppT> >(
-        libff::Fr<ppT>::size_in_bits(),
+        libff::Fr<ppT>::ceil_size_in_bits(),
         G_window,
         G_table,
         tmp_exponents);
@@ -405,7 +405,7 @@ r1cs_se_ppzksnark_keypair<ppT> r1cs_se_ppzksnark_generator(const r1cs_se_ppzksna
     }
     libff::G1_vector<ppT> C_query_2 = libff::batch_exp<libff::G1<ppT>,
                                                        libff::Fr<ppT> >(
-        libff::Fr<ppT>::size_in_bits(),
+        libff::Fr<ppT>::ceil_size_in_bits(),
         G_window,
         G_table,
         tmp_exponents);

--- a/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.tcc
@@ -256,38 +256,38 @@ uscs_ppzksnark_keypair<ppT> uscs_ppzksnark_generator(const uscs_ppzksnark_constr
     libff::print_indent(); printf("* G2 window: %zu\n", g2_window);
 
     libff::enter_block("Generating G1 multiexp table");
-    libff::window_table<libff::G1<ppT> > g1_table = get_window_table(libff::Fr<ppT>::size_in_bits(), g1_window, libff::G1<ppT>::one());
+    libff::window_table<libff::G1<ppT> > g1_table = get_window_table(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, libff::G1<ppT>::one());
     libff::leave_block("Generating G1 multiexp table");
 
     libff::enter_block("Generating G2 multiexp table");
-    libff::window_table<libff::G2<ppT> > g2_table = get_window_table(libff::Fr<ppT>::size_in_bits(), g2_window, libff::G2<ppT>::one());
+    libff::window_table<libff::G2<ppT> > g2_table = get_window_table(libff::Fr<ppT>::ceil_size_in_bits(), g2_window, libff::G2<ppT>::one());
     libff::leave_block("Generating G2 multiexp table");
 
     libff::enter_block("Generate proof components");
 
     libff::enter_block("Compute the query for V_g1", false);
-    libff::G1_vector<ppT> V_g1_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, Vt_table_minus_Xt_table);
+    libff::G1_vector<ppT> V_g1_query = batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_table, Vt_table_minus_Xt_table);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(V_g1_query);
 #endif
     libff::leave_block("Compute the query for V_g1", false);
 
     libff::enter_block("Compute the query for alpha_V_g1", false);
-    libff::G1_vector<ppT> alpha_V_g1_query = batch_exp_with_coeff(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, alpha, Vt_table_minus_Xt_table);
+    libff::G1_vector<ppT> alpha_V_g1_query = batch_exp_with_coeff(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_table, alpha, Vt_table_minus_Xt_table);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(alpha_V_g1_query);
 #endif
     libff::leave_block("Compute the query for alpha_V_g1", false);
 
     libff::enter_block("Compute the query for H_g1", false);
-    libff::G1_vector<ppT> H_g1_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, Ht_table);
+    libff::G1_vector<ppT> H_g1_query = batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_table, Ht_table);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G1<ppT> >(H_g1_query);
 #endif
     libff::leave_block("Compute the query for H_g1", false);
 
     libff::enter_block("Compute the query for V_g2", false);
-    libff::G2_vector<ppT> V_g2_query = batch_exp(libff::Fr<ppT>::size_in_bits(), g2_window, g2_table, Vt_table);
+    libff::G2_vector<ppT> V_g2_query = batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g2_window, g2_table, Vt_table);
 #ifdef USE_MIXED_ADDITION
     libff::batch_to_special<libff::G2<ppT> >(V_g2_query);
 #endif
@@ -306,7 +306,7 @@ uscs_ppzksnark_keypair<ppT> uscs_ppzksnark_generator(const uscs_ppzksnark_constr
 
     libff::enter_block("Encode IC query for USCS verification key");
     libff::G1<ppT> encoded_IC_base = Xt_table[0] * libff::G1<ppT>::one();
-    libff::G1_vector<ppT> encoded_IC_values = batch_exp(libff::Fr<ppT>::size_in_bits(), g1_window, g1_table, libff::Fr_vector<ppT>(Xt_table.begin() + 1, Xt_table.end()));
+    libff::G1_vector<ppT> encoded_IC_values = batch_exp(libff::Fr<ppT>::ceil_size_in_bits(), g1_window, g1_table, libff::Fr_vector<ppT>(Xt_table.begin() + 1, Xt_table.end()));
     libff::leave_block("Encode IC query for USCS verification key");
 
     libff::leave_block("Generate USCS verification key");

--- a/libsnark/zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.tcc
+++ b/libsnark/zk_proof_systems/zksnark/ram_zksnark/ram_compliance_predicate.tcc
@@ -128,7 +128,7 @@ ram_pcd_message_variable<ramT>::ram_pcd_message_variable(protoboard<FieldT> &pb,
     r1cs_pcd_message_variable<ram_base_field<ramT> >(pb, annotation_prefix), ap(ap)
 {
     const size_t unpacked_payload_size_in_bits = ram_pcd_message<ramT>::unpacked_payload_size_in_bits(ap);
-    const size_t packed_payload_size = libff::div_ceil(unpacked_payload_size_in_bits, FieldT::capacity());
+    const size_t packed_payload_size = libff::div_ceil(unpacked_payload_size_in_bits, FieldT::floor_size_in_bits());
     packed_payload.allocate(pb, packed_payload_size, FMT(annotation_prefix, " packed_payload"));
 
     this->update_all_vars();
@@ -157,7 +157,7 @@ void ram_pcd_message_variable<ramT>::allocate_unpacked_part()
     all_unpacked_vars.insert(all_unpacked_vars.end(), cpu_state_initial.begin(), cpu_state_initial.end());
     all_unpacked_vars.insert(all_unpacked_vars.end(), has_accepted);
 
-    unpack_payload.reset(new multipacking_gadget<FieldT>(this->pb, all_unpacked_vars, packed_payload, FieldT::capacity(), FMT(this->annotation_prefix, " unpack_payload")));
+    unpack_payload.reset(new multipacking_gadget<FieldT>(this->pb, all_unpacked_vars, packed_payload, FieldT::floor_size_in_bits(), FMT(this->annotation_prefix, " unpack_payload")));
 }
 
 template<typename ramT>
@@ -296,7 +296,7 @@ ram_compliance_predicate_handler<ramT>::ram_compliance_predicate_handler(const r
     temp_next_pc_addr.allocate(this->pb, addr_size, "temp_next_pc_addr");
     temp_next_cpu_state.allocate(this->pb, ap.cpu_state_size(), "temp_next_cpu_state");
 
-    const size_t chunk_size = FieldT::capacity();
+    const size_t chunk_size = FieldT::floor_size_in_bits();
 
     /*
       Always:


### PR DESCRIPTION
libsnark now requires libsodium as a dependency.

To make libsnark compatible with the new libff, some include paths and function invocations were changed. All tests now pass.

~Do NOT merge this PR until the corresponding libff PR is merged: https://github.com/scipr-lab/libff/pull/103~ Good to merge ~except I have not verified that unit tests pass because I can't compile locally~