### PR TITLE
Update .gitmodules to use https urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "depends/gtest"]
 	path = depends/gtest
-	url = git://github.com/google/googletest.git
+	url = https://github.com/google/googletest.git
 [submodule "depends/ate-pairing"]
 	path = depends/ate-pairing
-	url = git://github.com/herumi/ate-pairing.git
+	url = https://github.com/herumi/ate-pairing.git
 [submodule "depends/xbyak"]
 	path = depends/xbyak
-	url = git://github.com/herumi/xbyak.git
+	url = https://github.com/herumi/xbyak.git
 [submodule "depends/libsnark-supercop"]
 	path = depends/libsnark-supercop
-	url = git://github.com/mbbarbosa/libsnark-supercop.git
+	url = https://github.com/mbbarbosa/libsnark-supercop.git
 [submodule "depends/libff"]
 	path = depends/libff
 	url = https://github.com/scipr-lab/libff.git


### PR DESCRIPTION
Recent changes in the Git protocol security on GitHub https://github.blog/2021-09-01-improving-git-protocol-security-github/ broke our build script that clones libsnark. I found that some submodules referenced in  `.gitmodules`  use the unencrypted git protocol and some use `https`, which produces an error `The unauthenticated git protocol on port 9418 is no longer supported` if the repository is cloned using the `https` protocol.