### PR TITLE
Update outdated Apple docset link to current Doxygen documentation

### DIFF
--- a/doxygen.conf
+++ b/doxygen.conf
@@ -986,7 +986,7 @@ HTML_INDEX_NUM_ENTRIES = 0
 # directory and running "make install" will install the docset in
 # ~/Library/Developer/Shared/Documentation/DocSets so that Xcode will find
 # it at startup.
-# See http://developer.apple.com/tools/creatingdocsetswithdoxygen.html
+# See https://www.doxygen.nl/manual/docsets.html
 # for more information.
 
 GENERATE_DOCSET        = NO


### PR DESCRIPTION
Replaced the obsolete Apple developer link for creating docsets with Doxygen in the configuration file with the up-to-date official Doxygen docset documentation link (https://www.doxygen.nl/manual/docsets.html). This ensures users have access to relevant and maintained instructions.