### PR TITLE
Update submodules as old ones are rejected by GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "depends/gtest"]
 	path = depends/gtest
-	url = git://github.com/google/googletest.git
+	url = https://github.com/google/googletest.git
 [submodule "depends/ate-pairing"]
 	path = depends/ate-pairing
-	url = git://github.com/herumi/ate-pairing.git
+	url = https://github.com/herumi/ate-pairing.git
 [submodule "depends/xbyak"]
 	path = depends/xbyak
-	url = git://github.com/herumi/xbyak.git
+	url = https://github.com/herumi/xbyak.git
 [submodule "depends/libsnark-supercop"]
 	path = depends/libsnark-supercop
-	url = git://github.com/mbbarbosa/libsnark-supercop.git
+	url = https://github.com/mbbarbosa/libsnark-supercop.git
 [submodule "depends/libff"]
 	path = depends/libff
 	url = https://github.com/scipr-lab/libff.git


### PR DESCRIPTION
On March 15, 2022, GitHub no longer allows `git://`, and therefore, libraries depending on `libsnark` through submodules will all fail to initialize.

This PR fixes this issue.