### PR TITLE
[FIX] Migrate submodules to HTTPS in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "depends/gtest"]
 	path = depends/gtest
-	url = git://github.com/google/googletest.git
+	url = https://github.com/google/googletest.git
 [submodule "depends/ate-pairing"]
 	path = depends/ate-pairing
-	url = git://github.com/herumi/ate-pairing.git
+	url = https://github.com/herumi/ate-pairing.git
 [submodule "depends/xbyak"]
 	path = depends/xbyak
-	url = git://github.com/herumi/xbyak.git
+	url = https://github.com/herumi/xbyak.git
 [submodule "depends/libsnark-supercop"]
 	path = depends/libsnark-supercop
-	url = git://github.com/mbbarbosa/libsnark-supercop.git
+	url = https://github.com/mbbarbosa/libsnark-supercop.git
 [submodule "depends/libff"]
 	path = depends/libff
 	url = https://github.com/scipr-lab/libff.git


### PR DESCRIPTION
 Changes git:// in the URLs to https:// since git:// is obsolete