### PR TITLE
Fix typo across multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The libsnark library currently provides a C++ implementation of:
        This is easily adapted to any other Random Access Machine that satisfies a
        simple load-store interface.
     3. A scalable for TinyRAM using Proof-Carrying Data, as explained in \[BCTV14b]
-    4. Zero-knowldge cluster MapReduce, as explained in \[CTV15].
+    4. Zero-knowledge cluster MapReduce, as explained in \[CTV15].
 
 See the above references for discussions of efficiency aspects that arise in
 practical use of such constructions, as well as security and trust

--- a/libsnark/common/data_structures/accumulation_vector.hpp
+++ b/libsnark/common/data_structures/accumulation_vector.hpp
@@ -29,7 +29,7 @@ std::istream& operator>>(std::istream &in, accumulation_vector<T> &v);
 
 /**
  * An accumulation vector comprises an accumulation value and a sparse vector.
- * The method "accumulate_chunk" allows one to accumlate portions of the sparse
+ * The method "accumulate_chunk" allows one to accumulate portions of the sparse
  * vector into the accumualation value.
  */
 template<typename T>

--- a/libsnark/common/data_structures/sparse_vector.tcc
+++ b/libsnark/common/data_structures/sparse_vector.tcc
@@ -196,7 +196,7 @@ std::pair<T, sparse_vector<T> > sparse_vector<T>::accumulate(const typename std:
 
     const size_t range_len = it_end - it_begin;
     bool in_block = false;
-    size_t first_pos = -1, last_pos = -1; // g++ -flto emits unitialized warning, even though in_block guards for such cases.
+    size_t first_pos = -1, last_pos = -1; // g++ -flto emits uninitialized warning, even though in_block guards for such cases.
 
     for (size_t i = 0; i < indices.size(); ++i)
     {

--- a/libsnark/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
+++ b/libsnark/gadgetlib1/gadgets/cpu_checkers/tinyram/components/alu_arithmetic.tcc
@@ -1308,7 +1308,7 @@ void ALU_shr_shl_gadget<FieldT>::generate_r1cs_constraints()
 
           old_result =
           (shifted_result * 2^(i+1) + shifted_out_part) * need_to_shift +
-          (shfited_result) * (1-need_to_shift)
+          (shifted_result) * (1-need_to_shift)
 
           old_result - shifted_result = (shifted_result * (2^(i+1) - 1) + shifted_out_part) * need_to_shift
         */
@@ -1396,7 +1396,7 @@ void ALU_shr_shl_gadget<FieldT>::generate_r1cs_witness()
 
       old_result =
       (shifted_result * 2^i + shifted_out_part) * need_to_shift +
-      (shfited_result) * (1-need_to_shift)
+      (shifted_result) * (1-need_to_shift)
     */
 
     for (size_t i = 0; i < logw; ++i)

--- a/libsnark/gadgetlib2/variable.cpp
+++ b/libsnark/gadgetlib2/variable.cpp
@@ -227,7 +227,7 @@ FElemInterfacePtr R1P_Elem::inverse() const {
 }
 
 long R1P_Elem::asLong() const {
-    //GADGETLIB_ASSERT(elem_.as_ulong() <= LONG_MAX, "long overflow occured.");
+    //GADGETLIB_ASSERT(elem_.as_ulong() <= LONG_MAX, "long overflow occurred.");
     return long(elem_.as_ulong());
 }
 
@@ -246,13 +246,13 @@ VarIndex_t Variable::nextFreeIndex_ = 0;
 
 #ifdef DEBUG
 Variable::Variable(const string& name) : index_(nextFreeIndex_++), name_(name) {
-    GADGETLIB_ASSERT(nextFreeIndex_ > 0, GADGETLIB2_FMT("Variable index overflow has occured, maximum number of "
+    GADGETLIB_ASSERT(nextFreeIndex_ > 0, GADGETLIB2_FMT("Variable index overflow has occurred, maximum number of "
                                          "Variables is %lu", ULONG_MAX));
 }
 #else
 Variable::Variable(const string& name) : index_(nextFreeIndex_++) {
     libff::UNUSED(name);
-    GADGETLIB_ASSERT(nextFreeIndex_ > 0, GADGETLIB2_FMT("Variable index overflow has occured, maximum number of "
+    GADGETLIB_ASSERT(nextFreeIndex_ > 0, GADGETLIB2_FMT("Variable index overflow has occurred, maximum number of "
                                          "Variables is %lu", ULONG_MAX));
 }
 #endif

--- a/libsnark/knowledge_commitment/kc_multiexp.hpp
+++ b/libsnark/knowledge_commitment/kc_multiexp.hpp
@@ -10,9 +10,9 @@
 
 /*
   Split out from multiexp to prevent cyclical
-  dependencies. I.e. previously multiexp dependend on
-  knowledge_commitment, which dependend on sparse_vector, which
-  dependend on multiexp (to do accumulate).
+  dependencies. I.e. previously multiexp depended on
+  knowledge_commitment, which depended on sparse_vector, which
+  depended on multiexp (to do accumulate).
 
   Will probably go away in more general exp refactoring.
 */


### PR DESCRIPTION
- `README.md` - Fixed "Zero-knowldge" to "Zero-knowledge."
- `accumulation_vector.hpp` - Corrected "accumlate" to "accumulate."
- `sparse_vector.tcc` - Fixed "unitialized" to "uninitialized."
- `alu_arithmetic.tcc` - Fixed typos in comments, such as "shfited_result" to "shifted_result."
- `variable.cpp` - Corrected "occurred" spelling in assertions.
- `kc_multiexp.hpp` - Fixed "dependend" to "depended" and similar corrections for readability.
