### PR TITLE
Fix Typos in Comments

### DIFF
--- a/libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc
+++ b/libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.tcc
@@ -31,7 +31,7 @@ sha256_compression_function_gadget<FieldT>::sha256_compression_function_gadget(p
     packed_W.allocate(pb, 64, FMT(this->annotation_prefix, " packed_W"));
     message_schedule.reset(new sha256_message_schedule_gadget<FieldT>(pb, new_block, packed_W, FMT(this->annotation_prefix, " message_schedule")));
 
-    /* initalize */
+    /* initialize */
     round_a.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 7*32, prev_output.rbegin() + 8*32));
     round_b.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 6*32, prev_output.rbegin() + 7*32));
     round_c.push_back(pb_linear_combination_array<FieldT>(prev_output.rbegin() + 5*32, prev_output.rbegin() + 6*32));

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.tcc
@@ -303,7 +303,7 @@ r1cs_ppzksnark_keypair<ppT> r1cs_ppzksnark_generator(const r1cs_ppzksnark_constr
         gamma = libff::Fr<ppT>::random_element();
     const libff::Fr<ppT>      rC = rA * rB;
 
-    // consrtuct the same-coefficient-check query (must happen before zeroing out the prefix of At)
+    // construct the same-coefficient-check query (must happen before zeroing out the prefix of At)
     libff::Fr_vector<ppT> Kt;
     Kt.reserve(qap_inst.num_variables()+4);
     for (size_t i = 0; i < qap_inst.num_variables()+1; ++i)


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in code comments within two files:
- In `sha256_gadget.tcc`, the comment "initialize" is fixed for clarity.
- In `r1cs_ppzksnark.tcc`, the comment "construct the same-coefficient-check query" is corrected for accuracy and readability.

No functional code changes are introduced; only comment text is updated to improve code documentation and maintainability.